### PR TITLE
Add the HYPERKITTY_DATABASE_URL environment variable

### DIFF
--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -199,6 +199,11 @@ Env:
       secretKeyRef:
         name: githubtoken
         key: key
+  - name: HYPERKITTY_DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: hyperkitty
+        key: database_url
   # Static content cache timeout
   - name: STATIC_CACHE_TIMEOUT
     value: "60"

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -199,6 +199,11 @@ Env:
       secretKeyRef:
         name: githubtoken
         key: key
+  - name: HYPERKITTY_DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: hyperkitty
+        key: database_url
   # Static content cache timeout
   - name: STATIC_CACHE_TIMEOUT
     value: "60"

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -199,6 +199,11 @@ Env:
       secretKeyRef:
         name: githubtoken
         key: key
+  - name: HYPERKITTY_DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: hyperkitty
+        key: database_url
   # Static content cache timeout
   - name: STATIC_CACHE_TIMEOUT
     value: "60"

--- a/kube/boost/values.yaml
+++ b/kube/boost/values.yaml
@@ -179,6 +179,11 @@ Env:
       secretKeyRef:
         name: githubtoken
         key: key
+  - name: HYPERKITTY_DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: hyperkitty
+        key: database_url
   # Static content cache timeout
   - name: STATIC_CACHE_TIMEOUT
     value: "60"


### PR DESCRIPTION
- fixes #1434
- stat collection on the mailing list requires a direct connection to the hyperkitty archive database.