### PR TITLE
Fix Latest dropdown option when beta version present

### DIFF
--- a/templates/partials/version_select.html
+++ b/templates/partials/version_select.html
@@ -7,7 +7,7 @@
     >
         <option value="{{ LATEST_RELEASE_URL_PATH_STR }}"
                 {% if version_str == LATEST_RELEASE_URL_PATH_STR %}selected="selected"{% endif %}>
-            Latest ({{ versions.first.display_name }})
+            Latest ({{ current_version.display_name }})
         </option>
         {% for v in versions %}
             <option value="{{ v.slug|boost_version }}"


### PR DESCRIPTION
I missed a visual bug that occurs when there is a beta release in the dropdown (I hadn't imported the beta version locally).

This uses the globally available context object `current_version`, which is nicer than the prior implementation anyway.

![Screenshot 2024-11-25 at 4 56 49 PM](https://github.com/user-attachments/assets/c1520f93-4f86-4b93-9a92-bcc86db6cf15)
