### PR TITLE
Fix report crash issue

### DIFF
--- a/libraries/admin.py
+++ b/libraries/admin.py
@@ -147,12 +147,7 @@ class ReleaseReportView(TemplateView):
             return [self.form_template]
         if form.cleaned_data["no_cache"]:
             return [self.form_template]
-        content = form.cache_get()
-        if content:
-            if not content.content_html:
-                return [self.polling_template]
-        else:
-            return [self.polling_template]
+        return [self.polling_template]
 
     def get_form(self):
         data = None

--- a/libraries/forms.py
+++ b/libraries/forms.py
@@ -562,7 +562,11 @@ class CreateReportForm(CreateReportFullForm):
                 Graph.weeks.days.
 
                 """
-                high = self.max
+                if not (high := self.max):
+                    # No commits this release
+                    # TODO: we may want a more elegant solution
+                    #  than just not graphing this library
+                    return
                 for week in self.weeks:
                     for day in week.days:
                         decimal = day.count / high


### PR DESCRIPTION
1. Skips graphing commits for library with no commits in the given release
2. Ensures a template is always returned for the report view