### PR TITLE
Profile Setting Option to receive email on material Privacy and Terms changes

### DIFF
--- a/users/forms.py
+++ b/users/forms.py
@@ -43,6 +43,10 @@ class PreferencesForm(forms.ModelForm):
         label="There are new entries pending moderation",
         required=False,
     )
+    allow_notification_tou_changed = forms.BooleanField(
+        label="The site's Terms of Use are changed",
+        required=False,
+    )
 
     def __init__(self, *args, instance=None, **kwargs):
         if instance is not None:
@@ -73,6 +77,7 @@ class PreferencesForm(forms.ModelForm):
             "allow_notification_own_news_approved",
             "allow_notification_others_news_posted",
             "allow_notification_others_news_needs_moderation",
+            "allow_notification_tou_changed",
         ]
 
 

--- a/users/forms.py
+++ b/users/forms.py
@@ -59,6 +59,10 @@ class PreferencesForm(forms.ModelForm):
             is_moderator = False
             all_news = Preferences.ALL_NEWS_TYPES
             kwargs["initial"] = {i: all_news for i in self.Meta.fields}
+            # Use default for terms changed field
+            kwargs["initial"][
+                "allow_notification_terms_changed"
+            ] = Preferences().allow_notification_terms_changed
 
         super().__init__(*args, instance=instance, **kwargs)
 

--- a/users/forms.py
+++ b/users/forms.py
@@ -43,8 +43,8 @@ class PreferencesForm(forms.ModelForm):
         label="There are new entries pending moderation",
         required=False,
     )
-    allow_notification_tou_changed = forms.BooleanField(
-        label="The site's Terms of Use are changed",
+    allow_notification_terms_changed = forms.BooleanField(
+        label="The site's Terms of Use or Privacy Policy are changed",
         required=False,
     )
 
@@ -77,7 +77,7 @@ class PreferencesForm(forms.ModelForm):
             "allow_notification_own_news_approved",
             "allow_notification_others_news_posted",
             "allow_notification_others_news_needs_moderation",
-            "allow_notification_tou_changed",
+            "allow_notification_terms_changed",
         ]
 
 

--- a/users/migrations/0014_populate_tou_notification_preference.py
+++ b/users/migrations/0014_populate_tou_notification_preference.py
@@ -1,0 +1,31 @@
+from django.db import migrations
+
+
+def populate_tou_preference(apps, schema_editor):
+    from users.models import Preferences
+    # Preferences = apps.get_model("users", "Preferences")
+    prefs_to_save = []
+    for preference in Preferences.objects.all():
+        preference.notifications[Preferences.TOU_MATERIALLY_CHANGED] = [False]
+        prefs_to_save.append(preference)
+    Preferences.objects.bulk_update(prefs_to_save, ["notifications"])
+
+def drop_tou_preference(apps, schema_editor):
+    from users.models import Preferences
+    # Preferences = apps.get_model("users", "Preferences")
+    prefs_to_save = []
+    for preference in Preferences.objects.all():
+        del preference.notifications[Preferences.TOU_MATERIALLY_CHANGED]
+        prefs_to_save.append(preference)
+    Preferences.objects.bulk_update(prefs_to_save, ["notifications"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0013_user_indicate_last_login_method"),
+    ]
+
+
+
+    operations = [migrations.RunPython(populate_tou_preference, drop_tou_preference)]

--- a/users/migrations/0014_populate_tou_notification_preference.py
+++ b/users/migrations/0014_populate_tou_notification_preference.py
@@ -3,19 +3,20 @@ from django.db import migrations
 
 def populate_tou_preference(apps, schema_editor):
     from users.models import Preferences
-    # Preferences = apps.get_model("users", "Preferences")
+
     prefs_to_save = []
     for preference in Preferences.objects.all():
-        preference.notifications[Preferences.TOU_MATERIALLY_CHANGED] = [False]
+        preference.notifications[Preferences.TERMS_CHANGED] = [False]
         prefs_to_save.append(preference)
     Preferences.objects.bulk_update(prefs_to_save, ["notifications"])
 
+
 def drop_tou_preference(apps, schema_editor):
     from users.models import Preferences
-    # Preferences = apps.get_model("users", "Preferences")
+
     prefs_to_save = []
     for preference in Preferences.objects.all():
-        del preference.notifications[Preferences.TOU_MATERIALLY_CHANGED]
+        del preference.notifications[Preferences.TERMS_CHANGED]
         prefs_to_save.append(preference)
     Preferences.objects.bulk_update(prefs_to_save, ["notifications"])
 
@@ -25,7 +26,5 @@ class Migration(migrations.Migration):
     dependencies = [
         ("users", "0013_user_indicate_last_login_method"),
     ]
-
-
 
     operations = [migrations.RunPython(populate_tou_preference, drop_tou_preference)]

--- a/users/models.py
+++ b/users/models.py
@@ -346,6 +346,7 @@ def get_empty_notifications():
         Preferences.OWNS_NEWS_APPROVED: [Preferences.NEWS_TYPES_WILDCARD],
         Preferences.OTHERS_NEWS_POSTED: [],
         Preferences.OTHERS_NEWS_NEEDS_MODERATION: [Preferences.NEWS_TYPES_WILDCARD],
+        Preferences.TOU_MATERIALLY_CHANGED: [False],
     }
 
 
