### PR TITLE
Reduced steps for local development setup for social media auth (#1374)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,43 @@ static/css/styles.css
 *.code-workspace
 .vscode/settings.json
 .idea
+
+# TERRAFORM/TOFU
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/Makefile
+++ b/Makefile
@@ -98,3 +98,35 @@ shell:
 .PHONY: up
 up:
 	docker compose up -d
+
+# todo: update make setup to use development-tofu-init
+.PHONY: development-tofu-init
+development-tofu-init:
+#	@command -v gh >/dev/null 2>&1 || { echo >&2 "gh is required but not installed. see: https://cli.github.com/ Aborting."; exit 1; }
+	@command -v gcloud >/dev/null 2>&1 || { echo >&2 "gcloud is required but not installed. see: https://cloud.google.com/sdk/docs/install Aborting."; exit 1; }
+	@command -v tofu >/dev/null 2>&1 || { echo >&2 "opentofu is required but not installed. see: https://opentofu.org/docs/intro/install/ Aborting."; exit 1; }
+	@if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep -q '.'; then \
+		gcloud auth application-default login; \
+	fi
+	@cd development-tofu; tofu init
+
+.PHONY: development-tofu-plan
+development-tofu-plan:
+	@if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep -q '.'; then \
+		gcloud auth application-default login; \
+	fi
+	@cd development-tofu; direnv allow && tofu plan
+
+.PHONY: development-tofu-apply
+development-tofu-apply:
+	@if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep -q '.'; then \
+		gcloud auth application-default login; \
+	fi
+	@cd development-tofu; direnv allow && tofu apply
+
+.PHONY: development-tofu-destroy
+development-tofu-destroy:
+	@if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep -q '.'; then \
+		gcloud auth application-default login; \
+	fi
+	@cd development-tofu; direnv allow && tofu destroy

--- a/config/settings.py
+++ b/config/settings.py
@@ -348,8 +348,37 @@ SOCIALACCOUNT_PROVIDERS = {
             "access_type": "online",
         },
         "OAUTH_PKCE_ENABLED": True,
-    }
+    },
+    "github": {},
 }
+if LOCAL_DEVELOPMENT:
+    github_oauth_client_id = env("GITHUB_OAUTH_CLIENT_ID", default=None)
+    github_oauth_secret = env("GITHUB_OAUTH_CLIENT_SECRET", default=None)
+    if not github_oauth_client_id or not github_oauth_secret:
+        logging.warning("Github OAuth credentials not set")
+    else:
+        SOCIALACCOUNT_PROVIDERS["github"] = {
+            "APPS": [
+                {
+                    "client_id": github_oauth_client_id,
+                    "secret": github_oauth_secret,
+                }
+            ]
+        }
+    google_oauth_client_id = env("GOOGLE_OAUTH_CLIENT_ID", default=None)
+    google_oauth_secret = env("GOOGLE_OAUTH_CLIENT_SECRET", default=None)
+    if not google_oauth_client_id or not google_oauth_secret:
+        logging.warning("Google OAuth credentials not set")
+    else:
+        SOCIALACCOUNT_PROVIDERS["google"] = {
+            "APPS": [
+                {
+                    "client_id": google_oauth_client_id,
+                    "secret": google_oauth_secret,
+                }
+            ]
+        }
+
 
 # Allow Allauth to use HTTPS when deployed but HTTP for local dev
 SECURE_PROXY_SSL_HEADER_NAME = env("SECURE_PROXY_SSL_HEADER_NAME", default=None)

