### PR TITLE
Refactor dark mode link styles and nav elements

### DIFF
--- a/frontend/userguidestyles.css
+++ b/frontend/userguidestyles.css
@@ -14,14 +14,6 @@ body {
   @apply font-sans h-screen dark:bg-black dark:!text-white;
 }
 
-p a:link, p a:visited, table a, .title a {
-  @apply dark:text-sky-300;
-}
-
-p a:hover {
-  @apply dark:text-orange;
-}
-
 .nav-panel-explore,
 .navbar-item.search {
   @apply hidden;
@@ -95,7 +87,7 @@ footer, .components, .footer a {
 }
 
 .doc .admonitionblock .icon i {
-  @apply font-sans dark:text-white;
+  @apply dark:text-white;
 }
 
 .article .doc .tabs .tab:not(.is-selected) {


### PR DESCRIPTION
- removed dark text colors for links in paragraphs, tables, and titles
- removed dark hover color for paragraph links
- removed `font-sans` from `.doc .admonitionblock .icon i`

Needed for boostorg/boostlook#13