### PR TITLE
Keep a list of sublibraries and hide them in reports

### DIFF
--- a/libraries/constants.py
+++ b/libraries/constants.py
@@ -314,6 +314,35 @@ SKIP_LIBRARY_VERSIONS = {
     "identity-type": [{"max_version": "boost-1.49.0"}],
 }
 
+# dict of sub-library: parent
+SUB_LIBRARIES = {
+    "functional/factory": "functional",
+    "functional/forward": "functional",
+    "functional/hash": "functional",
+    "functional/overloaded_function": "functional",
+    "math/common_factor": "math",
+    "math/octonion": "math",
+    "math/quaternion": "math",
+    "math/special_functions": "math",
+    "math/statistical_distributions": "math",
+    "algorithm/minmax": "algorithm",
+    "algorithm/string": "algorithm",
+    "utility/call_traits": "utility",
+    "utility/compressed_pair": "utility",
+    "utility/identity_type": "utility",
+    "utility/in_place_factories": "utility",
+    "utility/operators": "utility",
+    "utility/ostream_string": "utility",
+    "utility/result_of": "utility",
+    "utility/string_ref": "utility",
+    "utility/string_view": "utility",
+    "utility/value_initialized": "utility",
+    "utility/enable_if": "core",
+    "bind/ref": "core",
+    "utility/swap": "core",
+    "bind/mem_fn": "bind",
+}
+
 # List of versions for which we know docs are missing
 VERSION_DOCS_MISSING = ["boost-1.33.0"]
 

--- a/libraries/forms.py
+++ b/libraries/forms.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from core.models import RenderedContent
 from versions.models import Version
 from .models import Commit, CommitAuthor, Issue, Library, LibraryVersion
+from libraries.constants import SUB_LIBRARIES
 from mailing_list.models import EmailData
 
 
@@ -38,7 +39,7 @@ class CreateReportFullForm(Form):
 
     html_template_name = "admin/library_report_full_detail.html"
 
