### PR TITLE
Fixed back button library select persistance

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -127,12 +127,22 @@
         }
       }
 
+      const versionResetForm = (event) => {
+        if (event.persisted) {
+          const form = document.getElementById('id_version').closest('form');
+          if (form) {
+            form.reset();
+          }
+        }
+      }
+
       (async () => {
         await trackLoginUpdateCheck();
         await delay(messageVisibilitySeconds * 1000);
         await hideMessage();
       })();
-    </script>
+      window.addEventListener('pageshow', versionResetForm);
+   </script>
 
   </body>
 


### PR DESCRIPTION
This is related to ticket #1304, the first part of the fix with the library page grid not updated is fixed in the [pull request #1300 ](https://github.com/boostorg/website-v2/pull/1300) which has now been approved.

For ease of review, this should be reviewed after that is merged into `develop`, this is a branch from that. Leaving as draft until then.