### PR TITLE
Added styling for disabled state on select dropdowns (#1316)

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -3,6 +3,15 @@
 @tailwind utilities;
 
 @layer base {
+  .text-slate {
+    @apply text-slate-500;
+  }
+  .border-slate {
+    @apply border-slate-500;
+  }
+  .bg-slate {
+    @apply bg-slate-500;
+  }
   [x-cloak] {
     display: none !important;
   }
@@ -89,7 +98,7 @@
   }
 
   select.dropdown {
-    @apply py-1 mb-3 h-[38px] min-w-[8rem] text-sm bg-white rounded-md border border-gray-300 cursor-pointer dark:bg-black text-sky-600 dark:text-orange dark:border-slate;
+    @apply py-1 mb-3 h-[38px] min-w-[8rem] text-sm bg-white rounded-md border border-gray-300 cursor-pointer dark:bg-black text-sky-600 dark:text-sky-300 dark:border-slate disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-300 dark:disabled:text-slate-700 dark:disabled:border-slate-700;
   }
 
   .errorlist {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,19 @@ module.exports = {
       silver: '#B5C9D3',
     },
     extend: {
+      colors: {
+        slate: {
+          100: '#C2D8E2',
+          200: '#A1C2D0',
+          300: '#7FACBE',
+          400: '#5F96AC',
+          500: '#314A57',
+          600: '#2A404F',
+          700: '#233847',
+          800: '#1C2C3F',
+          900: '#151E37',
+        }
+      },
       fontFamily: {
         'sans': [
           '"Noto Sans"',

--- a/templates/libraries/includes/library_preferences.html
+++ b/templates/libraries/includes/library_preferences.html
@@ -29,9 +29,9 @@
         <div>
           <select
             name="category"
-            class="block py-2 pr-11 pl-5 mb-3 w-full text-sm bg-white rounded-md border border-gray-300 cursor-pointer sm:inline-block md:mb-0 ml-3 md:ml-0 md:w-auto dark:bg-black dark:border-slate disabled:dark:"
+            class="dropdown"
             id="id_category"
-            {% if library_view_str == 'categorized' %}disabled="disabled"{% endif %}
+            {% if library_view_str == "categorized" %}disabled="disabled"{% endif %}
           >
 
             <option value="">Filter by category</option>


### PR DESCRIPTION
This is adding the styling to match with changes in the #1489 PR which changes the template to display but disable the dropdown on the categorized listing page. It will appear as:

@rbbeeston the category selection dropdown will now appear with text with the same orange as the version dropdown. Let me know if you want that changed or prefer them to be consistent. 

Enabled dark/light:
![enabled-dark](https://github.com/user-attachments/assets/d7208463-484e-4bc4-8260-a8b8b432b820)
![enabled-light](https://github.com/user-attachments/assets/348afb7d-9576-4ced-a079-ff29aceea64e)

Disabled dark/light:
![disabled-dark](https://github.com/user-attachments/assets/cb79d00f-edf8-49b5-bed1-dfba5f8fdaa3)
![disabled-light](https://github.com/user-attachments/assets/cdf59ff3-a143-49f3-98f3-91d5b95c95c5)
