### PR TITLE
Prompt user to select google account and auto-link social accounts

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -20,10 +20,6 @@ if READ_DOT_ENV_FILE:
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("DJANGO_DEBUG", default=False)
 
-# Whether or not we're in local development mode
-LOCAL_DEVELOPMENT = env.bool("LOCAL_DEVELOPMENT", default=False)
-CI = env.bool("CI", default=False)
-
 if DEBUG:
     root = logging.getLogger()
     root.setLevel(logging.INFO)
@@ -32,6 +28,15 @@ if DEBUG:
     root.addHandler(lh)
 
     env.log_level("LOG_LEVEL", default="DEBUG")
+
+# Whether or not we're in local development mode
+LOCAL_DEVELOPMENT = env.bool("LOCAL_DEVELOPMENT", default=False)
+CI = env.bool("CI", default=False)
+
+if CI or LOCAL_DEVELOPMENT:
+    # This is the default value for the development environment.
+    # This enables the tests to run.
+    SITE_ID = 1
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = Path(__file__).parent.parent
@@ -342,11 +347,8 @@ ACCOUNT_AUTHENTICATION_METHOD = "email"
 SOCIALACCOUNT_QUERY_EMAIL = True
 SOCIALACCOUNT_LOGIN_ON_GET = True
 ACCOUNT_UNIQUE_EMAIL = True
-
-if CI or LOCAL_DEVELOPMENT:
-    # This is the default value for the development environment.
-    # This enables the tests to run.
-    SITE_ID = 1
+SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
+SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
 
 # Allow us to override some of allauth's forms
 ACCOUNT_FORMS = {

--- a/config/settings.py
+++ b/config/settings.py
@@ -363,6 +363,7 @@ SOCIALACCOUNT_PROVIDERS = {
         ],
         "AUTH_PARAMS": {
             "access_type": "online",
+            "prompt": "select_account",
         },
         "OAUTH_PKCE_ENABLED": True,
     },
@@ -387,14 +388,12 @@ if LOCAL_DEVELOPMENT:
     if not google_oauth_client_id or not google_oauth_secret:
         logging.warning("Google OAuth credentials not set")
     else:
-        SOCIALACCOUNT_PROVIDERS["google"] = {
-            "APPS": [
-                {
-                    "client_id": google_oauth_client_id,
-                    "secret": google_oauth_secret,
-                }
-            ]
-        }
+        SOCIALACCOUNT_PROVIDERS["google"]["APPS"] = [
+            {
+                "client_id": google_oauth_client_id,
+                "secret": google_oauth_secret,
+            },
+        ]
 
 
 # Allow Allauth to use HTTPS when deployed but HTTP for local dev


### PR DESCRIPTION
- Set `SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT` to `True` so users who have an existing account with a given email will be logged in rather than getting an email about someone trying to register them but they already have an account
- Added `"prompt": "select_account"` so users will be prompted to select a google account even if they're only logged into a single one at the time.

Fixes #1536 