### PR TITLE
"Proposed for boost.org" added to footer.

### DIFF
--- a/templates/includes/_footer.html
+++ b/templates/includes/_footer.html
@@ -10,7 +10,7 @@
       <span class="inline sm:hidden text-white/30">&nbsp;&nbsp; | &nbsp;&nbsp;</span>
       <a class="my-2 inline hover:text-orange" href="https://github.com/boostorg" target="_blank">GitHub</a>
     </div>
-    <div><span class="text-sm">Website supported by grants from <a href="https://cppalliance.org/" target="_blank" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">The C++ Alliance</a>.</span></div>
+    <div><span class="text-sm">Website supported by grants from <a href="https://cppalliance.org/" target="_blank" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">The C++ Alliance</a>. Proposed for <a href="https://boost.org/" target="_blank" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">boost.org</a>.</span></div>
     <div><span class="text-xs italic">Distributed under the <a href="/LICENSE_1_0.txt" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">Boost Software License, Version 1.0</a>.</span></div>
     {# <div><span class="text-sm"><i>Slack is a registered trademark and service mark of Slack Technologies, Inc.</i></span></div> #}
   </div>


### PR DESCRIPTION
Added "Proposed for boost.org" in the footer as per #993 

![image](https://github.com/boostorg/website-v2/assets/49487079/1604c8f5-ce4b-4972-b6d3-cb05791014c0)
