### PR TITLE
Added skip use boostbook for v2 on antora docs

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -491,6 +491,7 @@ class UserGuideTemplateView(BaseStaticContentTemplateView):
             else {"data-modernizer": "boost-legacy-docs-extra-head"}
         )
         # potentially pass version if needed for HTML modification
+        context["skip_use_boostbook"] = True
         base_html = render_to_string(
             "docs_libs_placeholder.html", context, request=self.request
         )

--- a/templates/docs_libs_placeholder.html
+++ b/templates/docs_libs_placeholder.html
@@ -3,7 +3,9 @@
 
 {% block extra_head %}
   <link href="{% static 'css/styles.css' %}" rel="stylesheet" />
-  <link rel="preload" data-modernizer="boost-legacy-docs-extra-head" href="{% static 'css/boostbookV2.css' %}" rel="stylesheet" />
+  {% if not skip_use_boostbook %}
+    <link rel="preload" data-modernizer="boost-legacy-docs-extra-head" href="{% static 'css/boostbookV2.css' %}" rel="stylesheet" />
+  {% endif %}
   <link rel="preload" data-modernizer="boost-legacy-docs-extra-head" href="{% static 'css/fonts.css' %}" rel="stylesheet" />
   {% comment %}
    These style tweaks ensure that legacy doc pages are rendered decently.


### PR DESCRIPTION
@julioest requested a change to not adding boostbookV2.css on the user guides.