### PR TITLE
Replace Artifactory URLs with `archives.boost.io` URLs

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -474,7 +474,7 @@ MIN_ARTIFACTORY_RELEASE = "boost-1.63.0"
 
 # archives.boost.io settings
 # This is the URL where the archives.boost.io site is hosted.
-ARCHIVES_URL = "https://archives.boost.io/"
+ARCHIVES_URL = env("ARCHIVES_URL", default="https://archives.boost.io/")
 MIN_ARCHIVES_RELEASE = "boost-1.63.0"
 
 # The min Boost version is the oldest version of Boost that our import scripts

--- a/config/settings.py
+++ b/config/settings.py
@@ -464,11 +464,16 @@ CORS_ALLOW_HEADERS = (
     "credentials",
 )
 
-# Artifactory settings
+# Legacy Artifactory settings
+# Please note that these settings are not used in the current version of the site,
+# but are kept here for reference.
 ARTIFACTORY_URL = env(
     "ARTIFACTORY_URL", default="https://boostorg.jfrog.io/artifactory/api/storage/main/"
 )
 MIN_ARTIFACTORY_RELEASE = "boost-1.63.0"
+
+# archives.boost.io settings
+# This is the URL where the archives.boost.io site is hosted.
 ARCHIVES_URL = "https://archives.boost.io/"
 MIN_ARCHIVES_RELEASE = "boost-1.63.0"
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -469,6 +469,8 @@ ARTIFACTORY_URL = env(
     "ARTIFACTORY_URL", default="https://boostorg.jfrog.io/artifactory/api/storage/main/"
 )
 MIN_ARTIFACTORY_RELEASE = "boost-1.63.0"
+ARCHIVES_URL = "https://archives.boost.io/"
+MIN_ARCHIVES_RELEASE = "boost-1.63.0"
 
 # The min Boost version is the oldest version of Boost that our import scripts
 # will retrieve.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,14 +1,17 @@
 # Management Commands
 
