### PR TITLE
Fix news container word break bug

### DIFF
--- a/templates/news/detail.html
+++ b/templates/news/detail.html
@@ -68,7 +68,7 @@
         {% if entry.image %}
         <img src="{{ entry.image.url }}" class="mb-2 w-full h-auto md:float-right md:ml-5 md:mt-6 md:w-1/6 md:min-w-[200px] border border-black">
         {% endif %}
-        <div class="break-all">
+        <div class="break-words">
         {{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaks }}
         </div>
       </div>


### PR DESCRIPTION
Fixes #861 

Uses tailwind's `break-words` class instead of existing `break-all`. This maintains the character-level breaking on long strings like SHAs, while breaking paragraph text naturally.

Before:
<img width="607" alt="Screenshot 2024-11-04 at 12 03 03 PM" src="https://github.com/user-attachments/assets/22c4a876-cf27-4829-ba61-6a22dcbc756e">

After:
<img width="617" alt="Screenshot 2024-11-04 at 11 58 41 AM" src="https://github.com/user-attachments/assets/6bab582b-1acc-4e46-95cd-3f0e16811aba">
