### PR TITLE
WIP - Switched guides to iframe, other fixes

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -450,6 +450,7 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
             base_html = render_to_string(
                 "docs_libs_placeholder.html", context, request=self.request
             )
+            context["hide_footer"] = True
             context["content"] = modernize_legacy_page(
                 content,
                 base_html,
@@ -470,9 +471,11 @@ class UserGuideTemplateView(BaseStaticContentTemplateView):
     def process_content(self, content):
         """Replace page header with the local one."""
         content_type = self.content_dict.get("content_type")
-        original_docs_type = SourceDocType.ANTORA
         modernize = self.request.GET.get("modernize", "med").lower()
-        if content_type != "text/html" or modernize not in ("max", "med", "min"):
+
+        if (
+            "text/html" or "text/html; charset=utf-8"
+        ) not in content_type or modernize not in ("max", "med", "min"):
             # eventually check for more things, for example ensure this HTML
             # was not generate from Antora builders.
             return content
@@ -488,13 +491,20 @@ class UserGuideTemplateView(BaseStaticContentTemplateView):
             else {"data-modernizer": "boost-legacy-docs-extra-head"}
         )
         # potentially pass version if needed for HTML modification
-        return modernize_legacy_page(
+        base_html = render_to_string(
+            "docs_libs_placeholder.html", context, request=self.request
+        )
+        context["hide_footer"] = True
+        context["content"] = modernize_legacy_page(
             content,
             base_html,
             insert_body=insert_body,
             head_selector=head_selector,
-            original_docs_type=original_docs_type,
+            original_docs_type=SourceDocType.ANTORA,
+            show_footer=False,
+            show_navbar=False,
         )
+        return render_to_string("docsiframe.html", context, request=self.request)
 
 
 class ImageView(View):

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,7 +25,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@ryangjchandler/alpine-clipboard@2.x.x/dist/alpine-clipboard.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@alpinejs/persist@3.x.x/dist/cdn.min.js" defer></script>
     <script src="//unpkg.com/alpinejs" defer></script>
-    <script src="https://unpkg.com/htmx.org@1.9.12" integrity="ujb1lZYygJmzgSwoxRggbCHcjc0rB2XoQrxeTUQyRjrOnlCoYta87iKBWq3EsdM2" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.12" integrity="sha384-ujb1lZYygJmzgSwoxRggbCHcjc0rB2XoQrxeTUQyRjrOnlCoYta87iKBWq3EsdM2" crossorigin="anonymous"></script>
     <!-- TODO bring this local if we like it -->
     <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
     <!-- detect dark or light mode -->
@@ -66,7 +66,7 @@
       {% endblock %}
       </div>
 
-      {% if request.resolver_match.url_name != "docs-libs-page" %}
+      {% if not hide_footer %}
         {% include "includes/_footer.html" %}
       {% endif %}
     </div>

--- a/templates/includes/_header.html
+++ b/templates/includes/_header.html
@@ -413,7 +413,7 @@ html.dark {
             <div hx-get="/users/avatar/"
                  hx-trigger="load"
                  hx-target="#avatar"
-                 hx-indicator=".htmx-indicator">
+                 hx-indicator="#avatar">
             </div>
             <span id="avatar"></span>
         </span>


### PR DESCRIPTION
This sets the User Guides to show in an iframe, 

Other changes: 
* Hides the footer in the base template by a context variable.
* Fixes integrity sha for htmx.
* Fixes selector for avatar loading indicator.