### PR TITLE
:sparkles: Add ordering to admin

### DIFF
--- a/libraries/admin.py
+++ b/libraries/admin.py
@@ -6,6 +6,7 @@ from .models import Category, Issue, Library, LibraryVersion, PullRequest
 @admin.register(Category)
 class CategoryAdmin(admin.ModelAdmin):
     list_display = ["name"]
+    ordering = ["name"]
     search_fields = ["name"]
 
 
@@ -14,6 +15,7 @@ class LibraryAdmin(admin.ModelAdmin):
     list_display = ["name", "active", "open_issues"]
     search_fields = ["name", "description"]
     list_filter = ["active_development", "categories"]
+    ordering = ["name"]
 
     readonly_fields = [
         "last_github_update",
@@ -30,6 +32,7 @@ class LibraryAdmin(admin.ModelAdmin):
 class LibraryVersionAdmin(admin.ModelAdmin):
     list_display = ["library", "version"]
     list_filter = ["library", "version"]
+    ordering = ["library__name", "-version__name"]
     search_fields = ["library__name", "version__name"]
 
 


### PR DESCRIPTION
Oops I did it again... I put too many commits in one branch and had to break them up. 

This orders Libraries, Categories, and LibraryVersions by `name`. 