### PR TITLE
Associate the TOS label with its field

### DIFF
--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -49,6 +49,7 @@
             id="readTOS"
             onclick="accepted()"
           />
+          <label for="readTOS">
           I have read and accepted the
           <a
             href="terms-of-use"
@@ -58,6 +59,7 @@
             >Terms of Use</a
           >
           for this service.
+          </label>
         </p>
       </div>
       <div id="jsfallback" class="flex justify-center w-full pb-1">


### PR DESCRIPTION
This allows clicking the label to select the checkbox and is also good for screenreaders.