### PR TITLE
footer links and flashing header box

### DIFF
--- a/templates/adoc_content.html
+++ b/templates/adoc_content.html
@@ -2,10 +2,11 @@
 {% load i18n %}
 {% load static %}
 
-{% block title %}{% trans "help" %}{% endblock %}
+{% block title %}Blah{% endblock %}
 
 {% block content %}
-    <div id="ascii-doc-content">{{ content|safe }}</div>
+    <!--<div id="ascii-doc-content">{{ content|safe }}</div>-->
+    blah
 {% endblock %}
 
 {% block styles %}{% endblock %}

--- a/templates/includes/_footer.html
+++ b/templates/includes/_footer.html
@@ -3,13 +3,13 @@
 <footer class="py-2 px-4 my-5 mx-auto max-w-full md:pb-11 md:mb-11">
   <div class="items-center px-5 pt-4 mt-4 text-center">
     <div class="justify-between pt-3 pb-3 sm:space-x-3 xl:space-x-6 border-dotted border-t-2 px-20 border-t-white/5 w-fit mx-auto">
-      <a class="block my-2 sm:inline hover:text-orange" href="/help/">Contact</a>
+      <a class="block my-2 sm:inline hover:text-orange" href="https://lists.boost.org/mailman/listinfo.cgi/boost-users">Contact</a>
       <a class="block my-2 sm:inline hover:text-orange" href="{% url 'privacy' %}">Privacy Policy</a>
       <a class="block my-2 sm:inline hover:text-orange" href="{% url 'terms-of-use' %}">Terms of Use</a>
       <a class="block my-2 sm:inline hover:text-orange" href="/doc/user-guide/reporting-issues.html">Report Bug</a>
-      <a class="my-2 inline hover:text-orange" href="https://twitter.com/boost_libraries" target="_blank">Twitter</a>
+      <a class="my-2 inline hover:text-orange" title="X Social Media" href="https://x.com/boost_libraries" target="_blank"><i class="fa-brands fa-x-twitter"></i></a>
 	  <span class="inline sm:hidden text-white/30">&nbsp;&nbsp; | &nbsp;&nbsp;</span>
-      <a class="my-2 inline hover:text-orange" href="https://github.com/boostorg" target="_blank">GitHub</a>
+      <a class="my-2 inline hover:text-orange" title="Github" href="https://github.com/boostorg" target="_blank"><i class="fa-brands fa-github"></i></a>
     </div>
     <div><span class="text-sm">Website supported by grants from <a href="https://cppalliance.org/" target="_blank" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">The C++ Alliance</a>. Proposed for <a href="https://boost.org/" target="_blank" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">boost.org</a>.</span></div>
     <div><span class="text-xs italic">Distributed under the <a href="/LICENSE_1_0.txt" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">Boost Software License, Version 1.0</a>.</span></div>

--- a/templates/includes/_header.html
+++ b/templates/includes/_header.html
@@ -305,7 +305,7 @@ html.dark {
         </span>
         <span x-data="{ 'guideOpen': false }" style="position:relative;">
             <i class="icon-link fas fa-question-circle" @click="guideOpen = !guideOpen"></i>
-                <div x-show="guideOpen" x-cloak @click.away="guideOpen = false" id="guideMenu" class="guide-modal">
+                <div x-show="guideOpen" x-cloak @click.away="guideOpen = false" id="guideMenu" class="guide-modal hidden">
                     <a href="/doc/user-guide/index.html">User Guide</a>
                     <a href="/doc/contributor-guide/index.html">Contributor Guide</a>
                     <a href="/doc/formal-reviews/index.html">Formal Reviews</a>
@@ -491,6 +491,8 @@ html.dark {
       document.onreadystatechange = () => {
         if (document.readyState === 'complete') {
           removejscssfile("boostbook.css", "css")
+          var guide = document.getElementById("guideMenu")
+          guide.classList.remove("hidden");
         }
       }
     </script>


### PR DESCRIPTION
changes contact links for #1221 
changes twitter and github links to icons

also fixes a flashing of the help links in the header on refresh.