### PR TITLE
added support for 'release' in urls (#1084)

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -17,7 +17,6 @@ from core.views import (
     BSLView,
     CalendarView,
     ClearCacheView,
-    ContentToReleaseView,
     DocLibsTemplateView,
     ImageView,
     MarkdownTemplateView,
@@ -313,11 +312,6 @@ urlpatterns = (
     + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     + [
         # Libraries docs, some HTML parts are re-written
-        re_path(
-            r"^doc/libs/release/(?P<content_path>.+)/?",
-            ContentToReleaseView.as_view(),
-            name="docs-libs-release-page",
-        ),
         re_path(
             r"^doc/libs/(?P<content_path>.+)/?",
             DocLibsTemplateView.as_view(),

--- a/libraries/constants.py
+++ b/libraries/constants.py
@@ -312,3 +312,5 @@ VERSION_DOCS_MISSING = ["boost-1.33.0"]
 DEFAULT_LIBRARIES_LANDING_VIEW = "libraries-grid"
 SELECTED_BOOST_VERSION_COOKIE_NAME = "boost_version"
 SELECTED_LIBRARY_VIEW_COOKIE_NAME = "library_view"
+# change this to switch from /libraries/align/release/ to /libraries/align/latest/
+LATEST_RELEASE_URL_PATH_STR = "release"

--- a/templates/libraries/_library_category_list_item.html
+++ b/templates/libraries/_library_category_list_item.html
@@ -1,8 +1,14 @@
 <tr class="border-0 md:border border-gray-200/10 border-dotted md:border-t-0 md:border-r-0 md:border-l-0 md:border-b-1  hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-200 ease-in-out cursor-pointer"
-onclick="window.location='{% if version %}{% url 'library-detail-by-version' slug=library.slug version_slug=version.slug %}{% else %}{% url 'library-detail' slug=library.slug %}{% endif %}'">
+onclick="window.location='{% if version_str != LATEST_RELEASE_URL_PATH_STR %}{% url 'library-detail-by-version' slug=library.slug version_slug=version.slug %}{% else %}{% url 'library-detail' slug=library.slug %}{% endif %}'">
   <td class="py-2 align-top md:w-1/5">
     <a class="mr-1 font-bold capitalize text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"
-       href="{% url 'library-detail' slug=library.slug %}">{{ library.name }}</a>
+       href="
+        {% if version_str != LATEST_RELEASE_URL_PATH_STR %}
+          {% url 'library-detail-by-version' slug=library.slug version_slug=version.slug %}
+        {% else %}
+          {% url 'library-detail' slug=library.slug %}
+        {% endif %}"
+    >{{ library.name }}</a>
   </td>
 
   <td class="py-2 align-top w-12">

--- a/templates/libraries/_library_flat_list_item.html
+++ b/templates/libraries/_library_flat_list_item.html
@@ -2,7 +2,13 @@
 onclick="window.location='{% if version %}{% url 'library-detail-by-version' slug=library.slug version_slug=version.slug %}{% else %}{% url 'library-detail' slug=library.slug %}{% endif %}'">
   <td class="py-2 align-top md:w-1/5">
     <a class="mr-1 pl-1 font-bold capitalize text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"
-       href="{% url 'library-detail' slug=library.slug %}">{{ library.name }}</a>
+       href="
+        {% if version_str != LATEST_RELEASE_URL_PATH_STR %}
+          {% url 'library-detail-by-version' slug=library.slug version_slug=version.slug %}
+        {% else %}
+          {% url 'library-detail' slug=library.slug %}
+        {% endif %}"
+    >{{ library.name }}</a>
   </td>
 
   <td class="py-2 px-2 align-top w-12">

--- a/templates/libraries/_library_list_item.html
+++ b/templates/libraries/_library_list_item.html
@@ -2,11 +2,11 @@
 {% load date_filters %}
 
 <div class="relative content-between p-3 bg-white md:rounded-lg md:shadow-lg md:p-5 dark:bg-charcoal hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-200 ease-in-out cursor-pointer"
-onclick="window.location='{% if version %}{% url 'library-detail-by-version' slug=library.slug version_slug=version.slug %}{% else %}{% url 'library-detail' slug=library.slug %}{% endif %}'">
+onclick="window.location='{% if version_str != LATEST_RELEASE_URL_PATH_STR %}{% url 'library-detail-by-version' slug=library.slug version_slug=version.slug %}{% else %}{% url 'library-detail' slug=library.slug %}{% endif %}'">
   <div class="">
     <h3 class="pb-2 text-xl md:text-2xl capitalize border-b border-gray-700">
       <a class="link-header" href="
-        {% if version %}
+        {% if version_str != LATEST_RELEASE_URL_PATH_STR %}
           {% url 'library-detail-by-version' slug=library.slug version_slug=version.slug %}
         {% else %}
           {% url 'library-detail' slug=library.slug %}
@@ -34,7 +34,7 @@ onclick="window.location='{% if version %}{% url 'library-detail-by-version' slu
 {#<div class="w-1/6 tracking-wider text-charcoal dark:text-white/60">{% if library.first_boost_version %}{{ library.first_boost_version.release_date|years_since }} yrs{% endif %}</div>#}
     <div class="w-5/6 text-right font-bold capitalize  text-sky-600 dark:text-sky-300">
       {% for c in library.categories.all %}
-        <a href="{% url 'libraries' %}?category={{ c.slug }}{% if version %}&version={{ version.slug }}{% endif %}" class="hover:text-orange">{{ c.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
+        <a href="{% url 'libraries' %}?category={{ c.slug }}{% if version_str != LATEST_RELEASE_URL_PATH_STR %}&version={{ version.slug }}{% endif %}" class="hover:text-orange">{{ c.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
     </div>
   </div>
 </div>

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -26,10 +26,9 @@
                     name="version"
                     class="dropdown"
                     id="id_version">
-              <option value="latest" {% if version == "latest" %}selected="selected"{% endif %}>Latest</option>
+              <option value="latest" {% if version_str == LATEST_RELEASE_URL_PATH_NAME %}selected="selected"{% endif %}>Latest</option>
               {% for v in versions %}
-                <option value="{{ v.pk }}"
-                        {% if version == v %}selected="selected"{% endif %}>{{ v.display_name }}</option>
+                <option value="{{ v.pk }}" {% if version_str == v.slug %}selected="selected"{% endif %}>{{ v.display_name }}</option>
               {% endfor %}
             </select>
           </div>
@@ -64,7 +63,7 @@
               <span class="font-bold">Categories:</span>
               {% for category in object.categories.all %}
                 <a class="inline text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"
-                href="{% url 'libraries' %}?category={{ category.slug }}{% if version %}&version={{ version.slug }}{% endif %}">{{ category.name }}</a>
+                href="{% url 'libraries' %}?category={{ category.slug }}{% if version_str != LATEST_RELEASE_URL_PATH_NAME %}&version={{ version.slug }}{% endif %}">{{ category.name }}</a>
                 {% if not forloop.last %}, {% endif %}
               {% endfor %}
             </div>

--- a/templates/libraries/includes/library_preferences.html
+++ b/templates/libraries/includes/library_preferences.html
@@ -47,9 +47,9 @@
                 name="version"
                 class="dropdown py-2 md:block h-[38px] ml-3 md:ml-0"
                 id="id_version">
-          <option value="latest" {% if version == "latest" %}selected="selected"{% endif %}>Latest</option>
+          <option value="latest" {% if version_str == LATEST_RELEASE_URL_PATH_NAME %}selected="selected"{% endif %}>Latest</option>
           {% for v in versions %}
-          <option value="{{ v.slug }}" {% if version == v %}selected="selected"{% endif %}>{{ v.display_name }}</option>
+          <option value="{{ v.slug }}" {% if version_str == v.slug %}selected="selected"{% endif %}>{{ v.display_name }}</option>
           {% endfor %}
         </select>
       </div>


### PR DESCRIPTION
1. added support for 'release' in library urls
2. fixed versioning not working from the non-grid library list pages
3. fixed library detail user selection of versioning not working
4. unified cookie handling to share across both LibraryList and LibraryDetail
