### PR TITLE
Use Django Session to intelligently remember which boost version was explicitly selected

### DIFF
--- a/versions/views.py
+++ b/versions/views.py
@@ -11,6 +11,8 @@ from core.models import RenderedContent
 from libraries.forms import VersionSelectionForm
 from versions.models import Version
 
+SELECTED_BOOST_VERSION_SESSION_KEY = "boost_version"
+
 logger = structlog.get_logger(__name__)
 
 
@@ -21,6 +23,14 @@ class VersionDetail(FormMixin, DetailView):
     model = Version
     queryset = Version.objects.active().defer("data")
     template_name = "versions/detail.html"
+
+    def get_selected_boost_version(self):
+        """Returns the selected Boost version"""
+        return self.request.session.get(SELECTED_BOOST_VERSION_SESSION_KEY, None)
+
+    def set_selected_boost_version(self, version):
+        """Sets the selected Boost version"""
+        self.request.session[SELECTED_BOOST_VERSION_SESSION_KEY] = version
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data()
@@ -88,6 +98,25 @@ class VersionDetail(FormMixin, DetailView):
         else:
             logger.info("version_detail_invalid_version")
         return super().get(request)
+
+    def dispatch(self, request, *args, **kwargs):
+        """Set the version if it is not already set."""
+
+        version_in_url = self.kwargs.get("slug", False)
+        current_slug = Version.objects.most_recent().slug
+
+        if version_in_url:
+            self.set_selected_boost_version(version_in_url)
+        else:
+            stored_version = self.get_selected_boost_version()
+            if stored_version:
+                if stored_version != current_slug:
+                    return redirect(
+                        "release-detail",
+                        slug=stored_version,
+                    )
+
+        return super().dispatch(request, *args, **kwargs)
 
 
 class VersionCurrentReleaseDetail(VersionDetail):

--- a/versions/views.py
+++ b/versions/views.py
@@ -109,12 +109,12 @@ class VersionDetail(FormMixin, DetailView):
         if version_in_url:
             self.set_selected_boost_version(version_in_url)
         else:
-            stored_version = self.get_selected_boost_version()
-            if stored_version:
-                if stored_version != current_version_slug:
+            redirect_to_version = self.get_selected_boost_version()
+            if redirect_to_version:
+                if redirect_to_version != current_version_slug:
                     return redirect(
                         "release-detail",
-                        slug=stored_version,
+                        slug=redirect_to_version,
                     )
 
         return super().dispatch(request, *args, **kwargs)

--- a/versions/views.py
+++ b/versions/views.py
@@ -103,14 +103,15 @@ class VersionDetail(FormMixin, DetailView):
         """Set the version if it is not already set."""
 
         version_in_url = self.kwargs.get("slug", False)
-        current_slug = Version.objects.most_recent().slug
+        current_version = Version.objects.most_recent()
+        current_version_slug = current_version.slug if current_version else None
 
         if version_in_url:
             self.set_selected_boost_version(version_in_url)
         else:
             stored_version = self.get_selected_boost_version()
             if stored_version:
-                if stored_version != current_slug:
+                if stored_version != current_version_slug:
                     return redirect(
                         "release-detail",
                         slug=stored_version,


### PR DESCRIPTION
This may not be the approach we want to take, but here's a pull request that aims to solve #1040 using Django sessions.