### PR TITLE
Libraries by category view should only show populated categories for selected version

### DIFF
--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -129,6 +129,17 @@ def test_library_list_by_category(
     assert "category" in res.context["library_list"][0]
     assert "libraries" in res.context["library_list"][0]
 
+    # Create a new library version that is not in the selected version
+    existing_category = library_version.library.categories.first()
+    new_category = baker.make("libraries.Category", name="New Category")
+    new_version = baker.make("versions.Version", name="New")
+    new_lib = baker.make("libraries.Library", name="New", categories=[new_category])
+    baker.make("libraries.LibraryVersion", version=new_version, library=new_lib)
+    res = tp.get(f"/libraries/by-category/?version={library_version.version.slug}")
+    tp.response_200(res)
+    assert existing_category in [x["category"] for x in res.context["library_list"]]
+    assert new_category not in [x["category"] for x in res.context["library_list"]]
+
 
 def test_library_detail(library_version, tp):
     """GET /libraries/{slug}/"""

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -194,13 +194,18 @@ class LibraryListByCategory(LibraryList):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["library_list"] = self.get_results_by_category()
+        context["library_list"] = self.get_results_by_category(
+            version=context.get("version")
+        )
         return context
 
-    def get_results_by_category(self):
+    def get_results_by_category(self, version: Version | None):
         queryset = super().get_queryset()
         results_by_category = []
-        for category in Category.objects.all().order_by("name"):
+        filter_kwargs = {"libraries__versions__name": version} if version else {}
+        for category in (
+            Category.objects.filter(**filter_kwargs).distinct().order_by("name")
+        ):
             results_by_category.append(
                 {
                     "category": category,


### PR DESCRIPTION
Fixes #1224 

- In libraries-by-category view, filter categories to only ones with libraries in the selected version
- Added a prefetch to the query to fix the N+1 query (minor performance improvement)

Before:
<img width="1275" alt="Screenshot 2024-11-05 at 3 54 18 PM" src="https://github.com/user-attachments/assets/fadd4e56-7101-46bb-ab4f-68d7d01a8879">

After:
<img width="1266" alt="Screenshot 2024-11-05 at 3 53 58 PM" src="https://github.com/user-attachments/assets/b54f4e20-5928-477e-88c2-dc0082babfc0">
