### PR TITLE
Limit Celery's Redis connections

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -254,6 +254,9 @@ CELERY_ACCEPT_CONTENT = ["application/json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = "UTC"
+CELERY_BROKER_TRANSPORT_OPTIONS = {
+    "max_connections": env.int("MAX_CELERY_CONNECTIIONS", default=60)
+}
 
 CACHES = {
     "default": {

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -75,3 +75,7 @@ This project uses environment variables to configure certain aspects of the appl
 ### `CI`
 
 - If set, will set SITE_ID to 1 in `settings.py`.
+
+### `MAX_CELERY_CONNECTIIONS`
+
+- If set, will set the maximum number of connections to the Celery in `settings.py`. Defaults to 60.


### PR DESCRIPTION
This change adds a `MAX_CELERY_CONNECTIIONS` environment variable, which defaults to `60`. 