### PR TITLE
AsciiDoc use the embedded option

### DIFF
--- a/core/asciidoc.py
+++ b/core/asciidoc.py
@@ -1,54 +1,26 @@
-import os
 import subprocess
-import tempfile
-
-from .boostrenderer import get_body_from_html
 
 
-def convert_adoc_to_html(file_path, delete_file=True):
+def convert_adoc_to_html(input):
     """
     Converts an AsciiDoc file to HTML.
-    If delete_file is True, the temporary file will be deleted after the
-    conversion is complete.
 
-    Note: This returns the full <html> document, including the <head> and
-    <body> tags.
+    Note: This returns an html fragment, not the full <html> document with the
+    <head> and <body> tags.
 
     The asciidoctor package is a Ruby gem, which is why we're using subprocess
     to run the command.
     https://docs.asciidoctor.org/asciidoctor/latest/
 
-    :param file_path: The path to the AsciiDoc file
-    :param delete_file: Whether or not to delete the temporary file after the
-        conversion is complete
+    :param input: The contents of the AsciiDoc file
     """
     result = subprocess.run(
-        ["asciidoctor", "-o", "-", file_path],
+        ["asciidoctor", "-e", "-o", "-", "-"],
         check=True,
         capture_output=True,
+        text=True,
+        input=input,
     )
 
     # Get the output from the command
-    converted_html = result.stdout
-
-    # Delete the temporary file
-    if delete_file:
-        os.remove(file_path)
-
-    return converted_html
-
-
-def process_adoc_to_html_content(content):
-    """Renders asciidoc content to HTML."""
-    # Write the content to a temporary file
-    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-        if isinstance(content, str):
-            content = content.encode()
-        temp_file.write(content)
-
-    html_content = convert_adoc_to_html(temp_file.name, delete_file=True)
-    if isinstance(html_content, bytes):
-        html_content = html_content.decode("utf-8")
-
-    # Extract only the contents of the body tag that we want from the HTML
-    return get_body_from_html(html_content)
+    return result.stdout

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -5,16 +5,11 @@ from dateutil.parser import parse
 
 from django.core.cache import caches
 
-from .asciidoc import convert_adoc_to_html, process_adoc_to_html_content
+from core.asciidoc import convert_adoc_to_html
 from .boostrenderer import get_content_from_s3
 from .models import RenderedContent
 
 logger = structlog.get_logger()
-
-
-@shared_task
-def adoc_to_html(file_path, delete_file=True):
-    return convert_adoc_to_html(file_path, delete_file=delete_file)
 
 
 @shared_task
@@ -52,7 +47,7 @@ def refresh_content_from_s3(s3_key, cache_key):
     if content_dict and content:
         content_type = content_dict.get("content_type")
         if content_type == "text/asciidoc":
-            content = process_adoc_to_html_content(content)
+            content = convert_adoc_to_html(content)
         last_updated_at_raw = content_dict.get("last_updated_at")
         last_updated_at = parse(last_updated_at_raw) if last_updated_at_raw else None
         # Clear the cache because we're going to update it.

--- a/core/tests/test_asciidoc.py
+++ b/core/tests/test_asciidoc.py
@@ -1,49 +1,23 @@
-import pytest
-import tempfile
 from unittest.mock import patch
 
-from django.core.cache import caches
-from django.test import override_settings
-
-from core.asciidoc import convert_adoc_to_html, process_adoc_to_html_content
+from core.asciidoc import convert_adoc_to_html
 
 
-@override_settings(
-    CACHES={
-        "static_content": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "third-unique-snowflake",
-            "TIMEOUT": "60",  # Cache timeout in seconds: 1 minute
-        },
-    }
-)
-def test_adoc_to_html():
-    # Get the static content cache
-    caches["static_content"]
-
+def test_convert_adoc_to_html_subprocess():
     # The content of the sample adoc file
     sample_adoc_content = "= Document Title\n\nThis is a sample document.\n"
 
-    # Write the content to a temporary file
-    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-        temp_file.write(sample_adoc_content.encode())
-        temp_file_path = temp_file.name
-
     # Execute the task
     with patch("core.asciidoc.subprocess.run") as mock_run:
-        mock_run.return_value.stdout = "html_content".encode()
-        convert_adoc_to_html(temp_file_path, delete_file=True)
-
-    # Verify that the temporary file has been deleted
-    with pytest.raises(FileNotFoundError):
-        with open(temp_file_path, "r"):
-            pass
+        mock_run.return_value.stdout = "html_content"
+        result = convert_adoc_to_html(sample_adoc_content)
+    assert result == "html_content"
 
 
-def test_process_adoc_to_html_content():
+def test_convert_adoc_to_html_content():
     """Test the process_adoc_to_html_content function."""
     content = "sample"
