### PR TITLE
Add discussion policy link to community page

### DIFF
--- a/templates/community_temp.html
+++ b/templates/community_temp.html
@@ -31,7 +31,11 @@
           </a>
 
         </div>
-
+        <div>
+          <p class="text-center mx-auto pt-3">
+          Please, read our <a href="https://www.boost.io/doc/user-guide/discussion-policy.html" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange whitespace-nowrap">Discussion Policy</a> before posting.
+          </p>
+        </div>
       </div>
 
       <div class="p-6 text-white bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
@@ -44,7 +48,7 @@
       </div>
 
       <div class="p-6 text-white bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
-        <h5 class="text-2xl font-bold leading-tight text-orange">Cpplang Slack Workspace</h5>
+        <h5 class="text-2xl leading-tight text-orange">Cpplang Slack Workspace</h5>
 
         <p class="py-1 my-2 border-b border-gray-700">A vibrant hub for real-time discussions with Boost authors, maintainers, and contributors. Dive into one of the largest searchable databases for Boost/C++ insights and history. Join now.</p>
 


### PR DESCRIPTION
### Summary
This PR adds the discussion policy link to the Mailing List tab. Also removes the bold heading for Cpplang Slack Workspace for visual consistency.

Fixes #1087 

### Preview
![add-discussion-policy-link-1087](https://github.com/boostorg/website-v2/assets/3632378/37de8ede-e054-4c19-bc70-71ce22596730)
