### PR TITLE
Added support for release notes asciidoc macros (#1082)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -25,3 +25,19 @@ def temp_image_file():
     tmp_file.seek(0)
     file_obj = DjangoFile(open(tmp_file.name, mode="rb"), name="tmp_file")
     yield file_obj.seek(0)
+
+
+def pytest_collection_modifyitems(config, items):
+    """
+    Adds support for skipping tests based on the presence of markers:
+     - asciidoctor
+    """
+    keywordexpr = config.option.keyword
+    markexpr = config.option.markexpr
+    if keywordexpr or markexpr:
+        return  # let pytest handle this
+
+    skip_asciidoctor = pytest.mark.skip(reason="asciidoctor not selected")
+    for item in items:
+        if "asciidoctor" in item.keywords:
+            item.add_marker(skip_asciidoctor)

--- a/core/asciidoc.py
+++ b/core/asciidoc.py
@@ -15,7 +15,7 @@ def convert_adoc_to_html(input):
     :param input: The contents of the AsciiDoc file
     """
     result = subprocess.run(
-        ["asciidoctor", "-e", "-o", "-", "-"],
+        ["asciidoctor", "-r", "asciidoctor_boost", "-e", "-o", "-", "-"],
         check=True,
         capture_output=True,
         text=True,

--- a/core/tests/content/asciidoc.adoc
+++ b/core/tests/content/asciidoc.adoc
@@ -1,0 +1,24 @@
+:noheader:
+:nofooter:
+:notitle:
+
+// standard asciidoctor content
+Some text
+
+https://asciidoctor.org - automatic!
+
+https://asciidoctor.org[Asciidoctor]
+
+devel@discuss.example.org
+
+// boost specific asciidoc content
+
+boost_at:/tools/boost/boost_1_75_0/libs/algorithm/doc/html/algorithm/[Algorithm Library]
+
+boost_phrase:library[Hi!]
+
+PR: boost_gh:pr[geometry,1247]
+
+Issue: boost_gh:issue[geometry,1231]
+
+boost_phrase:library[Charconv:,/libs/charconv/]

--- a/core/tests/content/asciidoc.html
+++ b/core/tests/content/asciidoc.html
@@ -1,0 +1,27 @@
+<div class="paragraph">
+<p>Some text</p>
+</div>
+<div class="paragraph">
+<p><a href="https://asciidoctor.org" class="bare">https://asciidoctor.org</a> - automatic!</p>
+</div>
+<div class="paragraph">
+<p><a href="https://asciidoctor.org">Asciidoctor</a></p>
+</div>
+<div class="paragraph">
+<p><a href="mailto:devel@discuss.example.org">devel@discuss.example.org</a></p>
+</div>
+<div class="paragraph">
+<p><a href="/tools/boost/boost_1_75_0/libs/algorithm/doc/html/algorithm/">Algorithm Library</a></p>
+</div>
+<div class="paragraph">
+<p><span class="library">Hi!</span></p>
+</div>
+<div class="paragraph">
+<p>PR: <a href="https://github.com/boostorg/geometry/pull/1247">PR#1247</a></p>
+</div>
+<div class="paragraph">
+<p>Issue: <a href="https://github.com/boostorg/geometry/issues/1231">#1231</a></p>
+</div>
+<div class="paragraph">
+<p><span class="library"><a href="/libs/charconv/">Charconv:</a></span></p>
+</div>

--- a/core/tests/test_asciidoc.py
+++ b/core/tests/test_asciidoc.py
@@ -1,4 +1,8 @@
+from os import getcwd, makedirs
 from unittest.mock import patch
+
+import pytest
+
 
 from core.asciidoc import convert_adoc_to_html
 
@@ -14,6 +18,7 @@ def test_convert_adoc_to_html_subprocess():
     assert result == "html_content"
 
 
+@pytest.mark.asciidoctor
 def test_convert_adoc_to_html_content():
     """Test the process_adoc_to_html_content function."""
     content = "sample"
@@ -21,3 +26,17 @@ def test_convert_adoc_to_html_content():
 
     result = convert_adoc_to_html(content)
     assert result == expected_html
+
+
+@pytest.mark.asciidoctor
+def test_convert_adoc_to_html_content_file():
+    # for dev, change this to True, and update the test_pytest_asciidoctor run
+    #  command to include "-v /tmp/asciidocs:/tmp/asciidocs" after "run"
+    generate_files_for_debugging = False
+    expected_output = open(f"{getcwd()}/core/tests/content/asciidoc.html").read()
+    adoc_file_path = f"{getcwd()}/core/tests/content/asciidoc.adoc"
+    output = convert_adoc_to_html(open(adoc_file_path).read())
+    if generate_files_for_debugging:
+        makedirs("/tmp/asciidocs", exist_ok=True)
+        open("/tmp/asciidocs/tmp.html", "w").write(output)
+    assert output == expected_output

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ FROM python:3.11-slim AS release
 RUN apt update && apt install -y git libpq-dev ruby ruby-dev && rm -rf /var/lib/apt/lists/*
 
 # Install Asciidoctor
-RUN gem install asciidoctor
+RUN gem install asciidoctor asciidoctor-boost
 
 # Boostrap uv.
 RUN pip install 'uv>=0.2.27,<0.3'

--- a/justfile
+++ b/justfile
@@ -49,6 +49,9 @@ alias shell := console
 @test_pytest:
     -docker compose run --rm web pytest -s
 
+@test_pytest_asciidoctor:
+    -docker compose run --rm web pytest -m asciidoctor -s
+
 @test:
     just test_pytest
     docker compose down

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@ addopts = --reuse-db --no-migrations
 norecursedirs = .git config node_modules scss static templates static_deploy
                 uploads frontend media kube docker config content .github .pytest_cache venv
 python_files = test_*.py
+markers=
+  asciidoctor: indicating test involving local asciidoctor rendering


### PR DESCRIPTION
Related to ticket #1082, this adds support for asciidoc macros to emulate macros from qbk. The `qbk` items below are the originals from the ticket, the `asciidoc` items below are the new ones for asciidocs, and the `html` items below are the output.

qbk: `[phrase library..XX]`
String to use in asciidoc: `phrase::[library,Hi!]`
html: `<span class="library">Hi!</span>`


qbk: `[@/libs/function/ Function]`
asciidoc: `at::/tools/build/doc/html/#_version_5_1_0[B2 version 5.1.0]`
html: `<a href="/tools/boost/boost_1_75_0/libs/algorithm/doc/html/algorithm/">Algorithm Library</a>`

qbk: `[github_pr geometry 1247]`
asciidoc: `github_pr::[geometry,1247]`
html: `<a href="https://github.com/boostorg/geometry/pull/1247">PR#1247</a>`

qbk: `[github geometry 1231]`
aasciidoc: `github_issue::[geometry,1231]`
html: `<a href="https://github.com/boostorg/geometry/issues/1231">#1231</a>`

qbk: `[phrase library..[@/libs/charconv/ Charconv]:]`
asciidoc: `phrase::[library,at::/libs/charconv/[Charconv:]]`
html: `<span class="library"><a href="/libs/charconv/">Charconv:</a></span>`