### PR TITLE
fixed issues with releases page and versioning

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -69,7 +69,7 @@ from users.views import (
 )
 from versions.api import ImportVersionsView, VersionViewSet
 from versions.feeds import AtomVersionFeed, RSSVersionFeed
-from versions.views import VersionCurrentReleaseDetail, VersionDetail
+from versions.views import VersionDetail
 
 router = routers.SimpleRouter()
 
@@ -131,12 +131,8 @@ urlpatterns = (
         # Boost community calendar
         path("calendar/", CalendarView.as_view(), name="calendar"),
         # Boost versions views
+        path("releases/", VersionDetail.as_view(), name="releases-most-recent"),
         path("releases/<slug:slug>/", VersionDetail.as_view(), name="release-detail"),
-        path(
-            "releases/",
-            VersionCurrentReleaseDetail.as_view(),
-            name="releases-most-recent",
-        ),
         path(
             "donate/",
             TemplateView.as_view(template_name="donate/donate.html"),

--- a/core/views.py
+++ b/core/views.py
@@ -555,8 +555,7 @@ class RedirectToLibraryView(BaseRedirectView):
 
         # Handle the special case for "release" versions to redirect to the
         # most recent Boost release
-        if requested_version == "release":
-            requested_version = Version.objects.most_recent().slug
-
         new_path = f"/libraries/?version=boost-{ requested_version }"
+        if requested_version == "release":
+            new_path = "/libraries/"
         return HttpResponseRedirect(new_path)

--- a/libraries/mixins.py
+++ b/libraries/mixins.py
@@ -1,7 +1,10 @@
+from urllib.parse import urlencode
+
 import structlog
+from django.urls import reverse
 
+from libraries.constants import LATEST_RELEASE_URL_PATH_STR
 from versions.models import Version
-
 
 logger = structlog.get_logger()
 
@@ -11,25 +14,49 @@ class VersionAlertMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-
-        latest_version = Version.objects.most_recent()
-        version_slug = self.request.GET.get(
-            "version", latest_version.slug if latest_version else None
+        current_release = Version.objects.most_recent()
+        url_name = self.request.resolver_match.url_name
+        url_names_version_slug_override = {
+            "library-detail": "version_slug",
+            "library-detail-by-version": "version_slug",
+        }
+        version_slug_name = url_names_version_slug_override.get(url_name, "slug")
+        version_slug = self.kwargs.get(
+            version_slug_name,
+            self.request.GET.get("version", LATEST_RELEASE_URL_PATH_STR),
         )
+        req_version = version_slug or LATEST_RELEASE_URL_PATH_STR
 
-        selected_version = None
-        if version_slug:
-            try:
-                selected_version = Version.objects.get(slug=version_slug)
-            except Version.DoesNotExist:
-                selected_version = latest_version
+        try:
+            selected_version = Version.objects.get(slug=version_slug)
+        except Version.DoesNotExist:
+            selected_version = current_release
 
-        context["latest_version"] = latest_version
+        def generate_reverse(url_name):
+            if url_name in {
+                "libraries-mini",
+                "libraries-by-category",
+                "libraries-grid",
+            }:
+                url = reverse(url_name)
+                params = {"version": LATEST_RELEASE_URL_PATH_STR}
+                return f"{url}?{urlencode(params)}"
+            elif url_name == "library-detail-by-version":
+                library_slug = self.kwargs.get(
+                    "slug"
+                )  # only really accurately set on library detail page
+                return reverse("library-detail", args=[library_slug])
+            elif url_name == "release-detail":
+                return reverse(url_name, args=[LATEST_RELEASE_URL_PATH_STR])
+
+        # 'version_str' is representative of what the user has chosen, while 'version'
+        # is the actual version instance that will be used in the template. We use the
+        # value of LATEST_RELEASE_URL_PATH_STR as the default in order to normalize
+        # behavior
         context["version"] = selected_version
-
-        if selected_version and latest_version:
-            context["version_alert"] = selected_version != latest_version
-        else:
-            context["version_alert"] = False
-
+        context["version_str"] = req_version
+        context["LATEST_RELEASE_URL_PATH_STR"] = LATEST_RELEASE_URL_PATH_STR
+        context["current_release"] = current_release
+        context["version_alert"] = context["version_str"] != LATEST_RELEASE_URL_PATH_STR
+        context["version_alert_url"] = generate_reverse(url_name)
         return context

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -221,10 +221,7 @@ def test_library_detail_context_get_documentation_url_no_docs_link(
     response = tp.get(url)
     tp.response_200(response)
     assert "documentation_url" in response.context
-    assert (
-        response.context["documentation_url"]
-        == library_version.version.documentation_url
-    )
+    assert response.context["documentation_url"] == "/doc/libs/release"
 
 
 def test_library_detail_context_get_documentation_url_missing_docs_bool(
@@ -243,10 +240,7 @@ def test_library_detail_context_get_documentation_url_missing_docs_bool(
     response = tp.get(url)
     tp.response_200(response)
     assert "documentation_url" in response.context
-    assert (
-        response.context["documentation_url"]
-        == library_version.version.documentation_url
-    )
+    assert response.context["documentation_url"] == "/doc/libs/release"
 
 
 def test_library_detail_context_get_documentation_url_docs_present(

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 from types import SimpleNamespace
 
 import structlog
@@ -36,6 +35,7 @@ from .utils import (
     determine_view_from_library_request,
     determine_selected_boost_version,
     set_selected_boost_version,
+    get_documentation_url,
 )
 from .constants import LATEST_RELEASE_URL_PATH_STR
 
@@ -69,7 +69,10 @@ class LibraryList(VersionAlertMixin, ListView):
             params["version"] = selected_boost_version
 
         # default to the most recent version
-        if "version" not in params or params["version"] == "latest":
+        if (
+            params.get("version", LATEST_RELEASE_URL_PATH_STR)
+            == LATEST_RELEASE_URL_PATH_STR
+        ):
             # If no version is specified, show the most recent version.
             version = Version.objects.most_recent()
             if version:
@@ -83,18 +86,17 @@ class LibraryList(VersionAlertMixin, ListView):
                 )
                 return Library.objects.none()
 
-        queryset = queryset.filter(library_version__version__slug=params["version"])
+        if params.get("version"):
+            queryset = queryset.filter(library_version__version__slug=params["version"])
 
         # avoid attempting to look up libraries with blank categories
-        if "category" in params and params["category"] != "":
+        if params.get("category"):
             queryset = queryset.filter(categories__slug=params["category"])
 
         return queryset
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        req_version = self.request.GET.get("version", "latest")
-
         # Handle the case where data hasn't been imported yet
         version = Version.objects.most_recent()
         if not version:
@@ -109,25 +111,15 @@ class LibraryList(VersionAlertMixin, ListView):
             )
             return context
 
-        if "category" in self.request.GET and self.request.GET["category"] != "":
+        if self.request.GET.get("category"):
             context["category"] = Category.objects.get(
                 slug=self.request.GET["category"]
             )
-        context["LATEST_RELEASE_URL_PATH_STR"] = LATEST_RELEASE_URL_PATH_STR
-        # 'version_str' is representative of what the user has chosen, while 'version'
-        # is the actual version instance that will be used in the template
-        # here we use 'latest' as the default in order to normalize behavior
-        if req_version == "latest":
-            context["version"] = Version.objects.most_recent()
-            context["version_str"] = LATEST_RELEASE_URL_PATH_STR
-        else:
-            context["version"] = Version.objects.get(slug=self.request.GET["version"])
-            context["version_str"] = req_version
-
         context["categories"] = self.get_categories(context["version"])
         context["versions"] = self.get_versions()
         context["library_list"] = self.get_queryset()
         context["url_params"] = build_view_query_params_from_request(self.request)
+
         return context
 
     def get_categories(self, version=None):
@@ -165,7 +157,9 @@ class LibraryList(VersionAlertMixin, ListView):
         """Set the selected version in the cookies."""
         response = super().dispatch(request, *args, **kwargs)
         query_params = build_view_query_params_from_request(request)
-        set_selected_boost_version(query_params.get("version", "latest"), response)
+        set_selected_boost_version(
+            query_params.get("version", LATEST_RELEASE_URL_PATH_STR), response
+        )
         # The following conditional practically only applies on "/libraries/", at
         # which point the redirection will be determined by prioritised view
         view = determine_view_from_library_request(request)
@@ -210,7 +204,7 @@ class LibraryListByCategory(LibraryList):
 
 
 @method_decorator(csrf_exempt, name="dispatch")
-class LibraryDetail(FormMixin, DetailView):
+class LibraryDetail(FormMixin, VersionAlertMixin, DetailView):
     """Display a single Library in insolation"""
 
     form_class = VersionSelectionForm
@@ -221,11 +215,7 @@ class LibraryDetail(FormMixin, DetailView):
     def get_context_data(self, **kwargs):
         """Set the form action to the main libraries page"""
         context = super().get_context_data(**kwargs)
-
         # Get fields related to Boost versions
-        context["version"] = self.get_version()
-        latest_version = Version.objects.most_recent()
-        context["latest_version"] = latest_version
         context["versions"] = (
             Version.objects.active()
             .filter(library_version__library=self.object)
@@ -241,27 +231,13 @@ class LibraryDetail(FormMixin, DetailView):
         # Manually exclude beta releases from the version dropdown.
         context["versions"] = context["versions"].exclude(beta=True)
         context["LATEST_RELEASE_URL_PATH_NAME"] = LATEST_RELEASE_URL_PATH_STR
-        documentation_url = self.get_documentation_url(context["version"])
-        # Show an alert if the user is on an older version
-        context["version_alert"] = (
-            True if context["version"] != latest_version else False
-        )
-        # here we use 'latest' as the default just to normalise behavior
-        req_version = self.kwargs.get("version_slug", "latest")
-        if req_version != "latest":
-            context["latest_library_version"] = self.get_current_library_version(
-                context["version"]
-            )
-            context["version_str"] = context["version"].slug
-            context["documentation_url"] = documentation_url
-        else:
-            context["version_str"] = LATEST_RELEASE_URL_PATH_STR
-            p = re.compile(r"(/doc/libs/)[a-zA-Z0-9_]+(/[/\S]+)$")
-            if p.match(documentation_url):
-                documentation_url = p.sub(r"\1release\2", documentation_url)
-            context["documentation_url"] = documentation_url
-
         # Get general data and version-sensitive data
+        library_version = LibraryVersion.objects.get(
+            library=self.get_object(), version=context["version"]
+        )
+        context["documentation_url"] = get_documentation_url(
+            library_version, context["version_str"] == LATEST_RELEASE_URL_PATH_STR
+        )
         context["github_url"] = self.get_github_url(context["version"])
         context["maintainers"] = self.get_maintainers(context["version"])
         context["author_tag"] = self.get_author_tag()
@@ -360,31 +336,6 @@ class LibraryDetail(FormMixin, DetailView):
             library=self.object, version=version
         ).first()
 
-    def get_documentation_url(self, version):
-        """Get the documentation URL for the current library."""
-
-        def find_documentation_url(version):
-            obj = self.get_object()
-            library_version = LibraryVersion.objects.get(library=obj, version=version)
-            docs_url = version.documentation_url
-
-            # If we know the library-version docs are missing, return the version docs
-            if library_version.missing_docs:
-                return docs_url
-            # If we have the library-version docs and they are valid, return those
-            elif library_version.documentation_url:
-                return library_version.documentation_url
-            # If we wind up here, return the version docs
-            else:
-                return docs_url
-
-        # Get the URL for the version.
-        url = find_documentation_url(version)
-        # Remove the "boost_" prefix from the URL.
-        url = url.replace("boost_", "")
-
-        return url
-
     def get_github_url(self, version):
         """Get the GitHub URL for the current library."""
         try:
@@ -472,9 +423,19 @@ class LibraryDetail(FormMixin, DetailView):
     def dispatch(self, request, *args, **kwargs):
         """Redirect to the documentation page, if configured to."""
         if self.redirect_to_docs:
-            return redirect(self.get_documentation_url(self.get_version()))
+            return redirect(
+                get_documentation_url(
+                    LibraryVersion.objects.get(
+                        library__slug=self.kwargs.get("slug"),
+                        version=self.get_version(),
+                    ),
+                    latest=True,
+                )
+            )
         response = super().dispatch(request, *args, **kwargs)
-        set_selected_boost_version(kwargs.get("version_slug", "latest"), response)
+        set_selected_boost_version(
+            kwargs.get("version_slug", LATEST_RELEASE_URL_PATH_STR), response
+        )
         return response
 
     def post(self, request, *args, **kwargs):

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -25,7 +25,7 @@
                     name="version"
                     class="dropdown pb-0"
                     id="id_version">
-              <option value="latest" {% if version_str == LATEST_RELEASE_URL_PATH_NAME %}selected="selected"{% endif %}>Latest</option>
+              <option value="{{ LATEST_RELEASE_URL_PATH_STR }}" {% if version_str == LATEST_RELEASE_URL_PATH_NAME %}selected="selected"{% endif %}>Latest</option>
               {% for v in versions %}
                 <option value="{{ v.pk }}" {% if version_str == v.slug %}selected="selected"{% endif %}>{{ v.display_name }}</option>
               {% endfor %}

--- a/templates/libraries/includes/library_preferences.html
+++ b/templates/libraries/includes/library_preferences.html
@@ -47,7 +47,7 @@
                 name="version"
                 class="dropdown py-2 md:block h-[38px] ml-3 md:ml-0"
                 id="id_version">
-          <option value="latest" {% if version_str == LATEST_RELEASE_URL_PATH_NAME %}selected="selected"{% endif %}>Latest</option>
+          <option value="{{ LATEST_RELEASE_URL_PATH_STR }}" {% if version_str == LATEST_RELEASE_URL_PATH_NAME %}selected="selected"{% endif %}>Latest</option>
           {% for v in versions %}
           <option value="{{ v.slug }}" {% if version_str == v.slug %}selected="selected"{% endif %}>{{ v.display_name }}</option>
           {% endfor %}

--- a/templates/libraries/includes/version_alert.html
+++ b/templates/libraries/includes/version_alert.html
@@ -1,21 +1,19 @@
 {% if version_alert %}
-    <div role="alert" class="py-2 px-3 mb-3 text-center rounded-sm bg-yellow-200/70">
-        <p class="p-0 m-0">
-            <i class="fas fa-exclamation-circle"></i>
-            {% if version.beta %}
-            This is a beta version of Boost.
-            {% elif version.full_release %}
-            This is an older version and was released in {{ version.release_date|date:"Y"}}.
-            {% else %}
-            This version of Boost is under active development.
-            {% endif %}
-           The current version is
-            {% if latest_library_version %}
-                <a href="{% url 'library-detail' slug=latest_library_version.library.slug %}" class="font-semibold underline dark:text-white text-charcoal">
-            {% else %}
-                <a href="{% url 'release-detail' latest_version.slug %}" class="font-semibold underline dark:text-white text-charcoal">
-            {% endif %}
-            {{ latest_version.display_name }}</a>
-        </p>
-    </div>
+  <div role="alert" class="py-2 px-3 mb-3 text-center rounded-sm bg-yellow-200/70">
+    <p class="p-0 m-0">
+      <i class="fas fa-exclamation-circle"></i>
+      {% if version == current_release %}
+        You've currently chosen the {{ current_release.display_name }} version. If a newer release comes out, you will continue to view the {{ current_release.display_name }} version, not the new <a href="{{ version_alert_url }}" class="font-semibold underline dark:text-white text-charcoal">latest release</a>.
+      {% else %}
+        {% if version.beta %}
+          This is a beta version of Boost.
+        {% elif version.full_release %}
+          This is an older version and was released in {{ version.release_date|date:"Y"}}.
+        {% else %}
+          This version of Boost is under active development.
+        {% endif %}
+      The <a href="{{ version_alert_url }}" class="font-semibold underline dark:text-white text-charcoal">current version</a> is {{ current_release.display_name }}.
+      {% endif %}
+    </p>
+  </div>
 {% endif %}

--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -26,9 +26,10 @@
                     name="version"
                     class="dropdown !mb-0 h-[38px]"
                     id="id_version">
+              <option value="{{ LATEST_RELEASE_URL_PATH_STR }}" {% if version_str == LATEST_RELEASE_URL_PATH_STR %}selected="selected"{% endif %}>Latest</option>
               {% for v in versions %}
                 <option value="{{ v.pk }}"
-                        {% if version == v %}selected="selected"{% endif %}>
+                        {% if version_str == v.slug %}selected="selected"{% endif %}>
                   {{ v.display_name }}
                 </option>
               {% endfor %}
@@ -37,6 +38,9 @@
         </form>
       </div>
     </div>
+    <!-- alert for non-current Boost versions -->
+    {% include "libraries/includes/version_alert.html" %}
+
     <section class="content">
       <div class="pb-2 w-full h-auto md:pb-0 md:w-auto">
         <div class="flex flex-col">
@@ -46,9 +50,9 @@
           <div class="-ml-2 h-3"></div>
           <div class="-ml-2 h-14">
             <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"
-               href="{{ version.documentation_url }}">
+               href="{{ documentation_url }}">
               <span class="dark:text-white text-slate">Documentation</span>
-              <span class="block text-xs">{{ request.scheme }}://{{ request.get_host }}{{ version.documentation_url|cut:"https://"|cut:"index.html" }}</span>
+              <span class="block text-xs">{{ request.scheme }}://{{ request.get_host }}{{ documentation_url }}</span>
             </a>
           </div>
           <div class="-ml-2 h-14">

--- a/versions/views.py
+++ b/versions/views.py
@@ -3,54 +3,37 @@ import structlog
 from django.db.models import Q, Count
 from django.views.generic import DetailView
 from django.views.generic.edit import FormMixin
-from django.shortcuts import redirect
+from django.shortcuts import redirect, get_object_or_404
 from django.contrib import messages
 from itertools import groupby
 from operator import attrgetter
 
 from core.models import RenderedContent
+from libraries.constants import LATEST_RELEASE_URL_PATH_STR
 from libraries.forms import VersionSelectionForm
+from libraries.mixins import VersionAlertMixin
 from libraries.models import Commit, CommitAuthor
+from libraries.utils import (
+    set_selected_boost_version,
+    determine_selected_boost_version,
+    library_doc_latest_transform,
+)
 from versions.models import Version
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 
-SELECTED_BOOST_VERSION_COOKIE_NAME = "boost_version"
 
 logger = structlog.get_logger(__name__)
 
 
 @method_decorator(csrf_exempt, name="dispatch")
-class VersionDetail(FormMixin, DetailView):
+class VersionDetail(FormMixin, VersionAlertMixin, DetailView):
     """Web display of list of Versions"""
 
     form_class = VersionSelectionForm
     model = Version
     queryset = Version.objects.active().defer("data")
     template_name = "versions/detail.html"
-
-    def get_selected_boost_version(self):
-        """Returns the selected Boost version"""
-        version_slug = self.request.COOKIES.get(
-            SELECTED_BOOST_VERSION_COOKIE_NAME, None
-        )
-        if version_slug:
-            try:
-                version = Version.objects.get(slug=version_slug)
-                return version
-            except Version.DoesNotExist:
-                logger.warning(f"Invalid version slug in cookies: {version_slug}")
-                return None
-        return None
-
-    def set_selected_boost_version(self, response, version_slug):
-        """Sets the selected Boost version"""
-        try:
-            Version.objects.get(slug=version_slug)
-            response.set_cookie(SELECTED_BOOST_VERSION_COOKIE_NAME, version_slug)
-        except Version.DoesNotExist:
-            logger.warning(f"Attempted to set invalid version slug: {version_slug}")
-            messages.error(self.request, "Invalid version selected.")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data()
@@ -68,23 +51,25 @@ class VersionDetail(FormMixin, DetailView):
             context["current_release"] = None
             context["is_current_release"] = False
             return context
-
         context["versions"] = Version.objects.version_dropdown_strict()
         downloads = obj.downloads.all().order_by("operating_system")
         context["downloads"] = {
             k: list(v)
             for k, v in groupby(downloads, key=attrgetter("operating_system"))
         }
-        current_release = Version.objects.most_recent()
-        context["current_release"] = current_release
         obj = self.get_object()
-        is_current_release = bool(current_release == obj)
-        context["is_current_release"] = is_current_release
-
-        context["heading"] = self.get_version_heading(obj, is_current_release)
+        context["heading"] = self.get_version_heading(
+            obj, context["current_release"] == obj
+        )
         context["release_notes"] = self.get_release_notes(obj)
         context["top_contributors_release"] = self.get_top_contributors_release(obj)
 
+        context["documentation_url"] = obj.documentation_url
+        if context["version_str"] == LATEST_RELEASE_URL_PATH_STR:
+            context["documentation_url"] = library_doc_latest_transform(
+                obj.documentation_url
+            )
+            context["version_alert"] = False
         return context
 
     def get_top_contributors_release(self, version: Version):
@@ -121,44 +106,51 @@ class VersionDetail(FormMixin, DetailView):
     def post(self, request, *args, **kwargs):
         """User has submitted a form and will be redirected to the right record."""
         form = self.get_form()
-        if form.is_valid():
+        version_slug = self.request.POST.get("version")
+        if version_slug == LATEST_RELEASE_URL_PATH_STR:
+            response = redirect("releases-most-recent")
+            set_selected_boost_version(LATEST_RELEASE_URL_PATH_STR, response)
+            return response
+        elif form.is_valid():
             version = form.cleaned_data["version"]
             response = redirect(
                 "release-detail",
                 slug=version.slug,
             )
-            self.set_selected_boost_version(response, version.slug)
+            set_selected_boost_version(version.slug, response)
             return response
         else:
             logger.info("version_detail_invalid_version")
         return super().get(request)
 
     def dispatch(self, request, *args, **kwargs):
-        """Set the version if it is not already set."""
+        response = super().dispatch(request, *args, **kwargs)
 
-        version_in_url = self.kwargs.get("slug", False)
-
-        if version_in_url:
-            response = super().dispatch(request, *args, **kwargs)
-            self.set_selected_boost_version(response, version_in_url)
+        # if 'release' clear the version values, e.g. from version_alert
+        if self.kwargs.get("slug") == LATEST_RELEASE_URL_PATH_STR:
+            response = redirect("releases-most-recent")
+            set_selected_boost_version(LATEST_RELEASE_URL_PATH_STR, response)
             return response
+
+        version = determine_selected_boost_version(
+            self.kwargs.get("slug"), self.request
+        )
+        if version != self.kwargs.get("slug"):
+            response = redirect(
+                "release-detail",
+                slug=version,
+            )
+
+        return response
+
+    def get_object(self, queryset=None):
+        """Return the object that the view is displaying"""
+        if self.request.POST:
+            version_slug = self.request.POST.get("version")
         else:
-            redirect_to_version = self.get_selected_boost_version()
-            if redirect_to_version:
-                return redirect(
-                    "release-detail", slug=redirect_to_version.slug, permanent=False
-                )
+            version_slug = self.kwargs.get("slug", LATEST_RELEASE_URL_PATH_STR)
 
-        return super().dispatch(request, *args, **kwargs)
+        if version_slug == LATEST_RELEASE_URL_PATH_STR:
+            return Version.objects.most_recent()
 
-
-class VersionCurrentReleaseDetail(VersionDetail):
-    """Web display of list of Versions"""
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data()
-        context["is_current_release"] = True
-        return context
-
-    def get_object(self):
-        return Version.objects.most_recent()
+        return get_object_or_404(Version, slug=version_slug)


### PR DESCRIPTION
* Fixed issues with releases page and versioning
* Added latest support and version alert
* Updated version alert to link to /release and clarify most recent vs vs "release" selection
* Refactored Libraries and Releases pages to align similar code for reuse.