### PR TITLE
Add missing redirect

### DIFF
--- a/kube/boost/templates/configmap-nginx.yaml
+++ b/kube/boost/templates/configmap-nginx.yaml
@@ -108,6 +108,7 @@ data:
       location = /community/requests.html { return 301 /community/; }
       location = /community/reviews.html { return 301 /review/; }
       location = /community/review_schedule.html { return 301 /review/past/; }
+      location = /development/index.html { return 301 /doc/contributor-guide/index.html; }
       location = /development/submissions.html { return 301 /review/; }
       location = /development/bugs.html { return 301 /doc/user-guide/reporting-issues.html; }
       location = /development/pull_requests.php { return 301 $scheme://$host; }


### PR DESCRIPTION
Fixes #1514 

Turns out nearly every url was being redirected correctly already. There was one missing. This PR adds it.