### PR TITLE
Add redirect for '/libs/' legacy boost.org urls in config/urls.py

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -154,6 +154,12 @@ urlpatterns = (
             LibraryDetail.as_view(),
             name="library-detail",
         ),
+        # Redirect for '/libs/' legacy boost.org urls.
+        re_path(
+            r"^libs/(?P<slug>[-\w]+)/?$",
+            LibraryDetail.as_view(redirect_to_docs=True),
+            name="library-docs-redirect",
+        ),
         path(
             "mailing-list/<int:pk>/",
             MailingListDetailView.as_view(),
@@ -265,12 +271,6 @@ urlpatterns = (
     ]
     + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     + [
-        # Redirect for '/libs/' legacy boost.org urls.
-        re_path(
-            r"libs/(?P<slug>.+)/?$",
-            LibraryDetail.as_view(redirect_to_docs=True),
-            name="library-docs-redirect",
-        ),
         # Libraries docs, some HTML parts are re-written
         re_path(
             r"^doc/libs/(?P<content_path>.+)/?",


### PR DESCRIPTION
This change makes links in /releases/ clickable.