### PR TITLE
Remove Cairo font family reference globally

### DIFF
--- a/docstailwind.config.js
+++ b/docstailwind.config.js
@@ -27,11 +27,6 @@ module.exports = {
       bronze: '#BB8A56',
       silver: '#B5C9D3',
     },
-    extend: {
-      fontFamily: {
-        cairo: "'Cairo', sans-serif",
-      },
-    },
   },
   variants: {
     extend: {},

--- a/frontend/docsstyles.css
+++ b/frontend/docsstyles.css
@@ -6,9 +6,7 @@
 }
 
 body {
-  @apply max-w-7xl mx-auto md:pt-11 md:px-6 my-0;
-  @apply h-screen font-cairo;
-  @apply font-cairo;
+  @apply max-w-7xl mx-auto md:pt-11 md:px-6 my-0 h-screen;
 }
 
 hr:first-of-type {
@@ -21,11 +19,11 @@ hr:first-of-type {
 
 
 div.section:first-of-type,
-div.spirit-nav:first-of-type,,
-div.copyright-footer:first-of-type,,
-div.chapter:first-of-type,,
-div.refentry:first-of-type,,
-div.book:first-of-type, {
+div.spirit-nav:first-of-type,
+div.copyright-footer:first-of-type,
+div.chapter:first-of-type,
+div.refentry:first-of-type,
+div.book:first-of-type {
   @apply max-w-7xl px-3 md:px-6 mx-auto;
 }
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -14,7 +14,6 @@
 
   body {
     @apply text-slate dark:text-white;
-    @apply font-cairo;
   }
   h1 {
     @apply text-6xl;

--- a/frontend/userguidestyles.css
+++ b/frontend/userguidestyles.css
@@ -11,8 +11,8 @@ html {
 }
 
 body {
-  @apply h-screen font-cairo dark:bg-black dark:!text-white;
-  @apply font-cairo;
+  @apply h-screen dark:bg-black dark:!text-white;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
 p a:link, p a:visited, table a, .title a {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -2750,7 +2750,7 @@ code,
 }
 
 .font-cairo {
-  font-family: 'Cairo', sans-serif;
+  /* font-family: 'Cairo', sans-serif; */
 }
 
 .text-5xl {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -602,10 +602,6 @@ body {
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
-body {
-  font-family: 'Cairo', sans-serif;
-}
-
 h1 {
   font-size: 3.75rem;
   line-height: 1;
@@ -1554,10 +1550,6 @@ code,
 
 .mb-8 {
   margin-bottom: 2rem;
-}
-
-.mb-12 {
-  margin-bottom: 3rem;
 }
 
 .block {
@@ -2637,6 +2629,10 @@ code,
   padding-left: 1rem;
 }
 
+.pb-0 {
+  padding-bottom: 0px;
+}
+
 .pl-6 {
   padding-left: 1.5rem;
 }
@@ -2647,10 +2643,6 @@ code,
 
 .pr-7 {
   padding-right: 1.75rem;
-}
-
-.pb-0 {
-  padding-bottom: 0px;
 }
 
 .pt-8 {
@@ -2747,10 +2739,6 @@ code,
 
 .align-bottom {
   vertical-align: bottom;
-}
-
-.font-cairo {
-  /* font-family: 'Cairo', sans-serif; */
 }
 
 .text-5xl {
@@ -3521,20 +3509,20 @@ code,
     margin-bottom: 0.5rem;
   }
 
-  .md\:mt-5 {
-    margin-top: 1.25rem;
-  }
-
   .md\:mb-5 {
     margin-bottom: 1.25rem;
   }
 
-  .md\:mt-3 {
-    margin-top: 0.75rem;
+  .md\:mt-5 {
+    margin-top: 1.25rem;
   }
 
-  .md\:mb-11 {
-    margin-bottom: 2.75rem;
+  .md\:mb-3 {
+    margin-bottom: 0.75rem;
+  }
+
+  .md\:mt-3 {
+    margin-top: 0.75rem;
   }
 
   .md\:mt-8 {
@@ -3557,6 +3545,10 @@ code,
     margin-top: 2.75rem;
   }
 
+  .md\:mb-11 {
+    margin-bottom: 2.75rem;
+  }
+
   .md\:mb-6 {
     margin-bottom: 1.5rem;
   }
@@ -3571,10 +3563,6 @@ code,
 
   .md\:ml-6 {
     margin-left: 1.5rem;
-  }
-
-  .md\:mb-3 {
-    margin-bottom: 0.75rem;
   }
 
   .md\:block {
@@ -3891,19 +3879,9 @@ code,
     line-height: 1;
   }
 
-  .md\:text-xl {
-    font-size: 1.25rem;
-    line-height: 1.75rem;
-  }
-
   .md\:text-lg {
     font-size: 1.125rem;
     line-height: 1.75rem;
-  }
-
-  .md\:text-2xl {
-    font-size: 1.5rem;
-    line-height: 2rem;
   }
 
   .md\:text-sm {
@@ -3911,9 +3889,19 @@ code,
     line-height: 1.25rem;
   }
 
+  .md\:text-2xl {
+    font-size: 1.5rem;
+    line-height: 2rem;
+  }
+
   .md\:text-6xl {
     font-size: 3.75rem;
     line-height: 1;
+  }
+
+  .md\:text-xl {
+    font-size: 1.25rem;
+    line-height: 1.75rem;
   }
 }
 
@@ -4117,6 +4105,11 @@ code,
     line-height: 2rem;
   }
 
+  .lg\:text-lg {
+    font-size: 1.125rem;
+    line-height: 1.75rem;
+  }
+
   .lg\:text-base {
     font-size: 1rem;
     line-height: 1.5rem;
@@ -4125,16 +4118,6 @@ code,
   .lg\:text-3xl {
     font-size: 1.875rem;
     line-height: 2.25rem;
-  }
-
-  .lg\:text-lg {
-    font-size: 1.125rem;
-    line-height: 1.75rem;
-  }
-
-  .lg\:text-xl {
-    font-size: 1.25rem;
-    line-height: 1.75rem;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,11 +27,6 @@ module.exports = {
       bronze: '#BB8A56',
       silver: '#B5C9D3',
     },
-    extend: {
-      fontFamily: {
-        cairo: "'Cairo', sans-serif",
-      },
-    },
   },
   variants: {
     extend: {},

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,19 +3,7 @@
 <html>
 
   <head>
-    <!-- Google fonts for Cairo -->
-    <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js"></script>
-    <script>
-    {% comment %}
-      WebFont.load({
-        google: {
-          families: ['Cairo:200:latin', 'Cairo:300:latin', 'Cairo:400:latin', 'Cairo:500:latin', 'Cairo:600:latin', 'Cairo:700:latin', 'Cairo:800:latin']
-        }
-      });
-    {% endcomment %}
-    </script>
     <script defer data-domain="preview.boost.org" src="https://plausible.io/js/script.js"></script>
-
     <title>{% block title %}Boost{% endblock %}</title>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -52,7 +40,7 @@
               el.setAttribute('content', el.getAttribute('data-' + m));
             });
         }"
-        class="h-screen bg-gray-200 dark:bg-black font-cairo" {% block body_id %}{% endblock %}>
+        class="h-screen bg-gray-200 dark:bg-black" {% block body_id %}{% endblock %}>
 
     <div class="max-w-7xl md:px-6 mx-auto md:mt-14">
       {% block content_header %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,11 +6,13 @@
     <!-- Google fonts for Cairo -->
     <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js"></script>
     <script>
+    {% comment %}
       WebFont.load({
         google: {
           families: ['Cairo:200:latin', 'Cairo:300:latin', 'Cairo:400:latin', 'Cairo:500:latin', 'Cairo:600:latin', 'Cairo:700:latin', 'Cairo:800:latin']
         }
       });
+    {% endcomment %}
     </script>
     <script defer data-domain="preview.boost.org" src="https://plausible.io/js/script.js"></script>
 

--- a/templates/includes/_header.html
+++ b/templates/includes/_header.html
@@ -29,7 +29,7 @@
           </nav>
           <nav class="flex items-center space-x-3 lg:space-x-5 h-[30px]" x-data="{ 'searchOpen': false }">
             <span class="relative">
-              <i id="gecko-search-button" data-current-boost-version="{{ current_release.stripped_boost_url_slug }}" data-theme-mode="light" data-font-family="Cairo, sans-serif" class="inline -mt-1 cursor-pointer text-slate fas fa-search dark:text-white/50 dark:hover:text-orange hover:text-orange"></i>
+              <i id="gecko-search-button" data-current-boost-version="{{ current_release.stripped_boost_url_slug }}" data-theme-mode="light" data-font-family="sans-serif" class="inline -mt-1 cursor-pointer text-slate fas fa-search dark:text-white/50 dark:hover:text-orange hover:text-orange"></i>
               <script>
                 const geckoSearchButton = document.getElementById('gecko-search-button');
                 geckoSearchButton.setAttribute('data-theme-mode', localStorage.getItem('colorMode') === 'dark' ? 'dark' : 'light');

--- a/userguidetailwind.config.js
+++ b/userguidetailwind.config.js
@@ -28,11 +28,6 @@ module.exports = {
       silver: '#B5C9D3',
       active: '#1565c0',
     },
-    extend: {
-      fontFamily: {
-        cairo: "'Cairo', sans-serif",
-      },
-    },
   },
   variants: {
     extend: {},


### PR DESCRIPTION
This PR removes the Cairo font family and sets a modern fallback sans-serif font stack

This addresses #1065 