### PR TITLE
:sparkles: Add display for cxxstd value

### DIFF
--- a/libraries/models.py
+++ b/libraries/models.py
@@ -100,6 +100,21 @@ class Library(models.Model):
             self.slug = slugify(self.name)
         return super().save(*args, **kwargs)
 
+    def get_cpp_standard_minimum_display(self):
+        """Returns the display name for the C++ standard, or the value if not found.
+
+        Source of values is
+        https://docs.cppalliance.org/user-guide/prev/library_metadata.html"""
+        display_names = {
+            "98": "C++98",
+            "03": "C98/C03",
+            "11": "C++11",
+            "14": "C++14",
+            "17": "C++17",
+            "20": "C++20",
+        }
+        return display_names.get(self.cpp_standard_minimum, self.cpp_standard_minimum)
+
     def github_properties(self):
         """Returns the owner and repo name for the library"""
         parts = urlparse(self.github_url)

--- a/libraries/tests/test_models.py
+++ b/libraries/tests/test_models.py
@@ -1,6 +1,16 @@
 from model_bakery import baker
 
 
+def test_get_cpp_standard_minimum_display(library):
+    library.cpp_standard_minimum = "11"
+    library.save()
+    assert library.get_cpp_standard_minimum_display() == "C++11"
+
+    library.cpp_standard_minimum = "42"
+    library.save()
+    assert library.get_cpp_standard_minimum_display() == "42"
+
+
 def test_github_properties(library):
     properties = library.github_properties()
     assert properties["owner"] == "boostorg"
@@ -52,9 +62,7 @@ def test_library_version_multiple_versions(library, library_version):
         library_version__version=library_version.version
     ).exists()
     other_version = baker.make("versions.Version", name="New Version")
-    new_library_version = baker.make(
-        "libraries.LibraryVersion", library=library, version=other_version
-    )
+    baker.make("libraries.LibraryVersion", library=library, version=other_version)
     assert library.versions.count() == 2
     assert library.versions.filter(
         library_version__version=library_version.version

--- a/templates/includes/_header.html
+++ b/templates/includes/_header.html
@@ -36,7 +36,7 @@
                    x-transition:leave="transition ease-in duration-75"
                    x-transition:leave-start="transform opacity-100 scale-100"
                    x-transition:leave-end="transform opacity-0 scale-95"
-                   class="absolute -top-[2px] -right-2 z-10"
+                   class="absolute -right-2 z-10 -top-[2px]"
                    x-ref="search-form"
                    x-description="Search"
                    role="menu"

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -33,8 +33,11 @@
               <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100" href="{{ object.github_issues_url }}">Github Issues <i class="float-right fas fa-bug"></i></a>
               <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100" href="{{ object.github_url }}">Source Code <i class="float-right fab fa-github"></i></a>
               <a class="inline-block py-1 px-2 rounded cursor-pointer hover:bg-gray-100">Since 2019</a>
-              <a class="inline-block float-right py-1 px-2 rounded cursor-pointer hover:bg-gray-100">C++11</a>
-              <span class="block py-1 px-2 rounded cursor-pointer hover:bg-gray-100">Categories: <a class="text-sky-600">Memory</a></span>
+              <a class="inline-block float-right py-1 px-2 rounded cursor-pointer hover:bg-gray-100">{{ object.get_cpp_standard_minimum_display }}</a>
+              <span class="block py-1 px-2 rounded cursor-pointer hover:bg-gray-100">Categories:
+                {% for category in object.categories.all %}
+                  <a class="text-sky-600" href="{% url 'libraries-by-category' category=category.slug %}">{{ category.name }}</a></span>
+                {% endfor %}
 
               <p class="pt-4 pl-2 mt-4 text-sm border-t border-gray-200">{{ object.description }}</p>
             </ul>


### PR DESCRIPTION
Part of #252 

- Adds a method to translate the display name for the c++ standard minimum value, based on the table here: https://docs.cppalliance.org/user-guide/prev/library_metadata.html
- Uses that display in the library detail template **but not in the list template** per instructions. 
- Some changes pre-commit made me do 
- Makes the categories live and links the category name to the filtered category list 

<img width="496" alt="Screenshot 2023-05-09 at 3 52 23 PM" src="https://github.com/cppalliance/boost.org/assets/2286304/ef96ce9f-1e44-4bee-8709-9e887384bd02">
