### PR TITLE
Add temp fix for library documentation link

### DIFF
--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -42,10 +42,10 @@
 
         <div class="p-4 bg-white rounded-lg divide-x divide-gray-200 md:flex">
           <div class="pr-3 space-y-2 w-full md:w-1/4">
-              <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100" href="https://github.com/boostorg/smart_ptr">
+              <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100" href="https://boost.org/libs/{{ object.slug }}">
                 <i class="float-right mt-3 fas fa-folder"></i>
                 Documentation
-                <span class="block text-xs text-sky-600">boost.revsys.dev/libs/exception</span>
+                <span class="block text-xs text-sky-600">boost.org/libs/{{ object.slug }}</span>
               </a>
               <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100" href="{{ object.github_issues_url }}">Github Issues <i class="float-right fas fa-bug"></i></a>
               <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100" href="{{ object.github_url }}">Source Code <i class="float-right fab fa-github"></i></a>


### PR DESCRIPTION
- Forces the generation of `https://boost.org/libs/{{lib}}` on the details page 
- Does not work for all libraries. Libraries with slashes or similar in the name don't work since their URLs need some help, but this gets the bulk of the links to the old docs visible
- I suspect that we could add a template filter that replaced `-` in the slug with `_` and that will take care of the bulk of the problems that are left. ~Not sure if that's worth the effort since we'll be replacing these links with Antora ones eventually?~
- We will want to add a field for the link to the documentation (or the url parts for it) or some sort of process that makes this link reliable -- **this fix is for the demo debut**