### PR TITLE
Draft: Render markdown by converting through asciidoc with pandoc

### DIFF
--- a/core/tests/test_asciidoc.py
+++ b/core/tests/test_asciidoc.py
@@ -1,10 +1,11 @@
+import textwrap
 from os import getcwd, makedirs
 from unittest.mock import patch
 
 import pytest
 
 
-from core.asciidoc import convert_adoc_to_html
+from core.asciidoc import convert_adoc_to_html, convert_md_to_html
 
 
 def test_convert_adoc_to_html_subprocess():
@@ -40,3 +41,37 @@ def test_convert_adoc_to_html_content_file():
         makedirs("/tmp/asciidocs", exist_ok=True)
         open("/tmp/asciidocs/tmp.html", "w").write(output)
     assert output == expected_output
+
+
+@pytest.mark.asciidoctor
+def test_convert_md_to_html():
+    input = textwrap.dedent(
+        """
+        header
+        header
+        ------
+        text
+        """
+    )
+    output = textwrap.dedent(
+        """
+        <div class="sect1">
+        <h2 id="_header_header">header header</h2>
+        <div class="sectionbody">
+        <div class="paragraph">
+        <p>text</p>
+        </div>
+        </div>
+        </div>
+        """
+    )
+
+    assert convert_md_to_html(input).strip() == output.strip()
+
+
+@pytest.mark.asciidoctor
+def test_convert_md_to_html_huge_input():
+    """
+    Make sure we don't run into pipe buffering issues with large inputs.
+    """
+    convert_md_to_html("asdf\n" * 500000)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN yarn build
 # Final image.
 FROM python:3.11-slim AS release
 
-RUN apt update && apt install -y git libpq-dev ruby ruby-dev && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y git libpq-dev ruby ruby-dev pandoc && rm -rf /var/lib/apt/lists/*
 
 # Install Asciidoctor
 RUN gem install asciidoctor asciidoctor-boost

--- a/libraries/models.py
+++ b/libraries/models.py
@@ -10,13 +10,12 @@ from django.utils.text import slugify
 from django.db.models.functions import Upper
 
 from core.htmlhelper import get_release_notes_for_library_version
-from core.markdown import process_md
 from core.models import RenderedContent
-from core.asciidoc import convert_adoc_to_html
+from core.asciidoc import convert_adoc_to_html, convert_md_to_html
 from libraries.managers import IssueManager
 from mailing_list.models import EmailData
 
-from .utils import generate_random_string, write_content_to_tempfile
+from .utils import generate_random_string
 
 
 class Category(models.Model):
@@ -278,8 +277,7 @@ class Library(models.Model):
                 if file_path.endswith(".adoc"):
                     body_content = convert_adoc_to_html(content.decode("utf-8"))
                 else:
-                    temp_file = write_content_to_tempfile(content)
-                    _, body_content = process_md(temp_file.name)
+                    body_content = convert_md_to_html(content.decode("utf-8"))
                 static_content_cache.set(cache_key, body_content)
                 RenderedContent.objects.update_or_create(
                     cache_key=cache_key,


### PR DESCRIPTION
Use pandoc to convert markdown to asciidoc, then convert the asciidoc to html using asciidoctor.

This has what I consider to be a blocking bug that would only be fixable in the upstream pandoc. Whenever there are multiple instances of `++` on the same line, asciidoc interprets the text in between pairs of `++` to be a ["inline passthrough"](https://docs.asciidoctor.org/asciidoc/latest/pass/pass-macro/#single-double-plus). This makes it [hard to use asciidoc to talk about C++, requiring special workarounds](https://github.com/asciidoctor/asciidoctor/issues/1208).

This mangles, for example, the [atomic readme](https://www.stage.boost.cppalliance.org/libraries/atomic/).

Correct, current rendering:
![image](https://github.com/user-attachments/assets/fe92a55b-63ae-4eaf-8fd0-7664aaae8d05)
Incorrect, rendering in this PR:
![image](https://github.com/user-attachments/assets/c7779467-7899-4f8f-9b86-d2b253523b2b)
Notice how the link text is not correct and it says `C` and `C11` instead of `C++` and `C++11`.

Here is a minimal repro using the editor at asciidoc.org:
![image](https://github.com/user-attachments/assets/d9be03d6-3541-4787-b667-b9908457974e)

It is probably a bug in pandoc that the `++`  are not getting escaped. There are multiple open issues in pandoc around weird asciidoc escaping that seem similar, for example https://github.com/jgm/pandoc/issues/2337. We could consider trying to fix the issue in pandoc, but it'd probably take me at least several days to understand the code.

To see the results on staging, someone will have to clear the rendered content cache. Alternatively, I could change the cache key used for rendered readmes.

Fixes #1328