-    library_queryset = Library.objects.all().order_by("name")
+    library_queryset = Library.objects.exclude(key__in=SUB_LIBRARIES).order_by("name")
     library_1 = ModelChoiceField(
         queryset=library_queryset,
         required=False,
@@ -94,11 +95,9 @@ class CreateReportFullForm(Form):
         return f"full-report-{lib_string}"
 
     def _get_top_libraries(self):
-        return (
-            Library.objects.all()
-            .annotate(commit_count=Count("library_version__commit"))
-            .order_by("-commit_count")[:5]
-        )
+        return self.library_queryset.annotate(
+            commit_count=Count("library_version__commit")
+        ).order_by("-commit_count")[:5]
 
     def _get_library_order(self, top_libraries):
         library_order = [
@@ -132,7 +131,14 @@ class CreateReportFullForm(Form):
     def _get_top_contributors_overall(self):
         return (
             CommitAuthor.objects.all()
-            .annotate(commit_count=Count("commit"))
+            .annotate(
+                commit_count=Count(
+                    "commit",
+                    filter=Q(
+                        commit__library_version__library__in=self.library_queryset
+                    ),
+                )
+            )
             .values("name", "avatar_url", "commit_count", "github_profile_url")
             .order_by("-commit_count")[:10]
         )
@@ -157,7 +163,9 @@ class CreateReportFullForm(Form):
         return top_contributors_library
 
     def get_stats(self):
-        commit_count = Commit.objects.count()
+        commit_count = Commit.objects.filter(
+            library_version__library__in=self.library_queryset
+        ).count()
 
         top_libraries = self._get_top_libraries()
         library_order = self._get_library_order(top_libraries)
@@ -189,7 +197,7 @@ class CreateReportFullForm(Form):
             "top_contributors": top_contributors,
             "library_data": library_data,
             "top_libraries": top_libraries,
-            "library_count": Library.objects.all().count(),
+            "library_count": self.library_queryset.count(),
         }
 
     def cache_html(self):
@@ -254,14 +262,21 @@ class CreateReportForm(CreateReportFullForm):
             CommitAuthor.objects.filter(
                 commit__library_version__version=self.cleaned_data["version"]
             )
-            .annotate(commit_count=Count("commit"))
+            .annotate(
+                commit_count=Count(
+                    "commit",
+                    filter=Q(
+                        commit__library_version__library__in=self.library_queryset
+                    ),
+                )
+            )
             .values("name", "avatar_url", "commit_count", "github_profile_url")
             .order_by("-commit_count")[:10]
         )
 
     def _get_top_libraries_for_version(self):
         return (
-            Library.objects.filter(
+            self.library_queryset.filter(
                 library_version=LibraryVersion.objects.filter(
                     library=OuterRef("id"), version=self.cleaned_data["version"]
                 )[:1],
@@ -357,7 +372,7 @@ class CreateReportForm(CreateReportFullForm):
             version__in=version_lte,
             library=OuterRef("id"),
         ).values("id")
-        qs = Library.objects.aggregate(
+        qs = self.library_queryset.aggregate(
             this_release_count=Count(
                 "library_version__commit__author",
                 filter=Q(library_version__version=version),
@@ -494,17 +509,22 @@ class CreateReportForm(CreateReportFullForm):
         )
 
         commit_count = Commit.objects.filter(
-            library_version__version__name__lte=version.name
+            library_version__version__name__lte=version.name,
+            library_version__library__in=self.library_queryset,
         ).count()
         version_commit_count = Commit.objects.filter(
-            library_version__version=version
+            library_version__version=version,
+            library_version__library__in=self.library_queryset,
         ).count()
 
         top_libraries_for_version = self._get_top_libraries_for_version()
         library_order = self._get_library_order(top_libraries_for_version)
         libraries = Library.objects.filter(id__in=library_order)
         library_names = (
-            LibraryVersion.objects.filter(version=version)
+            LibraryVersion.objects.filter(
+                version=version,
+                library__in=self.library_queryset,
+            )
             .annotate(name=F("library__name"))
             .order_by("name")
             .values_list("name", flat=True)
@@ -547,29 +567,43 @@ class CreateReportForm(CreateReportFullForm):
             commit_contributors_release_count,
             commit_contributors_new_count,
         ) = self._count_commit_contributors_totals(version)
-        library_count = LibraryVersion.objects.filter(version=version).count()
+        library_count = LibraryVersion.objects.filter(
+            version=version,
+            library__in=self.library_queryset,
+        ).count()
         if prior_version:
             library_count_prior = LibraryVersion.objects.filter(
-                version=prior_version
+                version=prior_version,
+                library__in=self.library_queryset,
             ).count()
         else:
             library_count_prior = 0
 
         added_library_count = max(0, library_count - library_count_prior)
         removed_library_count = max(0, library_count_prior - library_count)
-        lines_added = LibraryVersion.objects.filter(version=version).aggregate(
-            lines=Sum("insertions")
-        )["lines"]
-        lines_removed = LibraryVersion.objects.filter(version=version).aggregate(
-            lines=Sum("deletions")
-        )["lines"]
+        lines_added = LibraryVersion.objects.filter(
+            version=version,
+            library__in=self.library_queryset,
+        ).aggregate(lines=Sum("insertions"))["lines"]
+        lines_removed = LibraryVersion.objects.filter(
+            version=version,
+            library__in=self.library_queryset,
+        ).aggregate(lines=Sum("deletions"))["lines"]
         return {
             "lines_added": lines_added,
             "lines_removed": lines_removed,
             "wordcloud_base64": self._generate_hyperkitty_word_cloud(version),
             "version": version,
-            "opened_issues_count": Issue.objects.opened_during_release(version).count(),
-            "closed_issues_count": Issue.objects.closed_during_release(version).count(),
+            "opened_issues_count": Issue.objects.filter(
+                library__in=self.library_queryset
+            )
+            .opened_during_release(version)
+            .count(),
+            "closed_issues_count": Issue.objects.filter(
+                library__in=self.library_queryset
+            )
+            .closed_during_release(version)
+            .count(),
             "mailinglist_counts": mailinglist_counts,
             "mailinglist_total": total_mailinglist_count or 0,
             "mailinglist_contributor_release_count": mailinglist_contributor_release_count,  # noqa: E501


### PR DESCRIPTION
- fixes #1398
- alter queries in report forms to ignore sublibraries where necessary.