### PR TITLE
Fix logic that marks older versions as missing docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,6 @@ python.log
 
 # mailman
 mailman/web/static/
+
+# dev
+*.code-workspace

--- a/config/settings.py
+++ b/config/settings.py
@@ -470,8 +470,10 @@ ARTIFACTORY_URL = env(
 MIN_ARTIFACTORY_RELEASE = "boost-1.63.0"
 
 # The min Boost version is the oldest version of Boost that our import scripts
-# will retrieve. It's determined by the files we store in the archives/ in S3.
-MINIMUM_BOOST_VERSION = "1.31.0"
+# will retrieve.
+MINIMUM_BOOST_VERSION = "1.16.1"
+# The highest Boost version with its docs stored in S3
+MAXIMUM_BOOST_DOCS_VERSION = "boost-1.30.2"
 
 # Boost Google Calendar
 BOOST_CALENDAR = "5rorfm42nvmpt77ac0vult9iig@group.calendar.google.com"

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -2,6 +2,7 @@ import structlog
 from dateutil.relativedelta import relativedelta
 
 from config.celery import app
+from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone
 from core.boostrenderer import get_content_from_s3
@@ -142,10 +143,9 @@ def version_missing_docs(version):
 
     # Check if the version is older than our oldest version
     # stored in S3
-    if version_within_range(version.name, max_version="boost-1.30.0"):
-        return True
-
-    return False
+    return version_within_range(
+        version.name, max_version=settings.MAXIMUM_BOOST_DOCS_VERSION
+    )
 
 
 def library_version_missing_docs(library_version):


### PR DESCRIPTION
Part of #900 

Corrects the missing_docs logic for the versions older than 1.30.2, which don't have docs in S3. Also adds a setting to update the newest version with missing docs, in case what is stored in S3 changes later. 

Updates the minimum Boost version, to reflect what's in Prod anyway. 