### PR TITLE
:sparkles: Include the social logins on the signup form

### DIFF
--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -2,6 +2,8 @@
 
 {% load i18n %}
 
+{% load account socialaccount %}
+
 {% block head_title %}{% trans "Signup" %}{% endblock %}
 
 {% block body_id %}id="authpages"{% endblock %}
@@ -52,6 +54,10 @@
           </div>
         </form>
       </div>
+
+      {% providers_media_js %}
+      {% include "socialaccount/snippets/provider_list.html" with process="login" %}
+      {% include "socialaccount/snippets/login_extra.html" %}
 
       <div class="text-center md:w-1/2">
         <div id="scene01"></div>


### PR DESCRIPTION
Part of #86  

- Includes the social logins on the signup form. Note: `django-allauth` handles signup and login as one process for social accounts, so the buttons and pages say "sign in" even though the experience is "sign up." There are probably ways to get around this, and if you're not able to make it work the way you need @gregnewman let me know and I can take a look. It may require overriding some of their views? https://github.com/pennersr/django-allauth/tree/master/allauth 

## Result 

<img width="1173" alt="Screen Shot 2023-01-25 at 11 07 33 AM" src="https://user-images.githubusercontent.com/2286304/214670559-8fb546e0-3235-46cf-bed7-0c236b06e047.png">
<img width="1130" alt="Screen Shot 2023-01-25 at 11 35 54 AM" src="https://user-images.githubusercontent.com/2286304/214670567-29dd48b8-725f-48e1-8a19-58732cae9211.png">
