### PR TITLE
Fixes #728

### DIFF
--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -126,6 +126,7 @@ def get_and_store_library_version_documentation_urls_for_version(version_pk):
             # validate this in S3
             key = documentation_url.split("#")
             content = get_content_from_s3(key[0])
+
             if content:
                 library_version.documentation_url = documentation_url
                 library_version.save()

--- a/libraries/tests/test_tasks.py
+++ b/libraries/tests/test_tasks.py
@@ -44,7 +44,7 @@ def test_get_and_store_library_version_documentation_urls_for_version(
     # Assert that the docs_path was updated as expected
     assert (
         library_version.documentation_url
-        == f"/doc/libs/{version.stripped_boost_url_slug}/libs/{library_name}/index.html"
+        == f"/doc/libs/{version.boost_url_slug}/libs/{library_name}/index.html"
     )
 
 

--- a/libraries/tests/test_tasks.py
+++ b/libraries/tests/test_tasks.py
@@ -44,7 +44,7 @@ def test_get_and_store_library_version_documentation_urls_for_version(
     # Assert that the docs_path was updated as expected
     assert (
         library_version.documentation_url
-        == f"/doc/libs/{version.boost_url_slug}/libs/{library_name}/index.html"
+        == f"/doc/libs/{version.stripped_boost_url_slug}/libs/{library_name}/index.html"
     )
 
 

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -314,7 +314,7 @@ class LibraryDetail(FormMixin, DetailView):
             # If we know the library-version docs are missing, return the version docs
             if library_version.missing_docs:
                 return docs_url
-            # If we have the library-version docs and believe they are valid, return those
+            # If we have the library-version docs and they are valid, return those
             elif library_version.documentation_url:
                 return library_version.documentation_url
             # If we wind up here, return the version docs

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -305,19 +305,28 @@ class LibraryDetail(FormMixin, DetailView):
 
     def get_documentation_url(self, version):
         """Get the documentation URL for the current library."""
-        obj = self.get_object()
-        library_version = LibraryVersion.objects.get(library=obj, version=version)
-        docs_url = version.documentation_url
 
-        # If we know the library-version docs are missing, return the version docs
-        if library_version.missing_docs:
-            return docs_url
-        # If we have the library-version docs and believe they are valid, return those
-        elif library_version.documentation_url:
-            return library_version.documentation_url
-        # If we wind up here, return the version docs
-        else:
-            return docs_url
+        def find_documentation_url(version):
+            obj = self.get_object()
+            library_version = LibraryVersion.objects.get(library=obj, version=version)
+            docs_url = version.documentation_url
+
+            # If we know the library-version docs are missing, return the version docs
+            if library_version.missing_docs:
+                return docs_url
+            # If we have the library-version docs and believe they are valid, return those
+            elif library_version.documentation_url:
+                return library_version.documentation_url
+            # If we wind up here, return the version docs
+            else:
+                return docs_url
+
+        # Get the URL for the version.
+        url = find_documentation_url(version)
+        # Remove the "boost_" prefix from the URL.
+        url = url.replace("boost_", "")
+
+        return url
 
     def get_github_url(self, version):
         """Get the GitHub URL for the current library."""

--- a/versions/models.py
+++ b/versions/models.py
@@ -51,6 +51,7 @@ class Version(models.Model):
         if self.slug:
             return self.slug
         name = self.name.replace(".", " ")
+        name = name.replace("boost_", "")
         return slugify(name)[:50]
 
     @cached_property
@@ -95,6 +96,7 @@ class Version(models.Model):
         S3 path."""
         site_path = "/doc/libs/"
         slug = self.slug.replace("-", "_").replace(".", "_")
+        slug = slug.replace("boost_", "")
         return f"{site_path}{slug}/index.html"
 
     @cached_property

--- a/versions/models.py
+++ b/versions/models.py
@@ -50,7 +50,7 @@ class Version(models.Model):
     def get_slug(self):
         if self.slug:
             return self.slug
-        name = self.name.replace(".", " ")
+        name = self.name.replace(".", " ").replace("boost_", "")
         return slugify(name)[:50]
 
     @cached_property
@@ -94,8 +94,7 @@ class Version(models.Model):
         static content config file for the mapping from the site_path to the
         S3 path."""
         site_path = "/doc/libs/"
-        slug = self.slug.replace("-", "_").replace(".", "_")
-        slug = slug.replace("boost_", "")
+        slug = self.slug.replace("-", "_").replace(".", "_").replace("boost_", "")
         return f"{site_path}{slug}/index.html"
 
     @cached_property

--- a/versions/models.py
+++ b/versions/models.py
@@ -96,7 +96,7 @@ class Version(models.Model):
         site_path = "/doc/libs/"
         slug = self.slug.replace("-", "_").replace(".", "_")
         slug = slug.replace("boost_", "")
-        return f"{site_path}{slug}/"
+        return f"{site_path}{slug}/index.html"
 
     @cached_property
     def cleaned_version_parts(self):

--- a/versions/models.py
+++ b/versions/models.py
@@ -96,7 +96,7 @@ class Version(models.Model):
         site_path = "/doc/libs/"
         slug = self.slug.replace("-", "_").replace(".", "_")
         slug = slug.replace("boost_", "")
-        return f"{site_path}{slug}/index.html"
+        return f"{site_path}{slug}/"
 
     @cached_property
     def cleaned_version_parts(self):

--- a/versions/models.py
+++ b/versions/models.py
@@ -51,7 +51,6 @@ class Version(models.Model):
         if self.slug:
             return self.slug
         name = self.name.replace(".", " ")
-        name = name.replace("boost_", "")
         return slugify(name)[:50]
 
     @cached_property

--- a/versions/tests/test_models.py
+++ b/versions/tests/test_models.py
@@ -50,7 +50,7 @@ def test_version_display_name(version):
 def test_version_documentation_url(version):
     version.slug = "boost-1.81.0"
     version.save()
-    assert version.documentation_url == "/doc/libs/boost_1_81_0/index.html"
+    assert version.documentation_url == "/doc/libs/1_81_0/index.html"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This pull request seeks to solve #728.

With this change, libraries and documentation are using the `/1_83_0/` url format instead of `/boost_1_83_0/`.