### PR TITLE
Nginx: adjust Cache-Control header

### DIFF
--- a/kube/boost/templates/configmap-nginx.yaml
+++ b/kube/boost/templates/configmap-nginx.yaml
@@ -74,12 +74,14 @@ data:
 
       location /static {
         alias /code/static_deploy;
-        expires 7d;
+        # manage in CDN
+        # expires 7d;
       }
 
       location /media {
         alias /code/media;
-        expires 1d;
+        # manage in CDN
+        # expires 1d;
       }
 
       location = /more/getting_started/index.html { return 301 /doc/user-guide/getting-started.html; }


### PR DESCRIPTION
Just discovered the boost.io nginx config is setting "expires 7d" on static assets.   That is the value of 604800 seconds conflicting with the CDN.  Remove that expiration.