### PR TITLE
Redirect to latest version on POST

### DIFF
--- a/libraries/views.py
+++ b/libraries/views.py
@@ -490,4 +490,5 @@ class LibraryDetail(FormMixin, DetailView):
             )
         else:
             logger.info("library_list_invalid_version")
+            return redirect(request.get_full_path())
         return super().get(request)


### PR DESCRIPTION
This removes the repost dialogue after switching to the latest version. Fixes #1314