### PR TITLE
Fix for #1007: libs/{libname} redirects are broken

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -135,7 +135,7 @@ urlpatterns = (
         path(
             "style-guide/",
             TemplateView.as_view(template_name="style_guide.html"),
-            name="donate",
+            name="style-guide",
         ),
         path(
             "libraries/by-category/",
@@ -153,6 +153,12 @@ urlpatterns = (
             "libraries/<slug:slug>/",
             LibraryDetail.as_view(),
             name="library-detail",
+        ),
+        # Redirect for legacy boost.org urls.
+        path(
+            "libs/<slug:slug>/",
+            LibraryDetail.as_view(redirect_to_docs=True),
+            name="library-docs-redirect",
         ),
         path(
             "mailing-list/<int:pk>/",

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -155,6 +155,7 @@ class LibraryDetail(FormMixin, DetailView):
     form_class = VersionSelectionForm
     model = Library
     template_name = "libraries/detail.html"
+    redirect_to_docs = False
 
     def get_context_data(self, **kwargs):
         """Set the form action to the main libraries page"""
@@ -342,6 +343,15 @@ class LibraryDetail(FormMixin, DetailView):
             return get_object_or_404(Version, slug=version_slug)
         else:
             return Version.objects.most_recent()
+
+    def dispatch(self, request, *args, **kwargs):
+        """Check if the user has requested a specific version of the library."""
+
+        # Redirect to the documentation page, if requested to.
+        if self.redirect_to_docs:
+            return redirect(self.get_documentation_url(self.get_version()))
+
+        return super().dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
         """User has submitted a form and will be redirected to the right record."""


### PR DESCRIPTION
This pull request adds a `redirect_to_docs` parameter to the Library collection view, allowing us to special case `/lib/lib-name` to redirect to the configured documentation URL.