### PR TITLE
Refactor version dropdown logic in LibraryDetail view

### DIFF
--- a/libraries/views.py
+++ b/libraries/views.py
@@ -232,6 +232,14 @@ class LibraryDetail(FormMixin, DetailView):
             .order_by("-release_date")
         )
 
+        # Manually exclude feature branches from the version dropdown.
+        context["versions"] = context["versions"].exclude(
+            name__in=["develop", "master", "head"]
+        )
+
+        # Manually exclude beta releases from the version dropdown.
+        context["versions"] = context["versions"].exclude(beta=True)
+
         # Show an alert if the user is on an older version
         if context["version"] != latest_version:
             context["version_alert"] = True


### PR DESCRIPTION
This fixes beta releases and branch names from showing up on the library detail view dropdown.