-- [`boost_setup`](#boost_setup)
-- [`import_versions`](#import_versions)
-- [`import_artifactory_release_data`](#import_artifactory_release_data)
-- [`update_libraries`](#update_libraries)
-- [`import_library_versions`](#import_library_versions)
-- [`import_library_version_docs_urls`](#import_library_version_docs_urls)
-- [`update_maintainers`](#update_maintainers)
-- [`update_authors`](#update_authors)
-- [`import_commit_counts`](#import_commit_counts)
+- [Management Commands](#management-commands)
+  - [`boost_setup`](#boost_setup)
+  - [`import_versions`](#import_versions)
+  - [`import_archives_release_data`](#import_archives_release_data)
+  - [`import_artifactory_release_data`](#import_artifactory_release_data)
+  - [`update_libraries`](#update_libraries)
+  - [`import_library_versions`](#import_library_versions)
+  - [`import_library_version_docs_urls`](#import_library_version_docs_urls)
+  - [`update_maintainers`](#update_maintainers)
+  - [`update_authors`](#update_authors)
+  - [`import_commit_counts`](#import_commit_counts)
+  - [`import_beta_release`](#import_beta_release)
 
 ## `boost_setup`
 
@@ -55,9 +58,33 @@ Imports `Version` objects from GitHub.
 - For each successful tag, import it as a `Version` object
 - Then, run the command to the release downloads from Artifactory as `VersionFile` objects
 
-## `import_artifactory_release_data`
+## `import_archives_release_data`
 
 *This process is run automatically as part of `import_versions`.*
+
+Import `VersionFile` objects from Artifactory.
+
+**Example**
+
+```bash
+./manage.py import_archives_release_data
+```
+
+**Options**
+
+| Options              | Format | Description                                                  |
+|----------------------|--------|--------------------------------------------------------------|
+| `--release`  | string   | Format: `boost-1.63.0`. If passed, will import Artifactory urls for only that version. |
+
+**More Information**
+
+- Loops through `Version` objects and calls the task that retrieves the Artifactory data with the version information
+- Saves the Archives JSON data as `VersionFile` objects
+
+
+## `import_artifactory_release_data`
+
+*This process was run automatically as part of `import_versions`, but has been replaced by `import_archives_release_data`.*
 
 Import `VersionFile` objects from Artifactory.
 

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -38,11 +38,17 @@ This project uses environment variables to configure certain aspects of the appl
 
 ## Boost Release Downloads Settings
 
-### `ARTIFACTORY_URL`
+### `ARTIFACTORY_URL` (deprecated)
 
 - Base API endpoint for accessing the JFrog Artifactory release downloads. This is NOT the base URL for the downloads themselves.
 - For **local development**, there is a default value in `config/settings.py`
 - In **deployed environments**, the valid value is set in `kube/boost/values.yaml` (or the environment-specific yaml file).
+
+### `ARCHIVES_URL`
+
+- Base API endpoint for accessing the archives.boost.io release downloads.
+- For **development and production**, there is a default value in `config/settings.py`
+- Alternatively, the value can be set in `kube/boost/values.yaml`.
 
 ### `MIN_ARTIFACTORY_RELEASE`
 

--- a/requirements.in
+++ b/requirements.in
@@ -26,6 +26,7 @@ django-storages
 wheel
 cryptography
 boto3
+jsoncomment
 
 # Logging
 django-tracer

--- a/requirements.txt
+++ b/requirements.txt
@@ -182,6 +182,8 @@ identify==2.5.35
     # via pre-commit
 idna==3.6
     # via requests
+importlib-metadata==5.2.0
+    # via json-spec
 iniconfig==2.0.0
     # via pytest
 ipython==8.22.2
@@ -192,6 +194,10 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+json-spec==0.11.0
+    # via jsoncomment
+jsoncomment==0.4.2
+    # via -r ./requirements.in
 jwcrypto==1.5.6
     # via django-oauth-toolkit
 kombu==5.3.6
@@ -361,6 +367,8 @@ wheel==0.43.0
     #   pip-tools
 whitenoise==6.6.0
     # via -r ./requirements.in
+zipp==3.18.1
+    # via importlib-metadata
 zope-event==5.0
     # via gevent
 zope-interface==6.2

--- a/versions/management/commands/import_archives_release_data.py
+++ b/versions/management/commands/import_archives_release_data.py
@@ -6,8 +6,8 @@ from django.conf import settings
 
 from versions.models import Version
 from versions.releases import (
-    get_artifactory_download_data,
-    get_artifactory_download_uris_for_release,
+    get_archives_download_data,
+    get_archives_download_uris_for_release,
     store_release_downloads_for_version,
 )
 
@@ -22,7 +22,7 @@ def command(release):
     specified release. If no release is specified, it will import the release data
     for all releases included in Artifactory.
     """
-    last_release = settings.MIN_ARTIFACTORY_RELEASE
+    last_release = settings.MIN_ARCHIVES_RELEASE
 
     if release:
         versions = Version.objects.filter(name__icontains=release)
@@ -32,17 +32,17 @@ def command(release):
     for v in versions:
         version_num = v.name.replace("boost-", "")
         try:
-            artifactory_data = get_artifactory_download_uris_for_release(version_num)
+            archives_data = get_archives_download_uris_for_release(version_num)
         except requests.exceptions.HTTPError:
             print(f"Skipping {version_num}, error retrieving release data")
             continue
 
         download_data = []
-        for d in artifactory_data:
+        for d in archives_data:
             try:
-                data = get_artifactory_download_data(d)
+                data = get_archives_download_data(d)
                 download_data.append(data)
-            except requests.exceptions.HTTPError:
+            except (requests.exceptions.HTTPError, ValueError):
                 print(f"Skipping {d}, error retrieving download data")
                 continue
 

--- a/versions/releases.py
+++ b/versions/releases.py
@@ -14,6 +14,7 @@ from .models import Version, VersionFile
 
 
 logger = structlog.get_logger(__name__)
+session = requests.Session()
 
 
 def get_archives_download_uris_for_release(release: str = "1.81.0") -> list:
@@ -34,7 +35,7 @@ def get_archives_download_uris_for_release(release: str = "1.81.0") -> list:
         release_path = f"{settings.ARCHIVES_URL}release/{release}/source/"
 
     try:
-        resp = requests.get(release_path)
+        resp = session.get(release_path)
         resp.raise_for_status()
     except requests.exceptions.HTTPError as e:
         logger.error(
@@ -74,7 +75,7 @@ def get_artifactory_download_uris_for_release(release: str = "1.81.0") -> list:
         release_path = f"{settings.ARTIFACTORY_URL}release/{release}/source/"
 
     try:
-        resp = requests.get(release_path)
+        resp = session.get(release_path)
         resp.raise_for_status()
     except requests.exceptions.HTTPError as e:
         logger.error(
@@ -114,7 +115,7 @@ def get_archives_download_data(url):
     json_url = f"{url}.json"
 
     try:
-        resp = requests.get(json_url)
+        resp = session.get(json_url)
         resp.raise_for_status()
     except requests.exceptions.HTTPError as e:
         logger.error("get_archives_download_data_error", exc_msg=str(e), url=json_url)
@@ -139,7 +140,7 @@ def get_archives_download_data(url):
 def get_artifactory_download_data(url):
     """Get the download information for a Boost release from the Boost artifactory."""
     try:
-        resp = requests.get(url)
+        resp = session.get(url)
         resp.raise_for_status()
     except requests.exceptions.HTTPError as e:
         logger.error("get_artifactory_releases_detail_error", exc_msg=str(e), url=url)
@@ -176,7 +177,7 @@ def get_release_notes_for_version(version_pk):
     filename = f"{version.slug.replace('boost', 'version').replace('-', '_')}.html"
     url = f"{base_url}{filename}"
     try:
-        response = requests.get(url)
+        response = session.get(url)
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         logger.error(

--- a/versions/releases.py
+++ b/versions/releases.py
@@ -122,6 +122,7 @@ def get_archives_download_data(url):
         raise
 
     try:
+        # Parse the JSON response, which sometimes has trailing commas.
         json_parser = JsonComment(json)
         resp_json = json_parser.loads(resp.text)
 

--- a/versions/releases.py
+++ b/versions/releases.py
@@ -48,6 +48,7 @@ def get_archives_download_uris_for_release(release: str = "1.81.0") -> list:
     uris = []
     for a in soup.find_all("a"):
         uri = a.get("href")
+        # Only include the download links with valid file extensions.
         if any(uri.endswith(ext) for ext in file_extensions):
             uris.append(f"{release_path}{uri}")
 

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -357,7 +357,7 @@ def import_release_downloads(version_pk):
         logger.info("import_release_downloads_skipped", version_name=version.name)
         return
 
-    call_command("import_artifactory_release_data", release=version_num)
+    call_command("import_archives_release_data", release=version_num)
     logger.info("import_release_downloads_complete", version_name=version.name)
 
 

--- a/versions/tests/test_releases.py
+++ b/versions/tests/test_releases.py
@@ -125,7 +125,7 @@ def test_get_archives_download_data_value_error():
     url = "https://example.com/release/1.81.0/source/boost_1_81_0.tar.bz2"
     responses.add(responses.GET, url, json={})
     with pytest.raises(ValueError):
-        get_artifactory_download_data(url)
+        get_archives_download_data(url)
 
 
 def test_store_release_downloads_for_version(version):

--- a/versions/tests/test_releases.py
+++ b/versions/tests/test_releases.py
@@ -122,7 +122,7 @@ def test_get_artifactory_download_data_value_error():
 
 @responses.activate
 def test_get_archives_download_data_value_error():
-    url = "https://example.com/release/1.81.0/source/boost_1_81_0.tar.bz2"
+    url = "https://example.com/release/1.81.0/source/boost_1_81_0.tar.bz2.json"
     responses.add(responses.GET, url, json={})
     with pytest.raises(ValueError):
         get_archives_download_data(url)

--- a/versions/tests/test_releases.py
+++ b/versions/tests/test_releases.py
@@ -35,32 +35,27 @@ def test_get_artifactory_downloads_for_release():
 def test_get_archives_downloads_for_release():
     version_num = "1.81.0"
     url = f"{settings.ARCHIVES_URL}release/{version_num}/source/"
-    data = """<html><head><title>Index of /release/1.81.0/source/</title><style type="text/css"></style></head>
+    data = """
+<html><head><title>Index of /release/1.81.0/source/</title></head>
 <body>
 <h1>Index of /release/1.81.0/source/</h1><hr><pre><a href="../">../</a>
-<a href="boost_1_81_0.7z">boost_1_81_0.7z</a>                                    15-Dec-2022 03:50           101553425
-<a href="boost_1_81_0.7z.json">boost_1_81_0.7z.json</a>                               15-Dec-2022 03:50                 196
-<a href="boost_1_81_0.tar.bz2">boost_1_81_0.tar.bz2</a>                               15-Dec-2022 03:50           118797750
-<a href="boost_1_81_0.tar.bz2.json">boost_1_81_0.tar.bz2.json</a>                          15-Dec-2022 03:50                 201
-<a href="boost_1_81_0.tar.gz">boost_1_81_0.tar.gz</a>                                15-Dec-2022 03:50           140221178
-<a href="boost_1_81_0.tar.gz.json">boost_1_81_0.tar.gz.json</a>                           15-Dec-2022 03:50                 200
-<a href="boost_1_81_0.zip">boost_1_81_0.zip</a>                                   15-Dec-2022 03:50           204805644
-<a href="boost_1_81_0.zip.json">boost_1_81_0.zip.json</a>                              15-Dec-2022 03:50                 197
-<a href="boost_1_81_0_rc1.7z">boost_1_81_0_rc1.7z</a>                                09-Dec-2022 03:47           101553425
-<a href="boost_1_81_0_rc1.7z.json">boost_1_81_0_rc1.7z.json</a>                           09-Dec-2022 03:47                 200
-<a href="boost_1_81_0_rc1.tar.bz2">boost_1_81_0_rc1.tar.bz2</a>                           09-Dec-2022 03:47           118797750
-<a href="boost_1_81_0_rc1.tar.bz2.json">boost_1_81_0_rc1.tar.bz2.json</a>                      09-Dec-2022 03:47                 205
-<a href="boost_1_81_0_rc1.tar.gz">boost_1_81_0_rc1.tar.gz</a>                            09-Dec-2022 03:47           140221178
-<a href="boost_1_81_0_rc1.tar.gz.json">boost_1_81_0_rc1.tar.gz.json</a>                       09-Dec-2022 03:47                 204
-<a href="boost_1_81_0_rc1.zip">boost_1_81_0_rc1.zip</a>                               09-Dec-2022 03:47           204805644
-<a href="boost_1_81_0_rc1.zip.json">boost_1_81_0_rc1.zip.json</a>                          09-Dec-2022 03:47                 201
+<a href="boost_1_81_0.7z">boost_1_81_0.7z</a> 15-Dec-2022 03:50           101553425
+<a href="boost_1_81_0.7z.json">boost_1_81_0.7z.json</a>  15-Dec-2022 03:50    196
+<a href="boost_1_81_0.tar.bz2">boost_1_81_0.tar.bz2</a>   15-Dec-2022 03:50  118797750
+<a href="boost_1_81_0.tar.bz2.json">boost_1_81_0.tar.bz2.json</a> 15-Dec-2022 03:50 201
+<a href="boost_1_81_0.tar.gz">boost_1_81_0.tar.gz</a> 15-Dec-2022 03:50  140221178
+<a href="boost_1_81_0.tar.gz.json">boost_1_81_0.tar.gz.json</a> 15-Dec-2022 03:50  200
+<a href="boost_1_81_0.zip">boost_1_81_0.zip</a> 15-Dec-2022 03:50  204805644
+<a href="boost_1_81_0.zip.json">boost_1_81_0.zip.json</a>   15-Dec-2022 03:50  197
+<a href="boost_1_81_0_rc1.7z">boost_1_81_0_rc1.7z</a>   09-Dec-2022 03:47 101553425
+<a href="boost_1_81_0_rc1.7z.json">boost_1_81_0_rc1.7z.json</a> 09-Dec-2022 03:47 200
 </pre><hr>
 
 </body></html>
     """
     responses.add(responses.GET, url, body=data)
     downloads = get_archives_download_uris_for_release(version_num)
-    assert len(downloads) == 8
+    assert len(downloads) == 5
     assert downloads[0] == f"{url}boost_1_81_0.7z"
 
 

--- a/versions/tests/test_releases.py
+++ b/versions/tests/test_releases.py
@@ -120,14 +120,6 @@ def test_get_artifactory_download_data_value_error():
         get_artifactory_download_data(url)
 
 
-@responses.activate
-def test_get_archives_download_data_value_error():
-    url = "https://example.com/release/1.81.0/source/boost_1_81_0.tar.bz2.json"
-    responses.add(responses.GET, url, json={})
-    with pytest.raises(ValueError):
-        get_archives_download_data(url)
-
-
 def test_store_release_downloads_for_version(version):
     count = VersionFile.objects.filter(version=version).count()
     data = [


### PR DESCRIPTION
This pull request adds support for `archives.boost.io` to the codebase, while leaving intact the artifactory code. 

Resolves #1005.