### PR TITLE
:fire: Remove the libraries-by-letter view

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -17,7 +17,6 @@ from ak.views import (
 from core.views import MarkdownTemplateView
 from libraries.views import (
     LibraryList,
-    LibraryByLetter,
     LibraryByCategory,
     LibraryDetail,
 )
@@ -48,11 +47,6 @@ urlpatterns = [
         "donate/",
         TemplateView.as_view(template_name="donate/donate.html"),
         name="donate",
-    ),
-    path(
-        "libraries-by-letter/<str:letter>/",
-        LibraryByLetter.as_view(),
-        name="libraries-by-letter",
     ),
     path(
         "libraries-by-category/<slug:category>/",

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -38,22 +38,6 @@ class LibraryList(CategoryMixin, FormMixin, ListView):
         return super().get(request)
 
 
-class LibraryByLetter(CategoryMixin, ListView):
-    """List all of our libraries that begin with a certain letter"""
-
-    paginate_by = 25
-    template_name = "libraries/list.html"
-
-    def get_queryset(self):
-        letter = self.kwargs.get("letter")
-
-        return (
-            Library.objects.prefetch_related("categories")
-            .filter(name__startswith=letter.lower())
-            .order_by("name")
-        )
-
-
 class LibraryByCategory(CategoryMixin, ListView):
     """List all of our libraries in a certain category"""
 


### PR DESCRIPTION
PR https://github.com/revsys/boost.org/pull/99 removed the alphabet filters from the UI, so now this PR removes the dead code. 