### PR TITLE
Don't skip beta releases when fetching release notes

### DIFF
--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -73,7 +73,7 @@ def import_versions(
 def import_release_notes():
     """Imports release notes from the existing rendered
     release notes in the repository."""
-    for version in Version.objects.active().filter(full_release=True):
+    for version in Version.objects.active():
         store_release_notes_task.delay(str(version.pk))
     store_release_notes_in_progress_task.delay()
 


### PR DESCRIPTION
We were skipping beta releases when fetching release notes. This PR removes that filter.

I was able to actually import the release notes for 1.87.x locally:

![Screenshot 2024-11-18 at 2 56 33 PM](https://github.com/user-attachments/assets/66a44feb-234c-4862-abbc-69e6027e71bb)
