### PR TITLE
Fix library dropdown switching

### DIFF
--- a/core/templatetags/version_select.py
+++ b/core/templatetags/version_select.py
@@ -1,0 +1,9 @@
+from django import template
+from django.template.loader import render_to_string
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def version_select(context):
+    return render_to_string("partials/version_select.html", context.flatten())

--- a/libraries/utils.py
+++ b/libraries/utils.py
@@ -172,7 +172,7 @@ def determine_view_from_library_request(request):
 
 def determine_selected_boost_version(request_value, request):
     valid_versions = Version.objects.version_dropdown_strict()
-    version_slug = get_version_from_cookie(request) or request_value
+    version_slug = request_value or get_version_from_cookie(request)
     if version_slug in [v.slug for v in valid_versions]:
         return version_slug
     else:

--- a/templates/libraries/category_list.html
+++ b/templates/libraries/category_list.html
@@ -8,31 +8,6 @@
 
 {% block content %}
 <main class="content">
-  <div class="py-0 px-0 mt-0 mb-0 w-full md:mb-2 flex flex-row flex-nowrap items-center md:block">
-    {% comment %}
-    <div class="flex-auto mb-2 w-full md:block md:w-auto md:mb-0">
-      <div>
-          <span class="text-xl md:text-3xl lg:text-4xl">Libraries by Category</span>
-      </div>
-    </div>
-
-    <div class="flex-shrink md:hidden">
-      <form action="." method="get">
-        <div>
-          <select onchange="this.form.submit()"
-              name="version"
-              class="dropdown"
-              id="id_version">
-            {% for v in versions %}
-            <option value="{{ v.slug }}" {% if version == v %}selected="selected"{% endif %}>{{ v.display_name }}</option>
-            {% endfor %}
-          </select>
-        </div>
-      </form>
-    </div>
-    {% endcomment %}
-  </div>
-
   {% include "libraries/includes/library_preferences.html" %}
 
   {# alert for non-current Boost versions #}

--- a/templates/libraries/flat_list.html
+++ b/templates/libraries/flat_list.html
@@ -8,31 +8,6 @@
 
 {% block content %}
 <main class="content">
-  <div class="py-0 px-0 mt-0 mb-0 w-full md:mb-2 flex flex-row flex-nowrap items-center md:block">
-    {% comment %}
-    <div class="flex-auto mb-2 w-full md:block md:w-auto md:mb-0">
-      <div>
-          <span class="text-xl md:text-3xl lg:text-4xl">Libraries by Name</span>
-      </div>
-    </div>
-
-    <div class="flex-shrink md:hidden">
-      <form action="." method="get">
-        <div>
-          <select onchange="this.form.submit()"
-              name="version"
-              class="dropdown"
-              id="id_version">
-            {% for v in versions %}
-            <option value="{{ v.slug }}" {% if version == v %}selected="selected"{% endif %}>{{ v.display_name }}</option>
-            {% endfor %}
-          </select>
-        </div>
-      </form>
-    </div>
-    {% endcomment %}
-  </div>
-
   {% include "libraries/includes/library_preferences.html" %}
 
   {# alert for non-current Boost versions #}

--- a/templates/libraries/includes/library_preferences.html
+++ b/templates/libraries/includes/library_preferences.html
@@ -1,3 +1,4 @@
+{%  load version_select %}
 {% with request.resolver_match.view_name as view_name %}
   <div class="pt-3 px-0 mb-2 text-right md:mb-2 mx-3 md:mx-0">
     <form action="{{request.path}}" method="get">
@@ -43,16 +44,8 @@
 
         {# Select a version #}
         <div class="flex grow justify-end">
-        <select onchange="this.form.submit()"
-                name="version"
-                class="dropdown py-2 md:block h-[38px] ml-3 md:ml-0"
-                id="id_version">
-          <option value="{{ LATEST_RELEASE_URL_PATH_STR }}" {% if version_str == LATEST_RELEASE_URL_PATH_NAME %}selected="selected"{% endif %}>Latest</option>
-          {% for v in versions %}
-          <option value="{{ v.slug }}" {% if version_str == v.slug %}selected="selected"{% endif %}>{{ v.display_name }}</option>
-          {% endfor %}
-        </select>
-      </div>
+            {% version_select %}
+        </div>
       </div>
     </form>
   </div>

--- a/templates/libraries/list.html
+++ b/templates/libraries/list.html
@@ -8,31 +8,6 @@
 {% block content %}
 <main class="content">
   {% if library_list %}
-  <div class="py-0 px-0 mt-0 mb-0 w-full md:mb-2 flex flex-row flex-nowrap items-center md:block">
-    {% comment %}
-    <div class="flex-auto mb-2 w-full md:block md:w-auto md:mb-0">
-      <div>
-          <span class="text-xl md:text-3xl lg:text-4xl">Libraries</span>
-      </div>
-    </div>
-
-    <div class="flex-shrink md:hidden">
-      <form action="." method="get">
-        <div>
-          <select onchange="this.form.submit()"
-              name="version"
-              class="dropdown"
-              id="id_version">
-            {% for v in versions %}
-            <option value="{{ v.slug }}" {% if version == v %}selected="selected"{% endif %}>{{ v.display_name }}</option>
-            {% endfor %}
-          </select>
-        </div>
-      </form>
-    </div>
-    {% endcomment %}
-  </div>
-
   {% include "libraries/includes/library_preferences.html" %}
 
   {# alert for non-current Boost versions #}

--- a/templates/partials/version_select.html
+++ b/templates/partials/version_select.html
@@ -1,0 +1,17 @@
+<form action="." method="get">
+    <select onchange="this.form.submit()"
+            name="version"
+            class="dropdown !mb-0 h-[38px]"
+            id="id_version">
+        <option value="{{ LATEST_RELEASE_URL_PATH_STR }}"
+                {% if version_str == LATEST_RELEASE_URL_PATH_STR %}selected="selected"{% endif %}>
+            Latest
+        </option>
+        {% for v in versions %}
+            <option value="{{ v.slug }}"
+                    {% if version_str == v.slug %}selected="selected"{% endif %}>
+                {{ v.display_name }}
+            </option>
+        {% endfor %}
+    </select>
+</form>


### PR DESCRIPTION
* Resolves the issue with libraries not updating on version dropdown selection going back from version to latest
* Fixes edge case of version alert not showing when query params are deleted from location bar
* Adds refactor of version selection drop downs on library preference page and cleans up some unused ones.