@@ -355,6 +356,7 @@ class Preferences(models.Model):
     OWNS_NEWS_APPROVED = "own-news-approved"
     OTHERS_NEWS_POSTED = "others-news-posted"
     OTHERS_NEWS_NEEDS_MODERATION = "others-news-needs-moderation"
+    TOU_MATERIALLY_CHANGED = "tou-materially-changed"
 
     user = models.OneToOneField(
         settings.AUTH_USER_MODEL,
@@ -401,6 +403,16 @@ class Preferences(models.Model):
     @allow_notification_others_news_needs_moderation.setter
     def allow_notification_others_news_needs_moderation(self, value):
         self.change_notification_allowed(self.OTHERS_NEWS_NEEDS_MODERATION, value)
+
+    @property
+    def allow_notification_tou_changed(self) -> bool:
+        return self.notification_allowed(self.TOU_MATERIALLY_CHANGED)[0]
+
+    @allow_notification_tou_changed.setter
+    def allow_notification_tou_changed(self, value):
+        if isinstance(value, bool):
+            value = [value]
+        self.change_notification_allowed(self.TOU_MATERIALLY_CHANGED, value)
 
 
 @receiver(post_save, sender=User)

--- a/users/models.py
+++ b/users/models.py
@@ -346,7 +346,9 @@ def get_empty_notifications():
         Preferences.OWNS_NEWS_APPROVED: [Preferences.NEWS_TYPES_WILDCARD],
         Preferences.OTHERS_NEWS_POSTED: [],
         Preferences.OTHERS_NEWS_NEEDS_MODERATION: [Preferences.NEWS_TYPES_WILDCARD],
-        Preferences.TOU_MATERIALLY_CHANGED: [False],
+        # Terms preference stored as a single-item list for compatability with other
+        # preferences. See special handling in associated property getter and setter.
+        Preferences.TERMS_CHANGED: [False],
     }
 
 
@@ -356,7 +358,7 @@ class Preferences(models.Model):
     OWNS_NEWS_APPROVED = "own-news-approved"
     OTHERS_NEWS_POSTED = "others-news-posted"
     OTHERS_NEWS_NEEDS_MODERATION = "others-news-needs-moderation"
-    TOU_MATERIALLY_CHANGED = "tou-materially-changed"
+    TERMS_CHANGED = "terms-changed"
 
     user = models.OneToOneField(
         settings.AUTH_USER_MODEL,
@@ -405,14 +407,16 @@ class Preferences(models.Model):
         self.change_notification_allowed(self.OTHERS_NEWS_NEEDS_MODERATION, value)
 
     @property
-    def allow_notification_tou_changed(self) -> bool:
-        return self.notification_allowed(self.TOU_MATERIALLY_CHANGED)[0]
+    def allow_notification_terms_changed(self) -> bool:
+        """Note special handling for this single-item preference."""
+        return self.notification_allowed(self.TERMS_CHANGED)[0]
 
-    @allow_notification_tou_changed.setter
-    def allow_notification_tou_changed(self, value):
+    @allow_notification_terms_changed.setter
+    def allow_notification_terms_changed(self, value: bool | list[bool]):
+        """Note special handling for this single-item preference."""
         if isinstance(value, bool):
             value = [value]
-        self.change_notification_allowed(self.TOU_MATERIALLY_CHANGED, value)
+        self.change_notification_allowed(self.TERMS_CHANGED, value)
 
 
 @receiver(post_save, sender=User)

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -179,7 +179,21 @@ def test_preferences(user):
         "own-news-approved": [Preferences.NEWS_TYPES_WILDCARD],
         "others-news-posted": [],
         "others-news-needs-moderation": [Preferences.NEWS_TYPES_WILDCARD],
+        "terms-changed": [False],
     }
+
+
+def test_preferences_set_value_terms(user):
+    notification_type = "terms-changed"
+    attr_name = f"allow_notification_{notification_type.replace('-', '_')}"
+
+    assert user.preferences.notifications[notification_type] == [False]
+    assert getattr(user.preferences, attr_name) is False
+
+    # Opt in
+    setattr(user.preferences, attr_name, True)
+    assert user.preferences.notifications[notification_type] == [True]
+    assert getattr(user.preferences, attr_name) is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #986 

- Adds a new notification preference to the existing `Preferences` model and associated form.
- Adds data migration to populate the new preference
- Adds a new test and modifies several others to reflect the new preference and its behavior

Note the ability to actually send notification will be added post-launch. If the need comes up in the meantime, it would be straightforward to manually trigger a notification to opted-in users.

### Manual testing
UI
<img width="553" alt="Screenshot 2024-11-06 at 9 52 52 AM" src="https://github.com/user-attachments/assets/e7d8ef21-8e21-4fe4-81b0-2e401d10203f">

Data
<img width="478" alt="Screenshot 2024-11-06 at 10 35 11 AM" src="https://github.com/user-attachments/assets/44237931-05dd-4c38-972f-057321c93945">
