### PR TITLE
Functions to help with loading authors and maintainers for libraries from GitHub

### DIFF
--- a/libraries/management/commands/load_contributors.py
+++ b/libraries/management/commands/load_contributors.py
@@ -15,6 +15,8 @@ def extract_email(val: str) -> str:
     Finds an email address in a string, reformats it, and returns it.
     Assumes the email address is in this format:
     <firstlast -at- domain.com>
+
+    Does not raise errors.
     """
     result = re.search("<.+>", val)
     if result:
@@ -56,3 +58,22 @@ def generate_fake_email(val: str) -> str:
     suffix = "".join(random.choice(letters) for i in range(8))
     local_email = slug.replace("-", "_")[:50]
     return f"{local_email}_{suffix}@example.com"
+
+
+def get_contributor_data(contributor: str) -> dict:
+    """Takes an author/maintainer string and returns a dict with their data"""
+    data = {}
+    data["meta"] = contributor
+    data["valid_email"] = False
+
+    email = extract_email(contributor)
+    if bool(email):
+        data["email"] = email
+        data["valid_email"] = True
+    else:
+
+        data["email"] = generate_fake_email(contributor)
+
+    data["first_name"], data["last_name"] = extract_names(contributor)
+
+    return data

--- a/libraries/tests/test_commands.py
+++ b/libraries/tests/test_commands.py
@@ -2,6 +2,7 @@ from ..management.commands.load_contributors import (
     extract_email,
     extract_names,
     generate_fake_email,
+    get_contributor_data,
 )
 
 
@@ -51,3 +52,30 @@ def test_extract_email():
     expected = None
     result = extract_email("Tester Testeron")
     assert expected == result
+
+
+def test_get_contributor_data():
+    sample = "Tester Testerson <tester -at- gmail.com>"
+    expected = {
+        "meta": sample,
+        "valid_email": True,
+        "email": "tester@gmail.com",
+        "first_name": "Tester",
+        "last_name": "Testerson",
+    }
+    result = get_contributor_data(sample)
+    assert expected == result
+
+    sample = "Tester Testerson"
+    expected = {
+        "meta": sample,
+        "valid_email": False,
+        "first_name": "Tester",
+        "last_name": "Testerson",
+    }
+    result = get_contributor_data(sample)
+    assert expected["meta"] == result["meta"]
+    assert expected["valid_email"] is False
+    assert expected["first_name"] == result["first_name"]
+    assert expected["last_name"] == result["last_name"]
+    assert "email" in result


### PR DESCRIPTION
Closes #143 

All these functions are about prepping for #144 by taking the contributor (author/maintainer) strings in each Library's `libraries.json` and using them to extract or generate the data we need to retrieve or create User objects 

- Function to extract an email address from a string 
- Function to extract first and last name fields from a string 
- Function to generate a fake email address using a string 
- Function to return User data in a dictionary based on a string input 

Final result is that calling `get_contributor_data` with a string like this: 

    "Tester Testerson <tester -at- gmail.com>"

Will return this: 

    {
        "meta":  "Tester Testerson <tester -at- gmail.com>",
        "valid_email": True,
        "email": "tester@gmail.com",
        "first_name": "Tester",
        "last_name": "Testerson",
    }