### PR TITLE
Add url path to handle /doc/libs/release/*

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -20,14 +20,14 @@ from core.views import (
     DocLibsTemplateView,
     ImageView,
     MarkdownTemplateView,
-    StaticContentTemplateView,
-    UserGuideTemplateView,
     RedirectToDocsView,
     RedirectToHTMLDocsView,
-    RedirectToToolsView,
     RedirectToHTMLToolsView,
-    RedirectToReleaseView,
     RedirectToLibraryView,
+    RedirectToReleaseView,
+    RedirectToToolsView,
+    StaticContentTemplateView,
+    UserGuideTemplateView,
 )
 from libraries.api import LibrarySearchView
 from libraries.views import (
@@ -61,11 +61,11 @@ from users.views import (
     CurrentUserAPIView,
     CurrentUserProfileView,
     CustomLoginView,
-    CustomSocialSignupViewView,
     CustomSignupView,
+    CustomSocialSignupViewView,
     ProfileView,
-    UserViewSet,
     UserAvatar,
+    UserViewSet,
 )
 from versions.api import ImportVersionsView, VersionViewSet
 from versions.feeds import AtomVersionFeed, RSSVersionFeed
@@ -311,6 +311,11 @@ urlpatterns = (
     + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     + [
         # Libraries docs, some HTML parts are re-written
+        re_path(
+            r"^doc/libs/release/(?P<content_path>.+)/?",
+            RedirectToReleaseView.as_view(),
+            name="docs-libs-release-page",
+        ),
         re_path(
             r"^doc/libs/(?P<content_path>.+)/?",
             DocLibsTemplateView.as_view(),

--- a/config/urls.py
+++ b/config/urls.py
@@ -17,6 +17,7 @@ from core.views import (
     BSLView,
     CalendarView,
     ClearCacheView,
+    ContentToReleaseView,
     DocLibsTemplateView,
     ImageView,
     MarkdownTemplateView,
@@ -313,7 +314,7 @@ urlpatterns = (
         # Libraries docs, some HTML parts are re-written
         re_path(
             r"^doc/libs/release/(?P<content_path>.+)/?",
-            RedirectToReleaseView.as_view(),
+            ContentToReleaseView.as_view(),
             name="docs-libs-release-page",
         ),
         re_path(

--- a/core/githubhelper.py
+++ b/core/githubhelper.py
@@ -3,15 +3,15 @@ import os
 import re
 from collections import defaultdict
 from datetime import datetime
-from dateutil.parser import parse
+
 import requests
 import structlog
+from dateutil.parser import parse
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from fastcore.net import HTTP404NotFoundError, HTTP422UnprocessableEntityError
 from fastcore.xtras import obj2dict
 from ghapi.all import GhApi, paged
-
 
 logger = structlog.get_logger()
 

--- a/core/views.py
+++ b/core/views.py
@@ -1,8 +1,8 @@
 import os
 import re
+
 import structlog
 from dateutil.parser import parse
-
 from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.cache import caches
@@ -17,13 +17,15 @@ from django.template.loader import render_to_string
 from django.views import View
 from django.views.generic import TemplateView
 
+from versions.models import Version
+
 from .asciidoc import process_adoc_to_html_content
 from .boostrenderer import (
-    get_content_from_s3,
-    get_s3_client,
-    extract_file_data,
     convert_img_paths,
+    extract_file_data,
+    get_content_from_s3,
     get_meta_redirect_from_html,
+    get_s3_client,
 )
 from .htmlhelper import modernize_legacy_page
 from .markdown import process_md
@@ -34,9 +36,6 @@ from .tasks import (
     refresh_content_from_s3,
     save_rendered_content,
 )
-
-from versions.models import Version
-
 
 logger = structlog.get_logger()
 
@@ -546,5 +545,28 @@ class RedirectToLibraryView(BaseRedirectView):
         # Get the requested version from the path of the URL.
         requested_version = requested_version.replace("_", "-")
 
+        # Handle the special case for "release" versions to redirect to the
+        # most recent Boost release
+        if requested_version == "release":
+            requested_version = Version.objects.most_recent().slug
+
         new_path = f"/libraries/?version=boost-{ requested_version }"
         return HttpResponseRedirect(new_path)
+
+
+class RedirectToReleaseView(BaseRedirectView):
+    """View to redirect to the latest release page."""
+
+    def get(self, request, *args, **kwargs):
+        # Grab the rest of the content path
+        content_path = self.kwargs.get("content_path")
+
+        # Determine the latest release
+        latest_release = Version.objects.most_recent()
+        latest_release_slug = latest_release.stripped_boost_url_slug
+
+        # Piece it all together to redirect the user to the latest release's
+        # docs
+        url = f"/doc/libs/{latest_release_slug}/{content_path}"
+
+        return HttpResponseRedirect(url)

--- a/core/views.py
+++ b/core/views.py
@@ -554,7 +554,7 @@ class RedirectToLibraryView(BaseRedirectView):
         return HttpResponseRedirect(new_path)
 
 
-class RedirectToReleaseView(BaseRedirectView):
+class ContentToReleaseView(BaseRedirectView):
     """View to redirect to the latest release page."""
 
     def get(self, request, *args, **kwargs):

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -1,24 +1,23 @@
 import datetime
-import structlog
 
+import structlog
 from dateutil.relativedelta import relativedelta
-from django.http import Http404
 from django.contrib import messages
 from django.db.models import Count
+from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import DetailView, ListView
 from django.views.generic.edit import FormMixin
 
-from versions.models import Version
-from .forms import VersionSelectionForm
-
 from core.githubhelper import GithubAPIClient
-from .utils import redirect_to_view_with_params
+from versions.models import Version
+
+from .forms import VersionSelectionForm
 from .mixins import VersionAlertMixin
 from .models import Category, CommitData, Library, LibraryVersion
-from django.utils.decorators import method_decorator
-from django.views.decorators.csrf import csrf_exempt
-
+from .utils import redirect_to_view_with_params
 
 SELECTED_BOOST_VERSION_COOKIE_NAME = "boost_version"
 SELECTED_LIBRARY_VIEW_COOKIE_NAME = "library_view"
@@ -47,6 +46,9 @@ class LibraryList(VersionAlertMixin, ListView):
         version_slug = self.request.COOKIES.get(
             SELECTED_BOOST_VERSION_COOKIE_NAME, None
         )
+
+        if version_slug is None:
+            version_slug = self.request.GET.get("version", None)
 
         if version_slug in [v.slug for v in valid_versions]:
             return version_slug


### PR DESCRIPTION
Redirect to the latest release when this URL prefix exists on documentation.

Fixes #1084