### PR TITLE
:snowflake: Add `CSRF_TRUSTED_ORIGINS`

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -92,6 +92,13 @@ INSTALLED_APPS += ["ak", "users", "versions", "libraries", "mailing_list"]
 
 AUTH_USER_MODEL = "users.User"
 CSRF_COOKIE_HTTPONLY = True
+# See https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins
+CSRF_TRUSTED_ORIGINS = [
+    "http://0.0.0.0",
+    "http://localhost",
+    "https://boost.revsys.dev",
+    "https://www.boost.revsys.dev",
+]
 
 MIDDLEWARE = [
     "tracer.middleware.RequestID",


### PR DESCRIPTION
We should do this with env variables, but I wanted to see if it worked first. 

Part of #201; might close it?

## What's in this PR: 
- A new setting `CSRF_TRUSTED_ORIGINS` introduced in Django 4.0
- Seems a lot like `ALLOWED_HOSTS` 

More info: 
- https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins
- https://gdevops.gitlab.io/tuto_django/versions/4.0/security/security.html 