### PR TITLE
Make release version redirect dynamic

### DIFF
--- a/kube/boost/templates/configmap-nginx.yaml
+++ b/kube/boost/templates/configmap-nginx.yaml
@@ -96,7 +96,7 @@ data:
       location = /users/bibliography.html { return 301 /doc/user-guide/resources.html; }
       location = /users/faq.html { return 301 /doc/user-guide/faq.html; }
       location = /users/proposal.pdf { return 301 /doc/user-guide/boost-history.html; }
-      location = /users/history/version_1_84_0.html { return 301 /releases/boost-1-84-0/; }
+      location ~ ^/users/history/version_(\d+)_(\d+)_(\d+)\.html$ { return 301 /releases/$1.$2.$3/; }
       location = /community/groups.html { return 301 /community/; }
       location = /community/policy.html { return 301 /doc/user-guide/discussion-policy.html; }
       location = /community/cpp.html { return 301 /doc/user-guide/faq.html#isocommitteemeetings; }


### PR DESCRIPTION
1. Fixes outdated pattern (we now use `/releases/x.xx.x/` instead of `/releases/boost-x-xx-x/`
2. Uses a regex pattern to make the redirect dynamic (was previously only handling 1.84.0

Note this is untested - I don't have a setup to test nginx redirects locally.