### PR TITLE
Remove per library release notes from release report.

### DIFF
--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -2,7 +2,6 @@ from bs4 import BeautifulSoup, Comment
 from django.template.loader import render_to_string
 
 from core.boostrenderer import get_body_from_html
-from core.models import RenderedContent
 
 
 # List HTML elements (with relevant attributes) to remove the FIRST occurrence
@@ -611,29 +610,3 @@ def modernize_release_notes(html_content):
     # Replace all links to boost.org with a local link
     content = result.replace("https://www.boost.org/doc/libs/", "/docs/libs/")
     return get_body_from_html(content)
-
-
-def get_release_notes_for_library_version(library_version):
-    """Attempts to find the release notes for specific library."""
-    html = None
-    try:
-        rendered_content = RenderedContent.objects.get(
-            cache_key=library_version.version.release_notes_cache_key
-        )
-        html = rendered_content.content_html
-    except RenderedContent.DoesNotExist:
-        pass
-    if not html:
-        return ""
-    soup = BeautifulSoup(html, "html.parser")
-    match = soup.find("a", text=library_version.library.name)
-    if not match:
-        return ""
-    release_notes = match.parent
-    if not release_notes:
-        return ""
-    ul = release_notes.find("ul")
-    if not ul:
-        return ""
-    points = ul.find_all("li", recursive=False)
-    return "".join(str(x) for x in points)

--- a/libraries/models.py
+++ b/libraries/models.py
@@ -9,7 +9,6 @@ from django.utils.functional import cached_property
 from django.utils.text import slugify
 from django.db.models.functions import Upper
 
-from core.htmlhelper import get_release_notes_for_library_version
 from core.markdown import process_md
 from core.models import RenderedContent
 from core.asciidoc import convert_adoc_to_html
@@ -392,10 +391,6 @@ class LibraryVersion(models.Model):
             raise ValueError("Invalid data for library version")
 
         return f"{self.library.github_url}/tree/{self.version.name}"
-
-    @cached_property
-    def get_release_notes(self):
-        return get_release_notes_for_library_version(self)
 
     def get_cpp_standard_minimum_display(self):
         """Returns the display name for the C++ standard, or the value if not found.

--- a/templates/admin/release_report_detail.html
+++ b/templates/admin/release_report_detail.html
@@ -157,14 +157,6 @@
             </div>
           </div>
         </div>
-        {% if item.library_version.get_release_notes %}
-          <div class="pdf-page {{ bg_color }} release-notes-page">
-            <h3>{{ item.library.name }} Release Notes <span class="continued"></span></h3>
-            <div class="flex flex-col flex-wrap px-2 gap-x-4 text-xs h-[90%] w-1/2 release-notes-content">
-              {{ item.library_version.get_release_notes|safe }}
-            </div>
-          </div>
-        {% endif %}
       {% endfor %}
     </div>
     <div class="pdf-page {{ bg_color }}" style="page-break-after: avoid;">This is the last page</div>
@@ -226,57 +218,6 @@
       };
       const chart = new ApexCharts(document.querySelector("#top-committed-libraries-chart"), options);
       chart.render();
-    </script>
-
-    <script>
-      // Release notes can sometimes be too long for a single page.
-      // Logic for dynamically creating new pages for release notes based on content length.
-      // Iterates through bullet top level `li` elements and appends them until overflow,
-      //   creates a new page, and continues...
-      function getSides(element) {
-        const right = element.offsetLeft + element.offsetWidth;
-        const bottom = element.offsetTop + element.offsetHeight;
-        return {top: element.offsetTop, left: element.offsetLeft, right, bottom}
-      }
-
-      function cloneReleaseNotesPage(page) {
-        newPage = page.cloneNode(true);
-        newPage.querySelector(".release-notes-content").innerHTML = "";
-        newPage.querySelector(".continued").textContent = "(continued)"
-        page.parentNode.insertBefore(newPage, page.nextSibling);
-        return newPage
-      }
-
-      function fixReleaseNotes(page) {
-        let pageSize = getSides(page);
-        let insertIntoPage = 0;
-        let contents = page.querySelector(".release-notes-content");
-        const elements = contents.querySelectorAll(":scope > li");
-        contents.innerHTML = "";
-        for (let i=0; i<elements.length; i++) {
-          const el = elements[i];
-          contents.appendChild(el);
-          let size = getSides(el);
-          if (size.bottom > pageSize.bottom || size.right > pageSize.right) {
-            // we went too far, remove the element and add it to a new page
-            contents.removeChild(el);
-            page = cloneReleaseNotesPage(page);
-            contents = page.querySelector(".release-notes-content");
-            pageSize = getSides(page);
-            if (insertIntoPage > 0) {
-              i--;
-            }
-            insertIntoPage = 0;
-          } else {
-            insertIntoPage++;
-          }
-        }
-      }
-      document.addEventListener("DOMContentLoaded", function() {
-        for (const element of document.querySelectorAll(".release-notes-page")) {
-          fixReleaseNotes(element);
-        }
-      })
     </script>
   {% endwith %}
 {% endblock content %}


### PR DESCRIPTION
- Also delete related per library release notes parsing functions, these functions are specific to the HTML version of the release notes which will be replaced by an adoc version in the near future. If per library release notes are needed in the future, these functions will need to be reimplemented anyway.
- fixes #1470