--- a/development-tofu/.terraform.lock.hcl
+++ b/development-tofu/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.8.0"
+  constraints = "6.8.0"
+  hashes = [
+    "h1:lGhTjjKozpr3ZX3zipw3DJOAhNw7mAGQyWrmJJKkMFg=",
+    "zh:06a80f46f4f49d30c7cdb07f5d0715b8398497f1d86acda43b32817cb99c0cfd",
+    "zh:073b406305aa675e8b367224485270ed1f18de86cc7afdaa202bbd8562dc32a7",
+    "zh:11c2e9f0de6eda72a4ba646a25cceeb489cfe7a39c26f48ff20421b3289b8fa7",
+    "zh:39d0db53e543d50eb267c56a6461039db4b08d0c99fbe5cd5b9beb3d0efe296e",
+    "zh:4bbbbaf241eb91fc7ba575c6b85706299c7a42b700dc74fd12dfa9f93d3c0102",
+    "zh:582332cf741c265f5e72cb35984598b7130aaf5580b243b5529fda30bdf12129",
+    "zh:881dc8c132273991941b018f8012a977b4a7ebb32f0fb99c7b5f5757dfb96b06",
+    "zh:96d2258f074b237ef735023be038f818f3ea975f4175e7598ac2b477d12df8f8",
+    "zh:b3cc4e99128a97ad640c12e7dc39299b52c4205f0201e53f9a674c0dfb623d49",
+    "zh:eaf2fc5acc3cba9c756da51295ad0e45d1f024f84490b920d989357c52c98562",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/http" {
+  version     = "2.2.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:/Q12gSDYtsL3CA4Yo1R+bWvL74SAZaWhtD9hsZhur7Y=",
+    "zh:2784c4f483c053389491d0c6a848ee6d2d7e30a38f9f8274343073d9c823451b",
+    "zh:2e407bbd932cc0fbc8a20b5ceafd746f81cf2789b79c39aaa9d0c46dddf81e6d",
+    "zh:3210194be95cb328a2721f1e442cf1de642131db1d9e39dea1996452dea3c13c",
+    "zh:38ae97eb006e5feec40fe706a64973ab7acfe55ee5af4ef841c8e49423a61e9d",
+    "zh:a316516f334cce04a35c4be87e84888072010b91d7a461c7f911c6f0ef991472",
+    "zh:b7a6d76c9a6b24e7c9a380579a7b6525a3f53428bfe2d98189e932b701b79798",
+    "zh:bb47534d491bfa18a66d0920361befb058ea599881bc58b68c59550b33272f58",
+    "zh:c63fa287d7d0ac78899841da67df4d7abef5b3c978f18841b965f7e5acdb1f03",
+    "zh:d70f4f5d2af290a228d69f1d7fcbc95143d94155ce8021a70d27417d35e1226b",
+    "zh:e70701f8a5c78c8c85dba7381c5e0b23ee293efdffa0cd358932c9d20fbd2fbe",
+  ]
+}

--- a/development-tofu/main.tf
+++ b/development-tofu/main.tf
@@ -1,0 +1,12 @@
+module "google_oauth_client" {
+  source                     = "./modules/google_oauth_client"
+  google_cloud_email         = var.google_cloud_email
+  google_cloud_project_name  = var.google_cloud_project_name
+  google_organization_domain = var.google_organization_domain
+}
+
+# can't implement github support at this time, no API available for
+# managing oauth. Leaving this here as a breadcrumb for the future.
+# module "github_oauth_client" {
+#   source = "./modules/github_oauth_client"
+# }

--- a/development-tofu/modules/github_oauth_client/variables.tf
+++ b/development-tofu/modules/github_oauth_client/variables.tf
@@ -1,0 +1,16 @@
+variable "github_homepage_url" {
+  type        = string
+  description = "The URL of the GitHub OAuth app"
+  default     = "http://localhost:8000"
+}
+
+variable "github_authorization_callback_url" {
+  type        = string
+  description = "The URL of the GitHub OAuth app callback"
+  default     = "http://localhost:8000/accounts/github/login/callback/"
+}
+
+variable "github_token" {
+  type        = string
+  description = "The GitHub token for creating the OAuth app"
+}

