### PR TITLE
Consolidate version dropdown code and fix library detail dropdown

### DIFF
--- a/libraries/forms.py
+++ b/libraries/forms.py
@@ -28,18 +28,6 @@ class LibraryForm(ModelForm):
         fields = ["categories"]
 
 
-class VersionSelectionForm(Form):
-    version = ModelChoiceField(
-        queryset=None,  # populated in __init__
-        label="Select a version",
-        empty_label="Choose a version...",
-    )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["version"].queryset = Version.objects.version_dropdown_strict()
-
-
 class CreateReportFullForm(Form):
     """Form for creating a report over all releases."""
 

--- a/libraries/forms.py
+++ b/libraries/forms.py
@@ -29,13 +29,17 @@ class LibraryForm(ModelForm):
 
 
 class VersionSelectionForm(Form):
-    queryset = Version.objects.version_dropdown_strict().defer("data")
-
     version = ModelChoiceField(
-        queryset=queryset,
+        queryset=None,
         label="Select a version",
         empty_label="Choose a version...",
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields[
+            "version"
+        ].queryset = Version.objects.version_dropdown_strict().defer("data")
 
 
 class CreateReportFullForm(Form):

--- a/libraries/forms.py
+++ b/libraries/forms.py
@@ -29,8 +29,7 @@ class LibraryForm(ModelForm):
 
 
 class VersionSelectionForm(Form):
-    queryset = Version.objects.active().defer("data")
-    queryset = queryset.exclude(name__in=["develop", "master", "head"])
+    queryset = Version.objects.version_dropdown_strict().defer("data")
 
     version = ModelChoiceField(
         queryset=queryset,

--- a/libraries/forms.py
+++ b/libraries/forms.py
@@ -30,16 +30,14 @@ class LibraryForm(ModelForm):
 
 class VersionSelectionForm(Form):
     version = ModelChoiceField(
-        queryset=None,
+        queryset=None,  # populated in __init__
         label="Select a version",
         empty_label="Choose a version...",
     )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields[
-            "version"
-        ].queryset = Version.objects.version_dropdown_strict().defer("data")
+        self.fields["version"].queryset = Version.objects.version_dropdown_strict()
 
 
 class CreateReportFullForm(Form):

--- a/libraries/tests/test_forms.py
+++ b/libraries/tests/test_forms.py
@@ -1,21 +1,6 @@
-from ..forms import LibraryForm, VersionSelectionForm
+from ..forms import LibraryForm
 
 
 def test_library_form_success(tp, library, category):
     form = LibraryForm(data={"categories": [category]})
     assert form.is_valid() is True
-
-
-def test_version_selection_form(library_version):
-    # Test with a valid version
-    valid_version = library_version.version
-    form = VersionSelectionForm(data={"version": valid_version.pk})
-    assert form.is_valid()
-
-    # Test with an invalid version
-    form = VersionSelectionForm(data={"version": 9999})
-    assert form.is_valid() is False
-
-    # Test with no version selected
-    form = VersionSelectionForm(data={"version": None})
-    assert form.is_valid() is False

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -10,13 +10,11 @@ from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import DetailView, ListView
-from django.views.generic.edit import FormMixin
 
 from core.githubhelper import GithubAPIClient
 from versions.models import Version
 
 from .constants import README_MISSING
-from .forms import VersionSelectionForm
 from .mixins import VersionAlertMixin, BoostVersionMixin
 from .models import (
     Category,
@@ -234,10 +232,9 @@ class LibraryCategorized(LibraryListBase):
 
 
 @method_decorator(csrf_exempt, name="dispatch")
-class LibraryDetail(FormMixin, VersionAlertMixin, BoostVersionMixin, DetailView):
+class LibraryDetail(VersionAlertMixin, BoostVersionMixin, DetailView):
     """Display a single Library in insolation"""
 
-    form_class = VersionSelectionForm
     model = Library
     template_name = "libraries/detail.html"
     redirect_to_docs = False

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -247,8 +247,8 @@ class LibraryDetail(FormMixin, VersionAlertMixin, BoostVersionMixin, DetailView)
         context = super().get_context_data(**kwargs)
         # Get fields related to Boost versions
         context["versions"] = (
-            self.get_form()
-            .queryset.filter(library_version__library=self.object)
+            Version.objects.version_dropdown_strict()
+            .filter(library_version__library=self.object)
             .distinct()
         )
         context["LATEST_RELEASE_URL_PATH_NAME"] = LATEST_RELEASE_URL_PATH_STR

--- a/versions/managers.py
+++ b/versions/managers.py
@@ -105,7 +105,7 @@ class VersionManager(models.Manager):
         if exclude_branches:
             queryset = queryset.exclude(name__in=["develop", "master", "head"])
 
-        return queryset.order_by("-name")
+        return queryset.order_by("-name").defer("data")
 
     def version_dropdown_strict(self, *, exclude_branches=True):
         """Returns the versions to be shown in the drop-down, but does not include

--- a/versions/views.py
+++ b/versions/views.py
@@ -30,7 +30,6 @@ class VersionDetail(FormMixin, BoostVersionMixin, VersionAlertMixin, DetailView)
 
     form_class = VersionSelectionForm
     model = Version
-    queryset = Version.objects.active().defer("data")
     template_name = "versions/detail.html"
 
     def get_context_data(self, **kwargs):
@@ -51,7 +50,7 @@ class VersionDetail(FormMixin, BoostVersionMixin, VersionAlertMixin, DetailView)
             context["is_current_release"] = False
             return context
 
-        context["versions"] = Version.objects.version_dropdown_strict()
+        context["versions"] = self.get_form().queryset
         downloads = obj.downloads.all().order_by("operating_system")
         context["downloads"] = {
             k: list(v)

--- a/versions/views.py
+++ b/versions/views.py
@@ -50,7 +50,7 @@ class VersionDetail(FormMixin, BoostVersionMixin, VersionAlertMixin, DetailView)
             context["is_current_release"] = False
             return context
 
-        context["versions"] = self.get_form().queryset
+        context["versions"] = Version.objects.version_dropdown_strict()
         downloads = obj.downloads.all().order_by("operating_system")
         context["downloads"] = {
             k: list(v)

--- a/versions/views.py
+++ b/versions/views.py
@@ -4,7 +4,6 @@ from operator import attrgetter
 
 from django.db.models import Q, Count
 from django.views.generic import DetailView, TemplateView, ListView
-from django.views.generic.edit import FormMixin
 from django.shortcuts import redirect, get_object_or_404
 from django.contrib import messages
 from django.conf import settings
@@ -13,7 +12,6 @@ from django.views.decorators.csrf import csrf_exempt
 
 from core.models import RenderedContent
 from libraries.constants import LATEST_RELEASE_URL_PATH_STR
-from libraries.forms import VersionSelectionForm
 from libraries.mixins import VersionAlertMixin, BoostVersionMixin
 from libraries.models import Commit, CommitAuthor
 from libraries.utils import (
@@ -25,10 +23,9 @@ from versions.models import Review, Version
 
 
 @method_decorator(csrf_exempt, name="dispatch")
-class VersionDetail(FormMixin, BoostVersionMixin, VersionAlertMixin, DetailView):
+class VersionDetail(BoostVersionMixin, VersionAlertMixin, DetailView):
     """Web display of list of Versions"""
 
-    form_class = VersionSelectionForm
     model = Version
     template_name = "versions/detail.html"
 


### PR DESCRIPTION
Fixes #1488 

- DRY up various pieces of code getting version queryset for dropdown
- This eliminated the special exclusion of the latest beta from the library detail page

![Screenshot 2024-11-26 at 3 32 36 PM](https://github.com/user-attachments/assets/eba0b5bf-d85c-4adc-ba94-eae240a64fe1)
