### PR TITLE
Show theme switcher on docs pages

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -387,7 +387,7 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
             # was not generate from Antora builders.
             return content
 
-        context = {"disable_theme_switcher": True}
+        context = {"disable_theme_switcher": False}
         base_html = render_to_string(
             "docs_libs_placeholder.html", context, request=self.request
         )


### PR DESCRIPTION
This pull request enables the theme switcher to be visible on documentation pages. 