### PR TITLE
:pencil: Add hover color-change for category links

### DIFF
--- a/templates/libraries/_library_list_item.html
+++ b/templates/libraries/_library_list_item.html
@@ -25,7 +25,7 @@
     <div class="w-1/6 tracking-wider text-charcoal dark:text-white/60">2yrs</div>
     <div class="w-4/6 text-right dark:text-gray-400 text-slate">
       {% for c in library.categories.all %}
-        <a href="{% if version_slug %}{% url 'libraries-by-version-by-category' version_slug=version_slug category=c.slug%}{% else %}{% url 'libraries-by-category' category=c.slug %}{% endif %}" class="text-sky-400 dark:text-blue-300/60">
+        <a href="{% if version_slug %}{% url 'libraries-by-version-by-category' version_slug=version_slug category=c.slug%}{% else %}{% url 'libraries-by-category' category=c.slug %}{% endif %}" class="text-sky-400 dark:text-blue-300/60 dark:hover:text-orange hover:text-orange">
           {{ c.name }}
         </a>{% if not forloop.last %}, {% endif %}{% endfor %}
     </div>


### PR DESCRIPTION
Closes #226 

## Changes in this PR
- Uses the `dark:hover:text-orange hover:text-orange` classes from the navigation header to make category links on the Library list page orange when they are hovered over. 

Light and dark mode examples: 

Hover is over "error handling" 
<img width="490" alt="Screenshot 2023-05-01 at 12 43 20 PM" src="https://user-images.githubusercontent.com/2286304/235518562-98eaff74-4927-4543-895f-459d54886a8d.png">

Hover is over "correctness" 
<img width="487" alt="Screenshot 2023-05-01 at 12 43 31 PM" src="https://user-images.githubusercontent.com/2286304/235518565-976e94b8-7254-4a1f-9050-0f8dbcfe1de8.png">

@gregnewman Since I poked at CSS, can you take a look? 

@vinniefalco Is this what you had in mind? 