### PR TITLE
remove unnecessary styles for libraryReadMe header links

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -111,9 +111,6 @@
   #libraryReadMe h1 {
     @apply text-3xl font-semibold border-b border-gray-300 dark:border-slate;
   }
-  #libraryReadMe h1 a {
-    @apply float-right inline-block mx-2;
-  }
   #libraryReadMe h2 {
     @apply mt-3 text-2xl font-semibold border-b border-gray-300 dark:border-slate;
   }


### PR DESCRIPTION
- removes the right-aligned heading 
- addresses issue https://github.com/boostorg/boostlook/issues/42

Preview:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/46ca0a4d-5811-4f0d-a727-8ddbdbbc4424">
