### PR TITLE
Use the title of the news entry itself for the page title

### DIFF
--- a/templates/news/detail.html
+++ b/templates/news/detail.html
@@ -3,7 +3,7 @@
 {% load static %}
 {% load text_helpers %}
 
-{% block title %}{% trans "News" %}{% endblock %}
+{% block title %}{{ entry.title }}{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
Fixes #1427