### PR TITLE
Nginx try_files, includes trailing slash

### DIFF
--- a/kube/boost/templates/configmap-nginx.yaml
+++ b/kube/boost/templates/configmap-nginx.yaml
@@ -54,8 +54,22 @@ data:
           add_header Content-Type text/plain;
       }
 
-      location / {
+      location @django1 {
           proxy_pass http://unix:/run/gunicorn.sock;
+          proxy_intercept_errors on;
+          recursive_error_pages on;
+          error_page 404 = @django2;
+      }
+
+      location @django2 {
+          if ($uri !~* /$ ) {
+              rewrite  ^(.*)$  $1/ redirect;
+          }
+          proxy_pass http://unix:/run/gunicorn.sock;
+      }
+
+      location / {
+          try_files not_a_file.html @django1;
       }
 
       location /static {


### PR DESCRIPTION
fixes #743

This was broken: 
https://www.boost.io/doc/libs/1_83_0/libs/json
While this works ok:
https://www.boost.io/doc/libs/1_83_0/libs/json/

A default nginx vhost tries URIs in order. How can that be done with proxy_pass.

```
location / {
  try_files $uri $uri/ =404;
}
```


1. Using the nginx "try_files" directive, sends all requests to a named location `@django1`.
2. `@django1` tries to serve the file. If it hits a 404 error, sends the request to `@django2`.
3. `@django2` adds a trailing slash (if one is missing), and sends back a redirect to the browser. 
4. The client request the file again, this time with the trailing slash. It loads. 

In some ways, it would be nice to use an internal rewrite, and instantly return a result, instead of a multistep process where `@django2` returns a redirect. The problem is that many boost documentation pages are themselves html meta refresh redirects. The browser needs to be know "where it is" (what the current path is),  if it receives one of these meta refresh pages. A redirect provides that information. Then the URL is correct. There is a small side-effect of this solution: every 404 error will appear to have a trailing slash /, since that's the last page that was attempted, before giving up. If that side-effect could be eliminated, while otherwise keeping the functionality of this feature, it would be even better.  But not a blocker.
