### PR TITLE
736 hyperkitty

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -75,6 +75,10 @@ INSTALLED_APPS += [
     "mptt",
     "haystack",
     "widget_tweaks",
+    # Hyperkitty dependencies:
+    "django_mailman3",
+    "hyperkitty",
+    "compressor",
 ]
 
 # Our Apps
@@ -106,6 +110,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "allauth.account.middleware.AccountMiddleware",
 ]
 
 if DEBUG:
@@ -132,6 +137,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "core.context_processors.login_url",
             ],
             "loaders": [
                 "django.template.loaders.filesystem.Loader",
@@ -202,6 +208,13 @@ STATICFILES_DIRS = [
 # This is the directory where all of the collected static files are put
 # after running collectstatic
 STATIC_ROOT = str(BASE_DIR.joinpath("static_deploy"))
+
+STATICFILES_FINDERS = [
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
+    # other finders..
+    "compressor.finders.CompressorFinder",
+]
 
 # Directory where uploaded media is saved.
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
@@ -295,6 +308,7 @@ JDOODLE_API_CLIENT_SECRET = env("JDOODLE_API_CLIENT_SECRET", "")
 SITE_ID = 1
 ACCOUNT_EMAIL_VERIFICATION = "none"
 LOGIN_REDIRECT_URL = "home"
+LOGIN_URL = "account_login"
 ACCOUNT_LOGOUT_ON_GET = True
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 ACCOUNT_EMAIL_REQUIRED = True

--- a/config/urls.py
+++ b/config/urls.py
@@ -52,8 +52,8 @@ from users.views import (
     CurrentUserAPIView,
     CurrentUserProfileView,
     CustomLoginView,
-    CustomSocialSignupViewView,
     CustomSignupView,
+    CustomSocialSignupViewView,
     ProfileView,
     UserViewSet,
 )
@@ -135,6 +135,7 @@ urlpatterns = (
             LibraryDetail.as_view(),
             name="library-detail",
         ),
+        path("mailing-list/archive/", include("hyperkitty.urls")),
         path(
             "mailing-list/<int:pk>/",
             MailingListDetailView.as_view(),

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def login_url(request):
+    return {"LOGIN_URL": settings.LOGIN_URL}

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 Django>=4.0, <=5.0
 bumpversion
 django-admin-env-notice
-django-allauth==0.53.1
+django-allauth==0.56.1
 django-anymail[mailgun]
 django-cors-headers
 django-db-geventpool
@@ -32,7 +32,7 @@ structlog
 
 # Celery
 celery==5.2.7
-redis==4.5.4
+redis
 
 # Testing
 Faker
@@ -63,3 +63,6 @@ elasticsearch==7.17.9
 # Github
 ghapi
 requests
+
+# Mailman / Mailing list related packages
+hyperkitty

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,12 +8,14 @@ amqp==5.1.1
     # via kombu
 appdirs==1.4.4
     # via fs
+arrow==1.3.0
+    # via django-q
 asgiref==3.7.2
     # via django
 asttokens==2.2.1
     # via stack-data
-async-timeout==4.0.2
-    # via redis
+atpublic==4.0
+    # via flufl-lock
 backcall==0.2.0
     # via ipython
 beautifulsoup4==4.12.2
@@ -22,6 +24,8 @@ billiard==3.6.4.0
     # via celery
 black==23.3.0
     # via -r ./requirements.in
+blessed==1.20.0
+    # via django-q
 boto3==1.26.154
     # via
     #   -r ./requirements.in
@@ -87,43 +91,68 @@ django==4.2.2
     #   dj-database-url
     #   django-allauth
     #   django-anymail
+    #   django-appconf
     #   django-cors-headers
     #   django-db-geventpool
     #   django-extensions
     #   django-haystack
     #   django-health-check
     #   django-js-asset
+    #   django-mailman3
+    #   django-picklefield
+    #   django-q
     #   django-redis
     #   django-rest-auth
     #   django-storages
     #   djangorestframework
+    #   hyperkitty
     #   model-bakery
 django-admin-env-notice==1.0
     # via -r ./requirements.in
-django-allauth==0.53.1
-    # via -r ./requirements.in
+django-allauth==0.56.1
+    # via
+    #   -r ./requirements.in
+    #   django-mailman3
 django-anymail[mailgun]==10.0
     # via -r ./requirements.in
+django-appconf==1.0.5
+    # via django-compressor
 django-bakery==0.13.2
     # via -r ./requirements.in
 django-cache-url==3.4.4
     # via environs
 django-click==2.3.0
     # via -r ./requirements.in
+django-compressor==4.4
+    # via hyperkitty
 django-cors-headers==4.0.0
     # via -r ./requirements.in
 django-db-geventpool==4.0.1
     # via -r ./requirements.in
 django-extensions==3.2.3
-    # via -r ./requirements.in
+    # via
+    #   -r ./requirements.in
+    #   hyperkitty
+django-gravatar2==1.4.4
+    # via
+    #   django-mailman3
+    #   hyperkitty
 django-haystack==3.2.1
-    # via -r ./requirements.in
+    # via
+    #   -r ./requirements.in
+    #   hyperkitty
 django-health-check==3.17.0
     # via -r ./requirements.in
 django-js-asset==2.0.0
     # via django-mptt
+django-mailman3==1.3.11
+    # via hyperkitty
 django-mptt==0.14
     # via -r ./requirements.in
+django-picklefield==3.1
+    # via django-q
+django-q==1.3.9
+    # via hyperkitty
 django-redis==5.3.0
     # via -r ./requirements.in
 django-rest-auth==0.9.5
@@ -140,6 +169,7 @@ djangorestframework==3.14.0
     # via
     #   -r ./requirements.in
     #   django-rest-auth
+    #   hyperkitty
 elasticsearch==7.17.9
     # via -r ./requirements.in
 environs[django]==9.5.0
@@ -152,6 +182,8 @@ fastcore==1.5.29
     # via ghapi
 filelock==3.12.2
     # via virtualenv
+flufl-lock==8.0.2
+    # via hyperkitty
 fs==2.4.16
     # via django-bakery
 gevent==22.10.2
@@ -163,6 +195,8 @@ greenlet==2.0.1
     #   -r ./requirements.in
     #   gevent
 gunicorn==20.1.0
+    # via -r ./requirements.in
+hyperkitty==1.3.8
     # via -r ./requirements.in
 identify==2.5.24
     # via pre-commit
@@ -180,6 +214,10 @@ jmespath==1.0.1
     #   botocore
 kombu==5.3.1
     # via celery
+mailmanclient==3.3.5
+    # via
+    #   django-mailman3
+    #   hyperkitty
 marshmallow==3.19.0
     # via environs
 matplotlib-inline==0.1.6
@@ -188,10 +226,14 @@ minio==7.1.15
     # via -r ./requirements.in
 mistletoe==1.1.0
     # via -r ./requirements.in
+mistune==2.0.5
+    # via hyperkitty
 model-bakery==1.12.0
     # via -r ./requirements.in
 mypy-extensions==1.0.0
     # via black
+networkx==3.2
+    # via hyperkitty
 nodeenv==1.8.0
     # via pre-commit
 oauthlib==3.2.2
@@ -228,6 +270,8 @@ prompt-toolkit==3.0.38
     # via
     #   click-repl
     #   ipython
+psutil==5.9.6
+    # via flufl-lock
 psycogreen==1.0.2
     # via django-db-geventpool
 psycopg2-binary==2.9.6
@@ -256,8 +300,10 @@ pytest-django==4.5.2
 python-dateutil==2.8.2
     # via
     #   -r ./requirements.in
+    #   arrow
     #   botocore
     #   faker
+    #   hyperkitty
 python-dotenv==1.0.0
     # via environs
 python-frontmatter==1.0.0
@@ -269,35 +315,48 @@ python3-openid==3.2.0
 pytz==2023.3
     # via
     #   celery
+    #   django-mailman3
     #   djangorestframework
+    #   hyperkitty
 pyyaml==6.0
     # via
     #   pre-commit
     #   python-frontmatter
     #   responses
-redis==4.5.4
+rcssmin==1.1.1
+    # via django-compressor
+redis==3.5.3
     # via
     #   -r ./requirements.in
+    #   django-q
     #   django-redis
 requests==2.31.0
     # via
     #   -r ./requirements.in
     #   django-allauth
     #   django-anymail
+    #   mailmanclient
     #   requests-oauthlib
     #   responses
 requests-oauthlib==1.3.1
     # via django-allauth
 responses==0.23.1
     # via -r ./requirements.in
+rjsmin==1.2.1
+    # via django-compressor
+robot-detection==0.4
+    # via hyperkitty
 s3transfer==0.6.1
     # via boto3
 six==1.16.0
     # via
+    #   asttokens
+    #   blessed
     #   django-bakery
     #   django-rest-auth
     #   fs
     #   python-dateutil
+    #   robot-detection
 soupsieve==2.4.1
     # via beautifulsoup4
 sqlparse==0.4.4
@@ -310,6 +369,8 @@ traitlets==5.9.0
     # via
     #   ipython
     #   matplotlib-inline
+types-python-dateutil==2.8.19.14
+    # via arrow
 types-pyyaml==6.0.12.10
     # via responses
 typing-extensions==4.6.3
@@ -324,12 +385,15 @@ urllib3==1.26.16
     #   responses
 vine==5.0.0
     # via
+    #   amqp
     #   celery
     #   kombu
 virtualenv==20.23.0
     # via pre-commit
 wcwidth==0.2.6
-    # via prompt-toolkit
+    # via
+    #   blessed
+    #   prompt-toolkit
 wheel==0.40.0
     # via
     #   -r ./requirements.in

--- a/users/models.py
+++ b/users/models.py
@@ -247,6 +247,14 @@ class User(BaseUser):
             self.claimed = True
             self.save()
 
+    @property
+    def username(self):
+        """
+        This property should not be used by Boost code at all. It exists simply to fix a bug in django_mailman3 which
+        is required by hyperkitty.  It assumes a username field exists when it emits logs in it's `create_profile` signal.
+        """
+        return self.email
+
 
 class LastSeen(models.Model):
     """

--- a/users/models.py
+++ b/users/models.py
@@ -250,8 +250,10 @@ class User(BaseUser):
     @property
     def username(self):
         """
-        This property should not be used by Boost code at all. It exists simply to fix a bug in django_mailman3 which
-        is required by hyperkitty.  It assumes a username field exists when it emits logs in it's `create_profile` signal.
+        This property should not be used by Boost code at all. It exists simply
+        to fix a bug in django_mailman3 which is required by hyperkitty.  It
+        assumes a username field exists when it emits logs in it's
+        `create_profile` signal.
         """
         return self.email
 


### PR DESCRIPTION
This PR has two migrations that **WILL FAIL** for you both locally and in deployed environments.  To work around this [this bug](https://gitlab.com/mailman/hyperkitty/-/issues/486) in hyperkitty you must execute the following: 

`manage.py migrate`

It will fail on Hyperkitty's 7th migration 

`manage.py migrate --fake hyperkitty 0007_allauth_20160808_1604`

Run migrate again to run the 8th migration, it will fail on the 9th one

`manage.py migrate`

Fake the 9th migration with: 

`manage.py migrate --fake hyperkitty 0009_duplicate_persona_users`

And finally run the rest of the migrations successfully: 

`manage.py migrate`

@sdarwin I don't have access to your clusters, so I can't just take care of this.  I would suggest you merge this when you're ready and do the following against your database(s). 