### PR TITLE
Fix mobile header height

### DIFF
--- a/templates/includes/_header.html
+++ b/templates/includes/_header.html
@@ -158,7 +158,7 @@
       <div class="relative z-10 transition transform origin-top-right md:hidden" x-data="{ isOpen: false }">
 
         <div class="pb-1 border-b-2 border-gray-300 dark:border-charcoal">
-          <div class="inline-block relative pt-2 pl-2 mx-auto h-full">
+          <div class="inline-block relative pt-2 pl-2 mx-auto">
             <a href="{% url 'home' %}">
                 <img class="hidden w-auto dark:inline h-[30px]"
                     src="{% static 'img/Boost_Brandmark_WhiteBoost_Transparent.svg' %}"


### PR DESCRIPTION
Removes unnecessary `h-full` class from mobile header logo container, preventing an oversized nav on library doc pages in mobile view. 

Fixes #1107 