--- a/development-tofu/modules/google_oauth_client/main.tf
+++ b/development-tofu/modules/google_oauth_client/main.tf
@@ -1,0 +1,21 @@
+resource "google_project" "project" {
+  project_id = var.google_cloud_project_name
+  name       = "Boost Development"
+  org_id     = replace(data.google_organization.org.id, "organizations/", "")
+  deletion_policy = "DELETE"
+}
+
+data "google_organization" "org" {
+  domain = var.google_organization_domain
+}
+
+resource "google_project_service" "project_service" {
+  project = google_project.project.project_id
+  service = "iap.googleapis.com"
+}
+
+resource "google_iap_brand" "project_brand" {
+  support_email     = var.google_cloud_email
+  application_title = "Cloud IAP Protected Application for Boost Development"
+  project           = google_project_service.project_service.project
+}

--- a/development-tofu/modules/google_oauth_client/variables.tf
+++ b/development-tofu/modules/google_oauth_client/variables.tf
@@ -1,0 +1,14 @@
+variable "google_cloud_email" {
+  type        = string
+  description = "The email address of the Google Cloud user"
+}
+
+variable "google_cloud_project_name" {
+  type        = string
+  description = "The project name for the Google Cloud project"
+}
+
+variable "google_organization_domain" {
+  type        = string
+  description = "The domain of the Google Cloud organization"
+}