-    expected_html = '<div id="header">\n</div><div id="content">\n<div class="paragraph">\n<p>sample</p>\n</div>\n</div>'  # noqa: E501
+    expected_html = '<div class="paragraph">\n<p>sample</p>\n</div>\n'  # noqa: E501
 
-    result = process_adoc_to_html_content(content)
+    result = convert_adoc_to_html(content)
     assert result == expected_html

--- a/core/tests/test_tasks.py
+++ b/core/tests/test_tasks.py
@@ -1,7 +1,3 @@
-import pytest
-import tempfile
-from unittest.mock import patch
-
 from model_bakery import baker
 
 from django.core.cache import caches
@@ -9,7 +5,6 @@ from django.test import override_settings
 
 from core.models import RenderedContent
 from core.tasks import (
-    adoc_to_html,
     clear_rendered_content_cache_by_cache_key,
     clear_rendered_content_cache_by_content_type,
 )
@@ -22,30 +17,6 @@ TEST_CACHES = {
         "TIMEOUT": "60",  # Cache timeout in seconds: 1 minute
     },
 }
-
-
-@override_settings(CACHES=TEST_CACHES)
-def test_adoc_to_html():
-    # Get the static content cache
-    caches["static_content"]
-
-    # The content of the sample adoc file
-    sample_adoc_content = "= Document Title\n\nThis is a sample document.\n"
-
-    # Write the content to a temporary file
-    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-        temp_file.write(sample_adoc_content.encode())
-        temp_file_path = temp_file.name
-
-    # Execute the task
-    with patch("core.asciidoc.subprocess.run") as mock_run:
-        mock_run.return_value.stdout = "html_content".encode()
-        adoc_to_html(temp_file_path, delete_file=True)
-
-    # Verify that the temporary file has been deleted
-    with pytest.raises(FileNotFoundError):
-        with open(temp_file_path, "r"):
-            pass
 
 
 @override_settings(CACHES=TEST_CACHES)

--- a/core/views.py
+++ b/core/views.py
@@ -20,7 +20,7 @@ from django.views.generic import TemplateView
 from libraries.constants import LATEST_RELEASE_URL_PATH_STR
 from versions.models import Version
 
-from .asciidoc import process_adoc_to_html_content
+from .asciidoc import convert_adoc_to_html
 from .boostrenderer import (
     convert_img_paths,
     extract_file_data,
@@ -353,7 +353,7 @@ class BaseStaticContentTemplateView(TemplateView):
 
     def convert_adoc_to_html(self, content):
         """Renders asciidoc content to HTML."""
-        return process_adoc_to_html_content(content)
+        return convert_adoc_to_html(content)
 
     def process_content(self, content):
         """No op, override in children if required."""

--- a/libraries/models.py
+++ b/libraries/models.py
@@ -7,10 +7,9 @@ from django.db import models, transaction
 from django.utils.functional import cached_property
 from django.utils.text import slugify
 
-from core.boostrenderer import get_body_from_html
 from core.markdown import process_md
 from core.models import RenderedContent
-from core.tasks import adoc_to_html
+from core.asciidoc import convert_adoc_to_html
 
 from .utils import generate_random_string, write_content_to_tempfile
 
@@ -244,11 +243,10 @@ class Library(models.Model):
             )
             if content:
                 # There is content, so process it
-                temp_file = write_content_to_tempfile(content)
                 if file_path.endswith(".adoc"):
-                    html_content = adoc_to_html(temp_file.name, delete_file=True)
-                    body_content = get_body_from_html(html_content)
+                    body_content = convert_adoc_to_html(content.decode("utf-8"))
                 else:
+                    temp_file = write_content_to_tempfile(content)
                     _, body_content = process_md(temp_file.name)
                 static_content_cache.set(cache_key, body_content)
                 RenderedContent.objects.update_or_create(


### PR DESCRIPTION
Instead of parsing out the HTML body from the full HTML document.

All adoc parsing now goes through `convert_adoc_to_html`. I removed the `adoc_to_html` task because it was never `.delay`ed, probably because it doesn't necessarily work: it expects content to be passed in a temp file, which might not exist on the worker processing the task. The new function passes the content as a string instead of a temp file.

This removes the `div#header` and `div#content` containers from the output. It's wrong to have IDs in embeddable html because multiple asciidoc outputs might be included on the same page, resulting in duplicate IDs. I couldn't find a place where these containers are necessary, though, because markdown output doesn't include them, resulting in a discrepancy in the output for markdown vs asciidoc that is now fixed. If we need to include the containers, I'd wrap the asciidoc output in the template where it is used rather than expecting it to be returned by `convert_adoc_to_html`.

Fixes #1302