### PR TITLE
Fall back to _x filename for beta release notes

### DIFF
--- a/core/boostrenderer.py
+++ b/core/boostrenderer.py
@@ -138,7 +138,7 @@ def get_file_data(client, bucket_name, s3_key):
         response = client.get_object(Bucket=bucket_name, Key=s3_key.lstrip("/"))
         return extract_file_data(response, s3_key)
     except ClientError as e:
-        # Log the exception but ignore it otherwise, since it's not necessaruly an error
+        # Log the exception but ignore it otherwise, since it's not necessarily an error
         logger.exception(
             "get_content_from_s3_error",
             s3_key=s3_key,

--- a/versions/releases.py
+++ b/versions/releases.py
@@ -168,6 +168,9 @@ def get_artifactory_download_data(url):
 
 def get_release_notes_for_version_s3(version_pk):
     """Retrieve the adoc release notes from S3 and return the converted html string"""
+    # TODO: this and the github function have duplication (including of this comment!),
+    #  and are not extensible if we encounter additional filename patterns in the
+    #  future; we should refactor.
     try:
         version = Version.objects.get(pk=version_pk)
     except Version.DoesNotExist:
@@ -201,6 +204,9 @@ def get_release_notes_for_version_github(version_pk):
 
     We retrieve the rendered release notes for older versions.
     """
+    # TODO: this and the S3 function have duplication (including of this comment!),
+    #  and are not extensible if we encounter additional filename patterns in the
+    #  future; we should refactor.
     try:
         version = Version.objects.get(pk=version_pk)
     except Version.DoesNotExist:


### PR DESCRIPTION
Follow-up fix for #1171 

It turns out the newest beta release notes have been named `version_1_87_x.html` instead of the expected `version_1_87_0.html` name. This PR creates a fallback strategy that first attempts the `_0` filename, then tries `_x` if the former results in a 404 response.

### Manual testing

I wasn't able to successfully test the S3 version of the function, since the beta release notes do not yet appear to be in S3.

For the GitHub version, I added a print statement for debug purposes to indicate we were hitting the fallback url with the `_x` filename suffix.

```python
In [1]: v = Version.objects.last()

In [2]: v.slug
Out[2]: 'boost-1-87-0-beta1'

In [3]: from versions.releases import get_release_notes_for_version_github

In [4]: html = get_release_notes_for_version_github(v.pk)
normal url failed; trying fallback

In [5]: html[:100]
Out[5]: b'<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"\n    "http://www.w3.org/TR/xhtml1/DTD/xhtml1'