### PR TITLE
disable modernization for iframe requests

### DIFF
--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -111,6 +111,8 @@ def _replace_body(result, original_body, base_body):
 
 
 def modernize_legacy_page(content, base_html, head_selector="head", insert_body=True):
+    """Modernize a legacy Boost documentation page."""
+
     result = BeautifulSoup(content, "html.parser")
     if result.html is None:
         # Not an HTML file we care about
@@ -164,7 +166,7 @@ def modernize_legacy_page(content, base_html, head_selector="head", insert_body=
     content = str(result)
 
     # Replace all links to boost.org with a local link
-    content = content.replace("https://www.boost.org/doc/libs/", "/docs/libs/")
+    content = content.replace("https://www.boost.org/doc/libs/", "/doc/libs/")
 
     return content
 


### PR DESCRIPTION
This pull request seeks to fix #621.

Basically, "modernization" of the doc is disabled if the request is coming from an iframe. Here's a pic of a currently–affected library's docs now:

<img width="1521" alt="image" src="https://github.com/boostorg/website-v2/assets/119893/f4e48fcf-4c71-46fd-bf32-902e2c69ef26">

We'll want to find a way to include our header here, eventually, but this is a good solution for restoring the functionality of these pages. 