### PR TITLE
Fix library display names

### DIFF
--- a/libraries/models.py
+++ b/libraries/models.py
@@ -127,6 +127,26 @@ class Library(models.Model):
     class Meta:
         verbose_name_plural = "Libraries"
 
+    @cached_property
+    def display_name(self):
+        """Returns the display name for the library"""
+        import re
+
+        words = []
+
+        # Split the name on spaces, hyphens, and underscores.
+        for word in re.split(r"[\s\-_]+", self.name):
+            # Capitalize the first letter of each word.
+            word_parts = []
+
+            for part in word.split("/"):
+                word_parts.append(part.capitalize())
+            word = "/".join(word_parts)
+
+            words.append(word)
+
+        return "".join(words)
+
     def __str__(self):
         return self.name
 

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -13,7 +13,7 @@
          x-on:keydown.escape="showSearch=false">
       <div class="flex-auto mb-2 w-full">
         <div id="overview">
-          <span class="text-xl md:text-3xl lg:text-4xl text-orange">Boost.{{ object.name }}</span>
+          <span class="text-xl md:text-3xl lg:text-4xl text-orange">{{ object.display_name }}</span>
 
         </div>
       </div>

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load static %}
 
-{% block title %}Boost.{{ object.name }} ({{ version.display_name }}){% endblock %}
+{% block title %}{{ object.display_name }} ({{ version.display_name }}){% endblock %}
 {% block description %}{% trans object.description %}{% endblock %}
 {% block author %}{{ author_tag }}{% endblock %}
 


### PR DESCRIPTION
Solves #1043. This adds `Library.display_name` and `Library.display_name_short`, which reflects the rules outlined in issue #1043.

There are a few instances where we will need to update the library name in Django Admin, I believe (e.g. `Boost.StlInterfaces`).