### PR TITLE
Make links inside library or releases to standard blue

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -128,6 +128,9 @@
   #libraryReadMe pre {
     @apply bg-transparent;
   }
+  #libraryReadMe a {
+    @apply text-sky-600;
+  }
 
   code,
   kbd,

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -970,8 +970,11 @@ select.dropdown {
   #libraryReadMe samp,
   #libraryReadMe pre {
   background-color: transparent;
-  font-size: 0.875rem;
-  line-height: 1.25rem;
+}
+
+#libraryReadMe a {
+  --tw-text-opacity: 1;
+  color: rgb(2 132 199 / var(--tw-text-opacity));
 }
 
 code,


### PR DESCRIPTION
### Summary
This PR allows links, or anchor tags, to resemble a standard blue link when rendered. Fixes #939 

### Before and after:
<img width="2416" alt="add-color-to-readme-links-939" src="https://github.com/boostorg/website-v2/assets/3632378/23c671c2-010f-47ea-b5e5-66e65006f84d">

### Questions
- In the Build Status section: are we ok with the "master", "develop" losing their background-color?