### PR TITLE
Fix category URL in library detail page

### DIFF
--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -64,8 +64,7 @@
               <span class="font-bold">Categories:</span>
               {% for category in object.categories.all %}
                 <a class="inline text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"
-                href="{% url 'libraries' %}?category=
-                     {{ category.slug }}{% if version %}&version={{ version.slug }}{% endif %}">{{ category.name }}</a>
+                href="{% url 'libraries' %}?category={{ category.slug }}{% if version %}&version={{ version.slug }}{% endif %}">{{ category.name }}</a>
                 {% if not forloop.last %}, {% endif %}
               {% endfor %}
             </div>


### PR DESCRIPTION
This pull request fixes links to categories from the library detail page. 