### PR TITLE
Feature/1150 wrapping library links

### DIFF
--- a/templates/docs_temp.html
+++ b/templates/docs_temp.html
@@ -37,9 +37,8 @@ make the columns go to 1
             <div class="col-span-2 w-full h-3"></div>
             <div class="w-auto ml-6 mr-2 col-span-2 md:col-span-1"><a class="list-item text-base text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/user-guide/common-introduction.html">Common Scenarios</a></div>
             <div class="w-auto ml-6 mr-2 col-span-2 md:col-span-1"><a class="list-item text-base text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/user-guide/advanced-introduction.html">Advanced Scenarios</a></div>
-            <div class="w-auto ml-6 mr-2 col-span-2 md:col-span-1"><a class="list-item text-base text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/user-guide/library-naming.html">Library Names &amp; Organization</a></div>
-            <div class="w-auto ml-6 mr-2 col-span-2 md:col-span-1"><a class="list-item text-base text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/user-guide/header-organization-compilation.html">Headers &amp; Compiled Binaries</a></div>
             <div class="w-auto ml-6 mr-2 col-span-2 md:col-span-1"><a class="list-item text-base text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/user-guide/resources.html">Additional Resources</a></div>
+            <div class="w-auto ml-6 mr-2 col-span-2 md:col-span-1"><a class="list-item text-base text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/user-guide/user-community-introduction.html">Introduction to the User Community</a></div>
           </div>
       </div>
       <div class="order-1 lg:order-2 p-6 dark:text-white text-slate bg-white rounded-lg rounded-b-none lg:rounded-br-lg lg:rounded-l-none dark:bg-charcoal dark:bg-neutral-700 min-h-96 max-h-96 lg:max-h-max overflow-y-hidden">
@@ -79,15 +78,14 @@ make the columns go to 1
           <div class="grid grid-cols-2 gap-2 mt-6 text-lg">
 
             <div class="w-full col-span-2 md:col-span-1"><a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/getting-involved.html"><i class="mt-1 mr-2 far fa-handshake inline-block w-6 text-center"></i>Getting Involved</a></div>
-            <div class="w-full col-span-2 md:col-span-1"><a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/design-guide/design-guide.html"><i class="mt-1 mr-2 fas fa-diagram-project inline-block w-6 text-center"></i>Design Guide</a></div>
+            <div class="w-full col-span-2 md:col-span-1"><a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/contributors-faq.html"><i class="mt-1 mr-2 fas fa-clipboard-question inline-block w-6 text-center"></i>Contributors FAQ</a></div>
+            <div class="w-full col-span-2 md:col-span-1"><a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/design-guide/design-best-practices.html"><i class="mt-1 mr-2 fas fa-diagram-project inline-block w-6 text-center"></i>Design Guide</a></div>
             <div class="w-full col-span-2 md:col-span-1"><a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/version-control.html"><i class="mt-1 mr-2 fab fa-github inline-block w-6 text-center"></i>Version Control</a></div>
             <div class="w-full col-span-2 md:col-span-1"><a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/testing/intro.html"><i class="mt-1 mr-2 fas fa-microscope inline-block w-6 text-center"></i>Testing</a></div>
+            <div class="w-full col-span-2 md:col-span-1"><a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/superproject/overview.html"><i class="mt-1 mr-2 fas fa-bolt-lightning inline-block w-6 text-center"></i>The Super-Project</a></div>
             <div class="col-span-2 w-full h-3"></div>
-            <div class="w-auto ml-6 mr-2 col-span-2 md:col-span-1"><a class="list-item text-base text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/requirements/library-requirements.html">Libraries</a></div>
-            <div class="w-auto ml-6 mr-2 col-span-2 md:col-span-1"><a class="list-item text-base text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/requirements/license-requirements.html">Licenses</a></div>
-            <div class="w-auto ml-6 mr-2 col-span-2 md:col-span-1"><a class="list-item text-base text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/requirements/portability-requirements.html">Portability</a></div>
-            <div class="w-auto ml-6 mr-2 col-span-2 md:col-span-1"><a class="list-item text-base text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/requirements/organization-requirements.html">Code Organization</a></div>
-
+            <div class="w-auto ml-6 mr-2 col-span-2 md:col-span-1"><a class="list-item text-base text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/contributor-community-introduction.html">Introduction to the Contributors Community</a></div>
+            <div class="w-auto ml-6 mr-2 col-span-2 md:col-span-1"><a class="list-item text-base text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/requirements/library-requirements.html">Library Requirements</a></div>
           </div>
 
       </div>

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -72,31 +72,31 @@
             <p class="pt-4 mt-4 whitespace-normal text-lg border-t border-gray-700">{{ object.description }}</p>
           </div>
 
-          <div class="-ml-2 h-14">
+          <div class="-ml-2 h-16">
             {% if documentation_url %}
             <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"
               href="{{ documentation_url }}">
               <span class="dark:text-white text-slate">Documentation</span>
-              <span class="block text-xs">{{ request.get_host }}{{ documentation_url|cut:"https://" }}</span>
+              <span class="block text-xs text-wrap whitespace-pre-line mb-2">{{ request.get_host }}{{ documentation_url|cut:"https://" }}</span>
             </a>
             {% endif %}
           </div>
-          <div class="-ml-2 h-14">
+          <div class="-ml-2 h-16">
             <a
               class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"
               href="{{ object.github_issues_url }}">
               <i class="float-right mt-1 fas fa-bug"></i>
               <span class="dark:text-white text-slate">GitHub Issues</span>
-              <span class="block text-xs">{{ object.github_issues_url|cut:"https://" }}</span>
+              <span class="block text-xs whitespace-pre-line mb-2">{{ object.github_issues_url|cut:"https://" }}</span>
             </a>
           </div>
-          <div class="-ml-2 h-14">
+          <div class="-ml-2 h-16">
             <a
               class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"
               href="{{ github_url }}">
               <i class="float-right mt-1 fab fa-github"></i>
               <span class="dark:text-white text-slate">Source Code</span>
-              <span class="block text-xs">{{ github_url|cut:"https://" }}</span>
+              <span class="block text-xs whitespace-pre-line mb-2">{{ github_url|cut:"https://" }}</span>
             </a>
           </div>
         </div>


### PR DESCRIPTION
added CSS to wrap URLs instead of overflowing and space the divs cleanly

<img width="702" alt="Screenshot 2024-07-22 at 3 23 32 PM" src="https://github.com/user-attachments/assets/5efc0e31-4c27-439c-94d5-2dd7d78f6d04">
