### PR TITLE
Purge Fastly CDN after import_versions.

### DIFF
--- a/versions/management/commands/import_versions.py
+++ b/versions/management/commands/import_versions.py
@@ -28,6 +28,9 @@ def command(
     """
     click.secho("Importing versions...", fg="green")
     import_versions.delay(
-        delete_versions=delete_versions, new_versions_only=new, token=token
+        delete_versions=delete_versions,
+        new_versions_only=new,
+        token=token,
+        purge_after=True,
     )
     click.secho("Finished importing versions.", fg="green")

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -417,7 +417,7 @@ def get_release_date_for_version(version_pk, commit_sha, token=None):
 
 @app.task
 def purge_fastly_release_cache():
-    if not settings.FASTLY_API_TOKEN:
+    if not settings.FASTLY_API_TOKEN or settings.FASTLY_API_TOKEN == 'empty':
         logger.warning("FASTLY_API_TOKEN not found. Not purging cache.")
 
     headers = {

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -417,7 +417,7 @@ def get_release_date_for_version(version_pk, commit_sha, token=None):
 
 @app.task
 def purge_fastly_release_cache():
-    if not settings.FASTLY_API_TOKEN or settings.FASTLY_API_TOKEN == 'empty':
+    if not settings.FASTLY_API_TOKEN or settings.FASTLY_API_TOKEN == "empty":
         logger.warning("FASTLY_API_TOKEN not found. Not purging cache.")
 
     headers = {

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -419,6 +419,7 @@ def get_release_date_for_version(version_pk, commit_sha, token=None):
 def purge_fastly_release_cache():
     if not settings.FASTLY_API_TOKEN or settings.FASTLY_API_TOKEN == "empty":
         logger.warning("FASTLY_API_TOKEN not found. Not purging cache.")
+        return
 
     headers = {
         "Fastly-Key": settings.FASTLY_API_TOKEN,


### PR DESCRIPTION
- fixes https://github.com/boostorg/website-v2/issues/1277

- Makes the required POST requests to Fastly to purge the cache for /release/ as described in the issue above.
- Chain the purge function to the import_version task group so that it runs only after all of the `import_version` tasks have completed