### PR TITLE
Remove fallback url map going to s3

### DIFF
--- a/core/boostrenderer.py
+++ b/core/boostrenderer.py
@@ -86,7 +86,10 @@ def get_content_from_s3(key=None, bucket_name=None):
         raise ValueError("No key provided.")
 
     bucket_name = bucket_name or settings.STATIC_CONTENT_BUCKET_NAME
-    s3_keys = get_s3_keys(key) or [key]
+    # s3_keys = get_s3_keys(key) or [key]
+    # Force a successful lookup from get_s3_keys, otherwise no match at all.
+    # That removes any random default "/" lookups.
+    s3_keys = get_s3_keys(key) or []
     client = get_s3_client()
 
     for s3_key in s3_keys:

--- a/stage_static_config.json
+++ b/stage_static_config.json
@@ -38,9 +38,5 @@
   {
     "site_path": "/doc/",
     "s3_path": "/site-docs/develop/"
-  },
-  {
-    "site_path": "/",
-    "s3_path": "/site/develop/"
   }
 ]


### PR DESCRIPTION
See issue 724.  Remove static content requests from "/" that don't match any specific mappings.

```
  {
    "site_path": "/",
    "s3_path": "/site/develop/"
  }
```

This s3 path  "/site/develop/" does not even exist in S3.   
If a bot requested a page `/not-a-file` it would generate a request to S3 every time.  
Before this modification a missing page 404 took 800ms or 1sec.     Now it might be 200ms which is 4-5 times faster.
Before, Cloud Logging showed many "get_content_from_s3_error" errors.   Now those errors are gone.