### PR TITLE
:bug: Fix uploading libraries bug, views bug

### DIFF
--- a/libraries/github.py
+++ b/libraries/github.py
@@ -212,7 +212,7 @@ class LibraryUpdater:
                 for sublibrary in meta:
                     libraries.append(
                         {
-                            "name": name,
+                            "name": sublibrary["name"],
                             "github_url": github_url,
                             "authors": sublibrary["authors"],
                             "description": sublibrary["description"],

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -79,7 +79,7 @@ class LibraryDetail(CategoryMixin, DetailView):
 
         try:
             obj = self.get_queryset().get(slug=slug)
-        except queryset.model.DoesNotExist:
+        except self.model.DoesNotExist:
             raise Http404("No library found matching the query")
         return obj
 


### PR DESCRIPTION
Part of #55 

Pretty simple PR -- replaces the loading of the `name` for `libraries.json` files when the content is a list with `meta["name"]`, which gets the sublibrary name. Here is some sample input: https://github.com/boostorg/math/blob/develop/meta/libraries.json 

```
[
    {
        "key": "math",
        "name": "Math",
        "authors": [
            "various"
        ],
        "description": "Boost.Math includes several contributions in the domain of mathematics: The Greatest Common Divisor and Least Common Multiple library provides run-time and compile-time evaluation of the greatest common divisor (GCD) or least common multiple (LCM) of two integers. The Special Functions library currently provides eight templated special functions, in namespace boost. The Complex Number Inverse Trigonometric Functions are the inverses of trigonometric functions currently present in the C++ standard. Quaternions are a relative of complex numbers often used to parameterise rotations in three dimensional space. Octonions, like quaternions, are a relative of complex numbers.",
        "category": [
            "Math"
        ],
        "maintainers": [
            "Hubert Holin <Hubert.Holin -at- meteo.fr>",
            "John Maddock <john -at- johnmaddock.co.uk>"
        ],
        "cxxstd": "14"
    },
    {
        "key": "math/common_factor",
        "name": "Math Common Factor",
        "authors": [
            "Daryle Walker"
        ],
        "description": "Greatest common divisor and least common multiple.",
        "documentation": "doc/html/gcd_lcm.html",
        "category": [
            "Math"
        ],
        "cxxstd": "14"
    }
]
```

We might need to drop the libraries to run this? I had some issues locally with updating the "first" library, and there is a little weirdness with their data being pulled into our data. We are saving `name` generally not from the `name` element in the `libraries.json`, but instead using whatever we find in the `.gitmodules` file, which doesn't work for the sublibraries, since those don't exist in `/gitsubmodules`. Result is some results like this: 

<img width="331" alt="Screenshot 2023-03-15 at 3 45 05 PM" src="https://user-images.githubusercontent.com/2286304/225460047-e8a89ad6-4a83-4e4b-80ff-c38e70a8cb3a.png">

We should also probably make `slug` unique for `Library`. 

But all that can be done in a future PR, and I anticipate some fine-tuning of the import script to come anyway. 
