### PR TITLE
Move helm database migrations to Job

### DIFF
--- a/kube/boost/templates/migration-job.yaml
+++ b/kube/boost/templates/migration-job.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: database-migrations-job
+  labels:
+    env: {{ .Values.deploymentEnvironment }}
+    app: boost
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+spec:
+  ttlSecondsAfterFinished: 3600
+  backoffLimit: 4
+  template:
+    spec:
+      restartPolicy: OnFailure
+      volumes:
+{{ toYaml .Values.Volumes | indent 6 }}
+      imagePullSecrets:
+        - name: revsys-docker-registry
+      containers:
+        - name: database-migrations
+          image: {{ .Values.Image }}:{{ .Values.ImageTag }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - "./manage.py migrate --noinput"
+          env:
+{{ toYaml .Values.Env | indent 10 }}
+          volumeMounts:
+{{ toYaml .Values.VolumeMounts | indent 10 }}

--- a/kube/boost/values.yaml
+++ b/kube/boost/values.yaml
@@ -15,8 +15,9 @@ replicaCount: "2"
 # where necessary
 
 initCommands:
-  - name: migrate
-    command: ./manage.py migrate --noinput
+  # migrate moved to a Job
+  # - name: migrate
+  #   command: ./manage.py migrate --noinput
   - name: collectstatic
     command: ./manage.py collectstatic --noinput
 


### PR DESCRIPTION
The included helm charts and kubernetes manifests are excellent! They work very well. 
There is a small issue that could lead to a race condition, even if that only happens rarely. DB migrations are being run as init containers. Consider the case of having four web server pods. Migrations will be run four times, possibly simultaneously, causing a conflict. Ideally migrations would be run once.
A quote from the GCP docs: "Modifying the schema of a relational database is a good use case for Kubernetes Jobs. Jobs run a given Pod until successful completion, and they have retry mechanisms."
Here is a blog post describing a solution: https://itnext.io/database-migrations-on-kubernetes-using-helm-hooks-fb80c0d97805
I have tested this and it seems to work fine. 

On a tangent, there is one potential issue. Usually the migrations take a few second, however if a large migration take longer than the default 5 minute timeout of helm, the Job would timeout. A solution can be to run helm with `--timeout 3600`. I was checking if timeout could be set as a job annotation. At the moment it's only available as a helm command-line flag. The topic is discussed here: https://github.com/helm/helm/issues/4294 .  An idea could be to submit a new feature pull request to upstream helm:

Timeout annotation on a Job:

```
helm.sh/job-timeout=10m
```

Global timeout to be added to Chart.yaml:

```
helm.sh/chart-default-timeout=5m
```

