### PR TITLE
Add missing README message

### DIFF
--- a/libraries/constants.py
+++ b/libraries/constants.py
@@ -309,6 +309,9 @@ SKIP_LIBRARY_VERSIONS = {
 # List of versions for which we know docs are missing
 VERSION_DOCS_MISSING = ["boost-1.33.0"]
 
+# This constant is for library-versions missing a README
+README_MISSING = "⚠️ This library has no README.md or library-details.adoc; consider contributing one."
+
 DEFAULT_LIBRARIES_LANDING_VIEW = "libraries-grid"
 SELECTED_BOOST_VERSION_COOKIE_NAME = "boost_version"
 SELECTED_LIBRARY_VIEW_COOKIE_NAME = "library_view"

--- a/libraries/models.py
+++ b/libraries/models.py
@@ -12,7 +12,6 @@ from core.markdown import process_md
 from core.models import RenderedContent
 from core.tasks import adoc_to_html
 
-from .constants import README_MISSING
 from .utils import generate_random_string, write_content_to_tempfile
 
 
@@ -260,7 +259,7 @@ class Library(models.Model):
                 return body_content
 
         # If no content was found for any of the files
-        return README_MISSING
+        return None
 
     def get_cpp_standard_minimum_display(self):
         """Returns the display name for the C++ standard, or the value if not found.

--- a/libraries/models.py
+++ b/libraries/models.py
@@ -12,6 +12,7 @@ from core.markdown import process_md
 from core.models import RenderedContent
 from core.tasks import adoc_to_html
 
+from .constants import README_MISSING
 from .utils import generate_random_string, write_content_to_tempfile
 
 
@@ -259,7 +260,7 @@ class Library(models.Model):
                 return body_content
 
         # If no content was found for any of the files
-        return None
+        return README_MISSING
 
     def get_cpp_standard_minimum_display(self):
         """Returns the display name for the C++ standard, or the value if not found.

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -4,6 +4,7 @@ import pytest
 
 from model_bakery import baker
 
+from ..constants import README_MISSING
 from ..models import Library
 from versions.models import Version
 
@@ -291,3 +292,20 @@ def test_libraries_by_version_detail_no_version_found(tp, library_version):
         000000,
     )
     tp.response_404(res)
+
+
+def test_library_detail_context_missing_readme(
+    tp, user, library_version
+):
+    """
+    GET /libraries/{slug}/
+    Test that the missing readme message appears as expected
+    """
+
+    library = library_version.library
+    url = tp.reverse("library-detail", library.slug)
+    response = tp.get(url)
+    tp.response_200(response)
+    assert not library.description
+    assert "description" in response.context
+    assert response.context["description"] == README_MISSING

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -304,8 +304,9 @@ def test_library_detail_context_missing_readme(
 
     library = library_version.library
     url = tp.reverse("library-detail", library.slug)
+
     response = tp.get(url)
+
     tp.response_200(response)
-    assert not library.description
     assert "description" in response.context
     assert response.context["description"] == README_MISSING

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -15,6 +15,7 @@ from django.views.generic.edit import FormMixin
 from core.githubhelper import GithubAPIClient
 from versions.models import Version
 
+from .constants import README_MISSING
 from .forms import VersionSelectionForm
 from .mixins import VersionAlertMixin
 from .models import (
@@ -268,7 +269,7 @@ class LibraryDetail(FormMixin, VersionAlertMixin, DetailView):
         client = GithubAPIClient(repo_slug=self.object.github_repo)
         context["description"] = self.object.get_description(
             client, tag=context["version"].name
-        )
+        ) or README_MISSING
 
         return context
 


### PR DESCRIPTION
Fixes #1339 

## Changes
- Adds a constant for the missing README message
- ~`Library.get_description` defaults to this message if no README/library-details.adoc is found~ Update: switched to alternative implementation below
  - Alternative implementation would be to use the default message in the view if `get_description` returns `None`
- Adds a test `test_library_detail_context_missing_readme`

## Manual testing

I created a bare minimum Library in the shell and visited its detail page. Since there was no README, the default message was displayed.

<img width="1268" alt="Screenshot 2024-10-10 at 10 52 57 AM" src="https://github.com/user-attachments/assets/f3b09c6d-669e-4a8e-9e3e-6108f4e128de">

I then set a cached value for the library's description and reloaded the detail view. The cached value was displayed.

<img width="1097" alt="Screenshot 2024-10-10 at 10 54 23 AM" src="https://github.com/user-attachments/assets/69c70f89-61d1-4984-a40f-81202da8429c">