### PR TITLE
The "authors" value can sometimes be a string.

### DIFF
--- a/libraries/github.py
+++ b/libraries/github.py
@@ -293,6 +293,9 @@ class LibraryUpdater:
         if not authors:
             return obj
 
+        if isinstance(authors, str):
+            authors = [authors]
+
         for author in authors:
             person_data = self.parser.extract_contributor_data(author)
             email = person_data["email"]


### PR DESCRIPTION
- In the case that it is a string, convert it to a list.
- fixes #1396