### PR TITLE
Docs: reviewing local docker-compose steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A Django based website that will power a new Boost website. See the [documentati
 
 Links:
 
-- https://stage.boost.cppalliance.org/ - staging
-- https://www.preview.boost.org/ - production
+- https://www.stage.boost.cppalliance.org/ - staging
+- https://www.boost.io/ - production
 
 ---
 
@@ -51,6 +51,24 @@ $ docker compose run --rm web python manage.py migrate
 
 This will create the Docker image, install dependencies, start the services
 defined in `docker-compose.yml`, and start the webserver.
+
+styles.css is still missing in a local docker-compose environment. Steps to add it:
+
+```
+# One-time setup
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash
+. ~/.bashrc
+nvm install 20
+nvm use 20
+npm install -g yarn
+```
+
+```
+# Each time - rebuild styles.css
+yarn
+yarn build
+cp static/css/styles.css static_deploy/css/styles.css
+```
 
 Access the site at http://localhost:8000.
 

--- a/docs/development_setup_notes.md
+++ b/docs/development_setup_notes.md
@@ -24,7 +24,7 @@ After rebooting, open Powershell (wait a minute, it may continue installing WSL)
 wsl
 ```
 
-When running the Django website, everything should be done from a WSL session, not Powershell, DOS, or git-bash.  Do not `git clone` the files in a DOS window, for example. However, once it's up and running, files may be edited elsewhere. The file path in explorer will be `\\wsl.localhost\Ubuntu\opt\github\cppalliance\temp-site`
+When running the Django website, everything should be done from a WSL session, not Powershell, DOS, or git-bash.  Do not `git clone` the files in a DOS window, for example. However, once it's up and running, files may be edited elsewhere. The file path in explorer will be `\\wsl.localhost\Ubuntu\opt\github\boostorg\website-v2`
 
 Continue to the [Ubuntu 22.04 instructions](#ubuntu-2204) below. Return here before executing `docker compose`.
 
@@ -43,16 +43,15 @@ Continue (as root) to the instructions in the top-level README.md file.
 
 ## Ubuntu 22.04
 
-Check if python 3.11 is installed.
+Check if python3 is installed.
 ```
 python3 --version
 ```
 
-or install python 3.11:
+or
+
 ```
-sudo add-apt-repository ppa:deadsnakes/ppa
-sudo apt-get update
-sudo apt-get install -y python3.11
+apt-get install -y python3
 ```
 
 Install `makedeb` (as a standard user, not root).
@@ -91,10 +90,13 @@ sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plug
 As root, clone the repository and switch to that directory.
 ```
 sudo su -
-mkdir -p /opt/github/cppalliance
-cd /opt/github/cppalliance
-git clone https://github.com/cppalliance/temp-site
-cd temp-site
+```
+
+```
+mkdir -p /opt/github/boostorg
+cd /opt/github/boostorg
+git clone https://github.com/boostorg/website-v2
+cd website-v2
 cp env.template .env
 ```
 

--- a/env.template
+++ b/env.template
@@ -16,10 +16,15 @@ SECRET_KEY="top-secret"
 
 GITHUB_TOKEN="top-secret"
 
-AWS_ACCESS_KEY_ID="changeme"
-AWS_SECRET_ACCESS_KEY="changeme"
-BUCKET_NAME="boost.revsys.dev"
+# AWS_ACCESS_KEY_ID="changeme"
+# AWS_SECRET_ACCESS_KEY="changeme"
+# BUCKET_NAME="boost.revsys.dev"
 
+STATIC_CONTENT_AWS_ACCESS_KEY_ID="changeme"
+STATIC_CONTENT_AWS_SECRET_ACCESS_KEY="changeme"
+STATIC_CONTENT_BUCKET_NAME="stage.boost.org.v2"
+STATIC_CONTENT_REGION="us-east-2"
+STATIC_CONTENT_AWS_S3_ENDPOINT_URL="https://s3.us-east-2.amazonaws.com"
 
 # Mailman database settings
 DATABASE_URL="postgresql://postgres@db:5432/postgres"


### PR DESCRIPTION
Testing docker-compose. Here are things I noticed.  

- `styles.css` seemed to be missing in the local docker-compose environment, even though it's present in the docker image.  With docker-compose a volume is mounted.  The volume points to your git repository where styles.css is now git-ignored.   
  
Therefore, I am adding steps in the README to build `styles.css`.   @kennethreitz @rbbeeston , is this incorrect?  Should the instructions be different?  What method do you use?

- local development: there had been a note to install Python 3.11.   Even though Django containers are running with Python 3.11, it should be acceptable for the local OS to have the system default of Python 3.10.   They are not directly interacting.   Don't modify the system python.

- To view the Users Guide and Contributors Guide, adding variables to the env.template (and your .env file)  

```
STATIC_CONTENT_AWS_ACCESS_KEY_ID=
STATIC_CONTENT_AWS_SECRET_ACCESS_KEY=
STATIC_CONTENT_BUCKET_NAME=
STATIC_CONTENT_REGION=
STATIC_CONTENT_AWS_S3_ENDPOINT_URL=

```

If anyone uses docker-compose and notices the instructions are incomplete, please comment and/or contribute fixes to the docs.

