### PR TITLE
Add support for external URLs in item description for RSS feeds

### DIFF
--- a/news/feeds.py
+++ b/news/feeds.py
@@ -25,7 +25,14 @@ class RSSNewsFeed(Feed):
             return aware_datetime_obj
 
     def item_description(self, item):
-        """Return the Entry content in the description field."""
+        """Return the Entry content in the description field.
+
+        If the Entry has an external URL (and no content), return a link to that URL
+        instead.
+        """
+
+        if item.external_url and not item.content:
+            return f"External link to <a href='{item.external_url}'>{item.external_url}</a>."
         return item.content
 
     def item_title(self, item):

--- a/news/feeds.py
+++ b/news/feeds.py
@@ -32,7 +32,10 @@ class RSSNewsFeed(Feed):
         """
 
         if item.external_url and not item.content:
-            return f"External link to <a href='{item.external_url}'>{item.external_url}</a>."
+            return (
+                f"External link to <a href='{ item.external_url }'>"
+                f"{ item.external_url }</a>."
+            )
         return item.content
 
     def item_title(self, item):


### PR DESCRIPTION
If a news item lacks a content body, but includes an external link, the description for that RSS item is now:

```python
f"External link to <a href='{item.external_url}'>{item.external_url}</a>."
```

This should resolve #946.