--- a/development-tofu/providers.tf
+++ b/development-tofu/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.8.0"
+    }
+    http = { # needed for github api requests
+      source  = "hashicorp/http"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/development-tofu/variables.tf
+++ b/development-tofu/variables.tf
@@ -1,0 +1,15 @@
+variable "google_cloud_email" {
+  type        = string
+  description = "The email address of the Google Cloud user"
+}
+
+variable "google_cloud_project_name" {
+  type        = string
+  description = "The project name for the Google Cloud project"
+  default     = "localboostdev"
+}
+
+variable "google_organization_domain" {
+  type        = string
+  description = "The domain of the Google Cloud organization"
+}

--- a/docs/development_setup_notes.md
+++ b/docs/development_setup_notes.md
@@ -291,30 +291,17 @@ See https://testdriven.io/blog/django-social-auth/ for more information.
 - Set `http://localhost:8000` as the Homepage URL
 - Set `http://localhost:8000/accounts/github/login/callback/` as the Callback URL
 - Click whether you want to enable the device flow
+   - <img src="https://user-images.githubusercontent.com/2286304/252841283-9a846c68-46bb-4dac-8d1e-d35270c09f1b.png" alt="The GitHub screen that registers a new OAuth app" width="400">
+- On completion copy the Client ID and Client Secret to the `.env` file as values of `GITHUB_OAUTH_CLIENT_ID` and `GITHUB_OAUTH_CLIENT_SECRET`.
+- Run `direnv allow` and restart your docker containers.
 
-<img src="https://user-images.githubusercontent.com/2286304/252841283-9a846c68-46bb-4dac-8d1e-d35270c09f1b.png" alt="The GitHub screen that registers a new OAuth app" width="400">
-
-- Log in to the admin
-- Click on Social Applications
-
-
-<img src="https://user-images.githubusercontent.com/2286304/204597123-3c8ae053-1ba8-4347-bacd-784fe52b2a04.png" alt="The Social Accounts section of the Django admin" width="400">
-
-- Click **Add Social Application**
-- Choose GitHub as the provider
-- Enter a name like "GitHub OAuth Provider"
-- Enter the Client ID from GitHub
-- Go back to GitHub and generate a new Client Secret, then copy it into the **Secret Key** field. Choose the site as a **Chosen sites** and save.
-
-<img src="https://user-images.githubusercontent.com/2286304/204648736-79aed1be-4b32-4946-be97-27e7c859603d.png" alt="Screenshot of where to get the Client ID and Client Secret" width="400">
-
-It's ready!
-
-**Working locally**: If you need to run through this flow multiple times, create a superuser so you can log into the admin. Then, log into the admin and delete your "Social Account" from the admin. This will test a fresh connection to GitHub for your logged-in GitHub user.
+Setup should be complete and you should be able to see an option to "Use Github" on the sign up page.
 
 To test the flow including authorizing Github for the Boost account, log into your GitHub account settings and click **Applications** in the left menu. Find the "Boost" authorization and delete it. The next time you log into Boost with this GitHub account, you will have to re-authorize it.
 
 <img src="https://user-images.githubusercontent.com/2286304/204642346-8b269aaf-4693-4351-9474-0a998b97689c.png" alt="The 'Authorized OAuth Apps' tab in your GitHub Applications" width="400">
+
+This setup process is not something that can currently be automated through terraform because of a lack of relevant Github API endpoints to create Oauth credentials.
 
 #### Google
 
@@ -322,15 +309,34 @@ More detailed instructions at:
 
 https://docs.allauth.org/en/latest/socialaccount/providers/google.html
 
-Go to https://console.developers.google.com/ and create a new project. Create OAuth 2.0 credentials.
+1. Update the `.env` file with values for:
+   1. `TF_VAR_google_cloud_email` (the email address of your Google Cloud account)
+   2. `TF_VAR_google_organization_domain` (usually the domain of your Google Cloud account, e.g. "boost.org" if you will be using an @boost.org email address)
+   3. `TF_VAR_google_cloud_project_name` (optional, default: localboostdev) - needs to change if destroyed and a setup is needed within 30 days
+2. Run `make development-tofu-init` to initialize tofu.
+3. Run `make development-tofu-plan` to confirm the planned changes.
+4. Run `make development-tofu-apply` to apply the changes.
+5. Go to https://console.developers.google.com/
+   1. Search for the newly created project, named "Boost Development" (ID: localboostdev by default).
+   2. Type "credentials" in the search input at the top of the page.
+   3. Select "Credentials" under "APIs & Services".
+      1. Click "+ CREATE CREDENTIALS"
+      2. Select "OAuth Client ID"
+      3. Select Application Type: "Web application"
+      4. Name: "Boost Development" (arbitrary)
+      5. For "Authorized Javascript Origins" use:`http://localhost:8000`
+      6. For "Authorized Redirect URIs" use:
+         * `http://localhost:8000/accounts/google/login/callback/`
+         * `http://localhost:8000/accounts/google/login/callback/?flowName=GeneralOAuthFlow`
+      7. Save
+6. From the page that's displayed, update the `.env` file with values for the following:
+   - `GOOGLE_OAUTH_CLIENT_ID` should be similar to "k235bn2b1l1(...)asdsk.apps.googleusercontent.com"
+   - `GOOGLE_OAUTH_CLIENT_SECRET` should be similar to "LAJACO(...)KLAI612ANAD"
+7. Run `direnv allow` and restart your docker containers.
 
-The client id is the full value including domain and tld.
+Point 5 above can not be automated through terraform because of a lack of relevant Google Cloud API endpoints to create Oauth credentials.
 
-For the "authorized javascript origins" values use:
+Setup should be complete and you should be able to see an option to "Use Google" on the sign up page.
 
-* `http://localhost:8000`
-
-For the "authorized redirect URIs" use:
-
-* `http://localhost:8000/accounts/google/login/callback/`
-* `http://localhost:8000/accounts/google/login/callback/?flowName=GeneralOAuthFlow`
+#### Additional Notes:
+**Working locally**: If you need to run through the login flows multiple times, create a superuser so you can log into the admin. Then, log into the admin and delete your "Social Account" from the admin. This will test a fresh connection to GitHub for your logged-in GitHub user.

--- a/docs/non-dev-server-allauth-setup.md
+++ b/docs/non-dev-server-allauth-setup.md
@@ -1,0 +1,60 @@
+# Production/Staging Server setup for allauth
+
+For development see [development_setup_notes.md](development_setup_notes.md).
+
+For this setup adjustments will need to be made to the values as applicable for each server and service.
+
+### Social Login with django-allauth
+
+Follow these instructions to use the social logins through django-allauth.
+
+See https://testdriven.io/blog/django-social-auth/ for more information.
+
+#### Github
+- Go to https://github.com/settings/applications/new and add a new OAuth application
+- Set `http://localhost:8000` as the Homepage URL
+- Set `http://localhost:8000/accounts/github/login/callback/` as the Callback URL
+- Click whether you want to enable the device flow
+
+<img src="https://user-images.githubusercontent.com/2286304/252841283-9a846c68-46bb-4dac-8d1e-d35270c09f1b.png" alt="The GitHub screen that registers a new OAuth app" width="400">
+
+- Log in to the admin
+- Click on Social Applications
+
+
+<img src="https://user-images.githubusercontent.com/2286304/204597123-3c8ae053-1ba8-4347-bacd-784fe52b2a04.png" alt="The Social Accounts section of the Django admin" width="400">
+
+- Click **Add Social Application**
+- Choose GitHub as the provider
+- Enter a name like "GitHub OAuth Provider"
+- Enter the Client ID from GitHub
+- Go back to GitHub and generate a new Client Secret, then copy it into the **Secret Key** field. Choose the site as a **Chosen sites** and save.
+
+<img src="https://user-images.githubusercontent.com/2286304/204648736-79aed1be-4b32-4946-be97-27e7c859603d.png" alt="Screenshot of where to get the Client ID and Client Secret" width="400">
+
+It's ready!
+
+**Working locally**: If you need to run through this flow multiple times, create a superuser so you can log into the admin. Then, log into the admin and delete your "Social Account" from the admin. This will test a fresh connection to GitHub for your logged-in GitHub user.
+
+To test the flow including authorizing Github for the Boost account, log into your GitHub account settings and click **Applications** in the left menu. Find the "Boost" authorization and delete it. The next time you log into Boost with this GitHub account, you will have to re-authorize it.
+
+<img src="https://user-images.githubusercontent.com/2286304/204642346-8b269aaf-4693-4351-9474-0a998b97689c.png" alt="The 'Authorized OAuth Apps' tab in your GitHub Applications" width="400">
+
+#### Google
+
+More detailed instructions at:
+
+https://docs.allauth.org/en/latest/socialaccount/providers/google.html
+
+Go to https://console.developers.google.com/ and create a new project. Create OAuth 2.0 credentials.
+
+The client id is the full value including domain and tld.
+
+For the "authorized javascript origins" values use:
+
+* `http://localhost:8000`
+
+For the "authorized redirect URIs" use:
+
+* `http://localhost:8000/accounts/google/login/callback/`
+* `http://localhost:8000/accounts/google/login/callback/?flowName=GeneralOAuthFlow`

--- a/env.template
+++ b/env.template
@@ -41,3 +41,15 @@ CELERY_BROKER=redis://redis:6379/0
 CELERY_BACKEND=redis://redis:6379/0
 
 CALENDAR_API_KEY=changeme
+
+# terraform vars for google cloud oauth credential creation for local dev use
+TF_VAR_google_cloud_email=
+TF_VAR_google_organization_domain=
+# TF_VAR_google_cloud_project_name=localboostdev  # needs to change once destroyed and needed again within 30 days
+
+# existing defaults are noted here for overriding
+GITHUB_OAUTH_CLIENT_ID=
+GITHUB_OAUTH_CLIENT_SECRET=
+
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=


### PR DESCRIPTION
This is related to ticket #1374, and simplifies the steps for local development environments to have a working login flow for github and google.

The improvements were configuration for the client id and secret for google and github via .env vars instead of having to go through setting up "Social Applications" via the admin interface, and automating the process for creating google cloud projects in which oauth clients can be created. Documentation was adjusted to fit.

That was as far as this could be automated given limitations on both Google Cloud Platform and Github's APIs for creating oauth clients/apps. 

The terraform process can be improved if these tickets see some progress or an API comes about to support this. 

Google
https://github.com/hashicorp/terraform-provider-google/issues/16452
https://issuetracker.google.com/issues/116182848

Github
https://github.com/integrations/terraform-provider-github/issues/786