### PR TITLE
Add category override mapping and use it in library update method

### DIFF
--- a/docs/syncing_data_with_github.md
+++ b/docs/syncing_data_with_github.md
@@ -21,15 +21,15 @@ Not all tags are official GitHub **Releases**, however, and this impacts where w
 To retrieve releases and tags, run:
 
 ```bash
-./manage.py import_releases
+./manage.py import_versions
 ```
 
-This will:
+Note the command enqueues a celery task rather than running synchronously. The task will:
 
-- Delete existing Versions and LibraryVersions
+- Delete existing Versions and LibraryVersions if you pass `--delete-versions` to the command
 - Retrieve tags and releases from the Boost GitHub repo
 - Create new Versions for each tag and release that is not a beta or rc release
-- Create a new LibraryVersion for each Library **but not for historical versions**
+- Create a new LibraryVersion for each Library (including for historical versions unless you pass `--new`)
 
 
 ## Library data

--- a/libraries/constants.py
+++ b/libraries/constants.py
@@ -288,6 +288,14 @@ LIBRARY_DOCS_EXCEPTIONS = {
     ],
 }
 
+# Mapping for duplicate library categories. If a library has one of the keys
+# in this mapping as its category, the associated canonical category should be used.
+# key: Duplicate category's Category.slug
+# value: Category.slug of the canonical category
+CATEGORY_OVERRIDES = {
+    "Container": "Containers",
+}
+
 
 # This constant is for library-version docs that we know are missing
 LIBRARY_DOCS_MISSING = {

--- a/libraries/github.py
+++ b/libraries/github.py
@@ -17,6 +17,7 @@ from django.db import transaction
 from django.utils import dateparse, timezone
 
 from versions.models import Version
+from .constants import CATEGORY_OVERRIDES
 from .models import (
     Category,
     Commit,
@@ -163,10 +164,7 @@ class LibraryUpdater:
     """
 
     def __init__(self, client=None, token=None):
-        if client:
-            self.client = client
-        else:
-            self.client = GithubAPIClient()
+        self.client = client or GithubAPIClient()
         self.api = self.client.initialize_api(token=token)
         self.parser = GithubDataParser()
         self.logger = structlog.get_logger()
@@ -279,6 +277,7 @@ class LibraryUpdater:
 
         obj.categories.clear()
         for cat_name in categories:
+            cat_name = CATEGORY_OVERRIDES.get(cat_name, cat_name)
             cat, _ = Category.objects.get_or_create(name=cat_name)
             obj.categories.add(cat)
 

--- a/libraries/tests/test_github.py
+++ b/libraries/tests/test_github.py
@@ -175,6 +175,14 @@ def test_update_categories(library, library_updater):
     assert Category.objects.filter(name="Test").exists()
     assert library.categories.filter(name="Test").exists()
 
+    # Ensure category overrides respected
+    assert Category.objects.filter(name="Containers").exists() is False
+    assert Category.objects.filter(name="Container").exists() is False
+    library_updater.update_categories(library, ["Container"])  # overridden
+    library.refresh_from_db()
+    assert Category.objects.filter(name="Containers").exists() is True
+    assert Category.objects.filter(name="Container").exists() is False
+
 
 def test_update_issues_new(
     tp, library, github_api_repo_issues_response, library_updater

--- a/static/css/boostlook.css
+++ b/static/css/boostlook.css
@@ -5,7 +5,7 @@
  * specific CSS rules are necessary to target each appropriately.
  *
  * High-Level HTML Structure:
- * 
+ *
  * - Antora Template:
  *   <div class="boostlook">
  *     <div class="card nav-container">...</div>
@@ -20,15 +20,15 @@
  *   </div>
  *
  * - For Antora templates:
- *   The `.boostlook .doc` selector targets elements within the `.doc` class, and the 
+ *   The `.boostlook .doc` selector targets elements within the `.doc` class, and the
  *   `.boostlook .nav-container` selector targets elements within the `.nav-container` class,
  *   both of which are specific to the Antora HTML structure.
  *
  * - For AsciiDoctor templates:
- *   The `.boostlook:not(:has(.doc))` selector is used to target elements that do not have 
+ *   The `.boostlook:not(:has(.doc))` selector is used to target elements that do not have
  *   a `.doc` child, applying styles specific to AsciiDoctor content.
 
- *   Since the `.doc` class is not present in the structure above, the styles defined for 
+ *   Since the `.doc` class is not present in the structure above, the styles defined for
  *   `.boostlook:not(:has(.doc))` will apply.
  */
 
@@ -248,11 +248,11 @@ p, h1, h2, h3, h4, h5, h6 {
 }
 
 .boostlook h1 { font-size: 2.5rem; }
-.boostlook h2 { font-size: 2rem; }  
+.boostlook h2 { font-size: 2rem; }
 .boostlook h3 { font-size: 1.5rem; }
 .boostlook h4 { font-size: 1.35rem; }
 .boostlook h5 { font-size: 1.25rem; }
-.boostlook h6 { font-size: 1rem; } 
+.boostlook h6 { font-size: 1rem; }
 
 .boostlook h1,
 .boostlook h2,
@@ -264,7 +264,7 @@ p, h1, h2, h3, h4, h5, h6 {
   margin-bottom: 1rem;
 }
 
-.boostlook p { 
+.boostlook p {
   font-size: 1rem;
   margin-bottom: 1.5rem;
 }
@@ -274,7 +274,7 @@ p, h1, h2, h3, h4, h5, h6 {
   margin: 0;
 }
 
-.boostlook a, 
+.boostlook a,
 .boostlook .doc a {
   color: var(--bl-link-color);
   text-decoration: none;
@@ -320,14 +320,14 @@ p, h1, h2, h3, h4, h5, h6 {
   color: var(--bl-code-text-color) !important;
 }
 
-.boostlook .quoteblock, 
+.boostlook .quoteblock,
 .boostlook .verseblock {
   background: var(--bl-quote-background);
   border-left: 3px solid var(--bl-border-color);
   color: var(--bl-text-color);
 }
 
-.boostlook .quoteblock::before, 
+.boostlook .quoteblock::before,
 .boostlook .verseblock::before {
   color: var(--bl-quote-word-color);
 }
@@ -336,8 +336,8 @@ p, h1, h2, h3, h4, h5, h6 {
   background-color: var(--bl-tabpanel-background);
 }
 
-.boostlook .hljs-keyword, 
-.boostlook .hljs-selector-tag, 
+.boostlook .hljs-keyword,
+.boostlook .hljs-selector-tag,
 .boostlook .hljs-subst {
   color: var(--bl-hljs-keyword-color);
 }
@@ -346,13 +346,13 @@ p, h1, h2, h3, h4, h5, h6 {
   color: var(--bl-hljs-number-color);
 }
 
-.boostlook .hljs-doctag, 
+.boostlook .hljs-doctag,
 .boostlook .hljs-string {
   color: var(--bl-hljs-doctag-color);
 }
 
-.boostlook .hljs-section, 
-.boostlook .hljs-selector-id, 
+.boostlook .hljs-section,
+.boostlook .hljs-selector-id,
 .boostlook .hljs-title {
   color: var(--bl-hljs-section-color);
 }
@@ -363,8 +363,8 @@ p, h1, h2, h3, h4, h5, h6 {
   color: var(--bl-link-color);
 }
 
-.boostlook .hljs-attribute, 
-.boostlook .hljs-name, 
+.boostlook .hljs-attribute,
+.boostlook .hljs-name,
 .boostlook .hljs-tag {
   color: var(--bl-hljs-attribute-color);
 }
@@ -448,7 +448,7 @@ p, h1, h2, h3, h4, h5, h6 {
 .boostlook #toc #toctitle {
   font-size: 1.5rem;
 }
- 
+
 .boostlook,
 .boostlook #toc.toc2 {
   background-color: var(--bl-card-background-color);
@@ -540,7 +540,7 @@ p, h1, h2, h3, h4, h5, h6 {
     height: 2rem;
     width: 2rem;
     text-indent: -9999px;
-    z-index: 1001; 
+    z-index: 1001;
   }
 }
 
@@ -567,7 +567,7 @@ p, h1, h2, h3, h4, h5, h6 {
     opacity: 0;
     visibility: hidden;
   }
-  
+
   html.toc-visible #toc.toc2 {
     opacity: 1;
     visibility: visible;
@@ -646,11 +646,11 @@ p, h1, h2, h3, h4, h5, h6 {
   color: var(--bl-link-hover-color);
 }
 
-.boostlook .nav-text { 
+.boostlook .nav-text {
   color: #828282;
 }
 
-/* TODO: Remove when docs wrapper is resolved in website-v2 */ 
+/* TODO: Remove when docs wrapper is resolved in website-v2 */
 .source-docs-antora .boostlook #toc.toc2 {
   top: 1rem !important;
   max-height: calc(100vh - 1rem) !important;
@@ -749,7 +749,7 @@ p, h1, h2, h3, h4, h5, h6 {
 }
 
 /* Toolbar */
-.boostlook .toolbar .breadcrumbs a, 
+.boostlook .toolbar .breadcrumbs a,
 .boostlook .toolbar .breadcrumbs li {
   color: var(--bl-text-color);
 }

--- a/versions/management/commands/import_versions.py
+++ b/versions/management/commands/import_versions.py
@@ -23,6 +23,8 @@ def command(
         verbose (bool): Enable verbose output (show logging statements)
         delete_versions (bool): If True, deletes all existing Version instances before
             importing.
+        new (bool): If True, only imports versions that do not already exist in
+            the database.
         token (str): Github API token, if you need to use something other than the
             setting.
     """


### PR DESCRIPTION
Fixes #1034

- Adds a `CATEGORY_OVERRIDES` mapping
- Uses the override in `update_libraries` management command

### Manual testing
- Ran `./manage.py import_versions`
- Ran `./manage.py update_libraries`
- Static String had the correct category
<img width="440" alt="Screenshot 2024-11-04 at 5 24 05 PM" src="https://github.com/user-attachments/assets/4b0cf4cb-15e2-4337-9284-7659afd40643">

### Post-deploy tasks
- Ensure `update_libraries` is run
- Verify **Container** category is orphaned
- Delete **Container** category