### PR TITLE
Tweak news image and attachment link alignment

### DIFF
--- a/templates/news/detail.html
+++ b/templates/news/detail.html
@@ -66,16 +66,16 @@
         {% endif %}
 
         {% if entry.image %}
-        <img src="{{ entry.image.url }}" class="mb-2 w-full h-auto md:float-right md:ml-5 md:mt-6 md:w-1/6 md:min-w-[200px] border border-black">
+          <img src="{{ entry.image.url }}" class="mb-2 w-full md:w-[300px] md:float-right md:ml-5 md:mt-1 border border-black">
         {% endif %}
-        <div class="break-words">
-        {{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaks }}
-        </div>
         {% if entry.news.attachment %}
           <a href="{{ entry.news.attachment.url }}" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">
             {{ entry.news.attachment_filename }}
           </a>
         {% endif %}
+        <div class="break-words">
+        {{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaks }}
+        </div>
       </div>
 
     </div>


### PR DESCRIPTION
In order to show a PDF "preview", this rearrangement allows the uploader to do the following:

1. Upload the PDF as the `attachment` field
2. Export the first page of the PDF as a png (on a Mac, you can do this in preview by choosing Export -> PNG, and then opening the PNG and deleting all pages but the page you want to keep)
3. Upload the PNG in the `image` field

This achieves this result:

<img width="589" alt="Screenshot 2024-12-11 at 7 07 51 PM" src="https://github.com/user-attachments/assets/51f81852-79f9-4523-a682-c2931d0e9152" />
