### PR TITLE
:pencil: Don't capitalize categories in the list

### DIFF
--- a/templates/libraries/list.html
+++ b/templates/libraries/list.html
@@ -42,7 +42,7 @@
           <label for="id_categories" hidden="true">Categories:</label>
           <select onchange="this.form.submit()"
                   name="categories"
-                  class="block py-2 pr-11 pl-5 mb-3 w-full text-sm uppercase bg-white rounded-md border border-gray-300 cursor-pointer sm:inline-block md:mb-0 md:w-auto dark:bg-black text-sky-600 dark:text-orange dark:border-slate"
+                  class="block py-2 pr-11 pl-5 mb-3 w-full text-sm bg-white rounded-md border border-gray-300 cursor-pointer sm:inline-block md:mb-0 md:w-auto dark:bg-black text-sky-600 dark:text-orange dark:border-slate"
                   id="id_categories"
           >
             <option>Filter by category</option>


### PR DESCRIPTION
Closes #232  

## In this PR
- remove the `uppercase` class from the categories list selector 

<img width="322" alt="Screenshot 2023-05-01 at 12 32 35 PM" src="https://user-images.githubusercontent.com/2286304/235517088-1bb0a49d-a259-419d-9a96-a92395327e80.png">

@vinniefalco Let me know if you had something else in mind! 