### PR TITLE
Update action versions in github actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
       - name: Git - Get Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/base.txt') }}
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Git - Get Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -76,7 +76,7 @@ jobs:
           git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
@@ -94,7 +94,7 @@ jobs:
           git push --tags
 
       - name: Login to REVSYS Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: registry.revsys.com
           username: boost


### PR DESCRIPTION
The CI workflows were showing a few errors such as "Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16".