### PR TITLE
Send individual emails to each notified user

### DIFF
--- a/news/notifications.py
+++ b/news/notifications.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.core.mail import EmailMessage, send_mail
+from django.core.mail import EmailMessage, get_connection, send_mail
 from django.template import Template, Context
 from django.urls import reverse
 from django.utils.safestring import mark_safe
@@ -113,9 +113,13 @@ def send_email_news_posted(request, entry):
         )
     )
     subject = "Boost.org: News entry posted"
-    return EmailMessage(
-        subject=subject,
-        body=body,
-        from_email=None,
-        bcc=recipient_list,
-    ).send()
+    messages = [
+        EmailMessage(
+            subject=subject,
+            body=body,
+            from_email=None,
+            to=[user_email],
+        )
+        for user_email in recipient_list
+    ]
+    return get_connection().send_messages(messages)


### PR DESCRIPTION
Fixes #1428

Previously, we sent a single email with all recipients in the `bcc` field, and no one in the `to` field. Mailgun does not support this.

This PR changes that behavior to send an email to each user using Django's `send_messages` (plural) method.

Note: I wasn't able to confirm this in the Mailgun documentation, but I assume this should not have any cost implications. Sending a "single" email with 100 `bcc` recipients should cost the same as sending 100 emails each with a single `to` recipient.

Another note: I did not test performance of this with many recipients. Probably all of our notification emails should be getting sent in a Celery task... probably a future optimization.