### PR TITLE
Shorten static content cache timeout and serve from a setting

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -271,8 +271,8 @@ CACHES = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": f"redis://{REDIS_HOST}:6379/2",
         "TIMEOUT": env(
-            "STATIC_CACHE_TIMEOUT", default=86400
-        ),  # Cache timeout in seconds: 1 day
+            "STATIC_CACHE_TIMEOUT", default=60
+        ),  # Cache timeout in seconds: 1 minute
     },
 }
 

--- a/core/views.py
+++ b/core/views.py
@@ -121,7 +121,11 @@ class StaticContentTemplateView(View):
 
             content, content_type = result
             # Store the result in cache
-            static_content_cache.set(cache_key, (content, content_type))
+            static_content_cache.set(
+                cache_key,
+                (content, content_type),
+                settings.CACHES["static_content"]["TIMEOUT"],
+            )
 
         response = HttpResponse(content, content_type=content_type)
         logger.info(

--- a/kube/boost/values.yaml
+++ b/kube/boost/values.yaml
@@ -119,6 +119,9 @@ Env:
       secretKeyRef:
         name: static-content
         key: bucket_name
+  # Static content cache timeout
+  - name: STATIC_CACHE_TIMEOUT
+    value: 60
 
 # Volumes
 Volumes:


### PR DESCRIPTION
Should close https://github.com/cppalliance/boost.org/issues/255

- Serves the static content from a env variable
- Adds it to kube
- Sets it to 60 seconds and also defaults it to 60 seconds in settings.py

@frankwiles Anytime I add a setting I like an ops 👍  😄 