### PR TITLE
Fix issue with slack stats sorting in report

### DIFF
--- a/libraries/forms.py
+++ b/libraries/forms.py
@@ -612,7 +612,7 @@ class CreateReportForm(CreateReportFullForm):
             )
             channel_stat["channel"] = channel
             stats.append(channel_stat)
-        stats.sort(key=lambda x: -x["total"])
+        stats.sort(key=lambda x: -(x["total"] or 0))  # Convert None to 0
         return stats
 
     def _get_slack_stats_for_channels(


### PR DESCRIPTION
This is a "blind" fix since I cannot reproduce this locally. Seems like it should fix the crash I'm seeing in the logs though.

![image](https://github.com/user-attachments/assets/190f1e2f-2143-4843-9b36-1f2ab0892201)