### PR TITLE
Add version number parenthetical to Latest option and DRY up template

### DIFF
--- a/templates/partials/version_select.html
+++ b/templates/partials/version_select.html
@@ -7,7 +7,7 @@
     >
         <option value="{{ LATEST_RELEASE_URL_PATH_STR }}"
                 {% if version_str == LATEST_RELEASE_URL_PATH_STR %}selected="selected"{% endif %}>
-            Latest
+            Latest ({{ versions.first.display_name }})
         </option>
         {% for v in versions %}
             <option value="{{ v.slug|boost_version }}"


### PR DESCRIPTION
Fixes #1486 

- Added version number parenthetical in `version_dropdown.html` partial
- Changed version detail template to use this partial instead of duplicating it

![Screenshot 2024-11-25 at 1 50 38 PM](https://github.com/user-attachments/assets/2fee007b-5d50-44ad-9e77-c60d3a2d6645)