### PR TITLE
fixed border bottom spacing on learn and community pages

### DIFF
--- a/templates/community_temp.html
+++ b/templates/community_temp.html
@@ -10,7 +10,7 @@
 
       <div class="p-6 text-white bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
         <h5 class="text-2xl leading-tight text-orange">Mailing Lists</h5>
-        <p class="py-1 my-2 border-b border-gray-700 text-slate dark:text-white">
+        <p class="py-1 my-2 border-b pb-4 border-gray-700 text-slate dark:text-white">
           Discover the Boost library community with options tailored to developers, casual users, and enthusiasts.
         </p>
         <div class="grid grid-cols-3">
@@ -40,7 +40,7 @@
 
       <div class="p-6 text-white bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
         <h5 class="text-2xl leading-tight text-orange">Discussion Forums</h5>
-        <p class="py-1 my-2 border-b border-gray-700 text-slate dark:text-white">
+        <p class="py-1 my-2 border-b pb-4 border-gray-700 text-slate dark:text-white">
           Coming soon, exploring the topics and decisions being made by the community will be available via a more modern interface.
         </p>
 
@@ -50,7 +50,7 @@
       <div class="p-6 text-white bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
         <h5 class="text-2xl leading-tight text-orange">Cpplang Slack Workspace</h5>
 
-        <p class="py-1 my-2 border-b border-gray-700">A vibrant hub for real-time discussions with Boost authors, maintainers, and contributors. Dive into one of the largest searchable databases for Boost/C++ insights and history. Join now.</p>
+        <p class="py-1 my-2 border-b pb-4 border-gray-700">A vibrant hub for real-time discussions with Boost authors, maintainers, and contributors. Dive into one of the largest searchable databases for Boost/C++ insights and history. Join now.</p>
 
         <div class="flex flex-col">
           <a href="https://cppalliance.org/slack/" class="flex p-3 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">Join Cpplang Slack</a>
@@ -76,13 +76,13 @@
 
       <div class="p-6 text-white bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
         <h5 class="text-2xl leading-tight text-orange">ISO C++</h5>
-        <p class="py-1 my-2 border-b border-gray-700 text-slate dark:text-white">News, Status & Discussion about Standard C++</p>
+        <p class="py-1 my-2 border-b pb-4 border-gray-700 text-slate dark:text-white">News, Status & Discussion about Standard C++</p>
         <p class="pt-3 text-slate dark:text-white"><a href="https://isocpp.org/" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange whitespace-nowrap">The Standard C++ Foundation</a> is a Washington 501(c)(6) not-for-profit organization supporting the C++ community and promotes the use of modern Standard C++.</p>
       </div>
 
       <div class="p-6 text-white bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
         <h5 class="text-2xl leading-tight text-orange">Across the Web</h5>
-        <p class="py-1 my-2 border-b border-gray-700 text-slate dark:text-white">Follow us, like, and share our announcements.</p>
+        <p class="py-1 my-2 border-b pb-4 border-gray-700 text-slate dark:text-white">Follow us, like, and share our announcements.</p>
         <div class="grid grid-cols-2 justify-items-center w-fit mx-auto">
           <a href="https://github.com/boostorg" class="block p-3 w-28 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"><span class="text-xs">On GitHub</span> <br /><i class="fa-brands fa-github fa-3x"></i></a>
           <a href="https://x.com/boost_libraries" class="block p-3 w-28 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"><span class="text-xs">On X (Twitter)</span> <br /><i class="fa-brands fa-x-twitter fa-3x"></i></a>

--- a/templates/docs_temp.html
+++ b/templates/docs_temp.html
@@ -27,7 +27,7 @@ make the columns go to 1
           <h5 class="text-2xl leading-tight text-orange">
             <a href="/doc/user-guide/index.html" class="link-header">User Guide</a>
           </h5>
-          <p class="text-lg py-1 border-b border-gray-700">How to use the libraries in your programs</p>
+          <p class="text-lg py-1 border-b pb-4 border-gray-700">How to use the libraries in your programs</p>
           <div class="grid grid-cols-2 gap-2 mt-6 text-lg">
 
             <div class="w-full col-span-2 md:col-span-1"><a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/user-guide/intro.html"><i class="mt-1 mr-2 fas fa-book inline-block w-6 text-center"></i>Intro to Boost</a></div>
@@ -74,7 +74,7 @@ make the columns go to 1
           <h5 class="text-2xl leading-tight text-orange">
             <a href="/doc/contributor-guide/index.html" class="link-header">Contributor Guide</a>
           </h5>
-          <p class="text-xl py-1 border-b border-gray-700">Resources to help you contribute</p>
+          <p class="text-xl py-1 border-b pb-4 border-gray-700">Resources to help you contribute</p>
           <div class="grid grid-cols-2 gap-2 mt-6 text-lg">
 
             <div class="w-full col-span-2 md:col-span-1"><a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/getting-involved.html"><i class="mt-1 mr-2 far fa-handshake inline-block w-6 text-center"></i>Getting Involved</a></div>
@@ -94,7 +94,7 @@ make the columns go to 1
          <h5 class="text-2xl leading-tight text-orange">
             <a href="/doc/formal-reviews/index.html" class="link-header">Boost Formal Reviews</a>
           </h5>
-          <p class="text-xl py-1 border-b border-gray-700">
+          <p class="text-xl py-1 pb-4 border-b border-gray-700">
             Learn how new libraries are added
           </p>
           <div class="grid grid-cols-1 gap-4 mt-6 text-lg pl-4">


### PR DESCRIPTION
border bottom lines were spaced too close to the text. Added a bit more space.
<img width="625" alt="Screenshot 2024-07-22 at 7 59 11 PM" src="https://github.com/user-attachments/assets/253a3c22-5066-4aea-ba76-65bd0c733b69">
<img width="630" alt="Screenshot 2024-07-22 at 7 59 32 PM" src="https://github.com/user-attachments/assets/3c4ced28-97fd-491c-8ead-faaf6a374fda">
