### PR TITLE
Added wrappers for docs (#1322)

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class SourceDocType(Enum):
+    ASCIIDOC = "asciidoc"
+    ANTORA = "antora"

--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -111,7 +111,7 @@ def _replace_body(result, original_body, base_body):
         result.body.body.unwrap()
 
 
-def wrap_main_body_elements(result):
+def wrap_main_body_elements(result, original_docs_type=None):
     def is_end_comment(element):
         return (
             isinstance(element, Comment) and element == " END Manually appending items "
@@ -120,6 +120,9 @@ def wrap_main_body_elements(result):
     start_index = None
     elements_to_wrap = []
     wrapper_div = result.new_tag("div", id="boost-legacy-docs-wrapper")
+    if original_docs_type:
+        # add a class based on the original docs type
+        wrapper_div["class"] = f"source-docs-{original_docs_type.value}"
     for index, element in enumerate(result.find("body").children):
         if is_end_comment(element):
             start_index = index
@@ -134,7 +137,9 @@ def wrap_main_body_elements(result):
     result.append(wrapper_div)
 
 
-def modernize_legacy_page(content, base_html, head_selector="head", insert_body=True):
+def modernize_legacy_page(
+    content, base_html, head_selector="head", insert_body=True, original_docs_type=None
+):
     """Modernize a legacy Boost documentation page."""
 
     result = BeautifulSoup(content, "html.parser")
@@ -185,7 +190,7 @@ def modernize_legacy_page(content, base_html, head_selector="head", insert_body=
                 placeholder.find("div", {"id": "boost-legacy-docs-header"}),
                 append=False,
             )
-            wrap_main_body_elements(result)
+            wrap_main_body_elements(result, original_docs_type)
             rendered_template = render_to_string("includes/_footer.html", {})
             rendered_template_as_dom = BeautifulSoup(rendered_template, "html.parser")
             result.append(rendered_template_as_dom)

--- a/core/views.py
+++ b/core/views.py
@@ -28,6 +28,7 @@ from .boostrenderer import (
     get_meta_redirect_from_html,
     get_s3_client,
 )
+from .constants import SourceDocType
 from .htmlhelper import modernize_legacy_page
 from .markdown import process_md
 from .models import RenderedContent
@@ -319,7 +320,6 @@ class BaseStaticContentTemplateView(TemplateView):
             return result
 
     def get_template_names(self):
-        """Return the template name."""
         content_type = self.content_dict.get("content_type")
         if content_type == "text/asciidoc":
             return [self.template_name]
@@ -404,8 +404,8 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
     def process_content(self, content):
         """Replace page header with the local one."""
         content_type = self.content_dict.get("content_type")
+        original_docs_type = SourceDocType.ASCIIDOC
         # Is the request coming from an iframe? If so, let's disable the modernization.
-
         sec_fetch_destination = self.request.headers.get("Sec-Fetch-Dest", "")
         is_iframe_destination = sec_fetch_destination in ["iframe", "frame"]
 
@@ -432,7 +432,11 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
         )
         # potentially pass version if needed for HTML modification
         return modernize_legacy_page(
-            content, base_html, insert_body=insert_body, head_selector=head_selector
+            content,
+            base_html,
+            insert_body=insert_body,
+            head_selector=head_selector,
+            original_docs_type=original_docs_type,
         )
 
 
@@ -444,6 +448,7 @@ class UserGuideTemplateView(BaseStaticContentTemplateView):
     def process_content(self, content):
         """Replace page header with the local one."""
         content_type = self.content_dict.get("content_type")
+        original_docs_type = SourceDocType.ANTORA
         modernize = self.request.GET.get("modernize", "med").lower()
         if content_type != "text/html" or modernize not in ("max", "med", "min"):
             # eventually check for more things, for example ensure this HTML
@@ -462,7 +467,11 @@ class UserGuideTemplateView(BaseStaticContentTemplateView):
         )
         # potentially pass version if needed for HTML modification
         return modernize_legacy_page(
-            content, base_html, insert_body=insert_body, head_selector=head_selector
+            content,
+            base_html,
+            insert_body=insert_body,
+            head_selector=head_selector,
+            original_docs_type=original_docs_type,
         )
 
 


### PR DESCRIPTION
For now this will wrap based on the view with the assumption, based on our discussions, that User Guide  docs are based on antora and lib docs are asciidocs. Should there turn out to be edge cases we will make some adjustments.

Generated classes will be `source-docs-antora` and `source-docs-asciidoc`.