### PR TITLE
Add management command to run all necessary tasks after a release.

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,7 +15,7 @@
   - [`import_beta_release`](#import_beta_release)
   - [`sync_mailinglist_stats`](#sync_mailinglist_stats)
   - [`update_library_version_dependencies`](#update_library_version_dependencies)
-  - [`post_release_tasks`](#post_release_tasks)
+  - [`release_tasks`](#release_tasks)
 
 ## `boost_setup`
 
@@ -303,14 +303,14 @@ If both the `--release` and the `--library-name` are passed, the command will lo
 | `--owner`  | string  | The repo owner. Defaults to "boostorg", which is correct in most cases but can be useful to specify for testing. |
 
 
-## `post_release_tasks`
+## `release_tasks`
 
-**Purpose**: Execute a chain of commands which are necessary to run after a release.
+**Purpose**: Execute a chain of commands which are necessary to run during a release. Imports new versions, beta versions, slack messages, github issues, commits, authors, maintainers, etc... Inspect the management command to see exactly which commands are being run.
 
 **Example**
 
 ```bash
-./manage.py post_release_tasks
+./manage.py release_tasks
 ```
 
 **Options**

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,6 +15,7 @@
   - [`import_beta_release`](#import_beta_release)
   - [`sync_mailinglist_stats`](#sync_mailinglist_stats)
   - [`update_library_version_dependencies`](#update_library_version_dependencies)
+  - [`post_release_tasks`](#post_release_tasks)
 
 ## `boost_setup`
 
@@ -300,3 +301,20 @@ If both the `--release` and the `--library-name` are passed, the command will lo
 | `--token`  | string  | Pass a GitHub API token. If not passed, will use the value in `settings.GITHUB_TOKEN`. |
 | `--clean`  | bool    | If passed, existing dependencies in the M2M will be cleared before reinserting them. |
 | `--owner`  | string  | The repo owner. Defaults to "boostorg", which is correct in most cases but can be useful to specify for testing. |
+
+
+## `post_release_tasks`
+
+**Purpose**: Execute a chain of commands which are necessary to run after a release.
+
+**Example**
+
+```bash
+./manage.py post_release_tasks
+```
+
+**Options**
+
+| Options              | Format | Description                                                  |
+|----------------------|--------|--------------------------------------------------------------|
+| `--user_id`  | int  | If passed, the user with this ID will receive email notifications when this task is started and finished, or if the task raises and exception. |

--- a/libraries/github.py
+++ b/libraries/github.py
@@ -508,9 +508,11 @@ class LibraryUpdater:
             lv.files_changed = diff.files_changed
             return lv
 
+        commits_handled = 0
         for item in get_commit_data_for_repo_versions(obj.key):
             match item:
                 case ParsedCommit():
+                    commits_handled += 1
                     commits.append(handle_commit(item))
                 case VersionDiffStat():
                     library_version_updates.append(handle_version_diff_stat(item))
@@ -530,6 +532,7 @@ class LibraryUpdater:
                 library_version_updates,
                 ["insertions", "deletions", "files_changed"],
             )
+        return commits_handled
 
     def update_commit_author_github_data(self, obj=None, email=None, overwrite=False):
         """Update CommitAuthor data by parsing data on their most recent commit."""

--- a/libraries/management/commands/post_release_tasks.py
+++ b/libraries/management/commands/post_release_tasks.py
@@ -1,0 +1,141 @@
+import traceback
+
+import djclick as click
+
+from django.core.mail import send_mail
+from django.utils import timezone
+from django.core.management import call_command
+from django.contrib.auth import get_user_model
+from django.conf import settings
+
+from libraries.tasks import update_commits
+from slack.management.commands.fetch_slack_activity import locked
+
+
+User = get_user_model()
+
+
+def send_notification(user, message):
+    if user.email:
+        send_mail(
+            "Task Started: post_release_tasks",
+            message,
+            settings.DEFAULT_FROM_EMAIL,
+            [user.email],
+        )
+
+
+def progress_message(message: str):
+    click.secho(message, fg="green")
+    return f"{timezone.now()}: {message}"
+
+
+@locked(1138692)
+def run_commands(progress: list[str]):
+    handled_commits = {}
+    progress.append(progress_message("Importing versions..."))
+    call_command("import_versions", "--new")
+    progress.append(progress_message("Finished importing versions."))
+
+    progress.append(progress_message("Importing most recent beta version..."))
+    call_command("import_beta_release", "--delete-versions")
+    progress.append(progress_message("Finished importing most recent beta version."))
+
+    progress.append(progress_message("Importing libraries"))
+    call_command("update_libraries")
+    progress.append(progress_message("Finished importing libraries."))
+
+    progress.append(progress_message("Saving library-version relationships..."))
+    call_command("import_library_versions")
+    progress.append(progress_message("Finished saving library-version relationships."))
+
+    progress.append(progress_message("Adding library maintainers..."))
+    call_command("update_maintainers")
+    progress.append(progress_message("Finished adding library maintainers."))
+
+    progress.append(progress_message("Adding library authors..."))
+    call_command("update_authors")
+    progress.append(progress_message("Finished adding library authors."))
+
+    progress.append(progress_message("Adding library version authors..."))
+    call_command("update_library_version_authors")
+    progress.append(progress_message("Finished adding library version authors."))
+
+    progress.append(progress_message("Importing git commits..."))
+    handled_commits = update_commits()
+    progress.append(progress_message("Finished importing commits..."))
+
+    progress.append(progress_message("Syncing mailinglist statistics..."))
+    call_command("sync_mailinglist_stats")
+    progress.append(progress_message("Finished syncing mailinglist statistics..."))
+
+    progress.append(progress_message("Updating github issues..."))
+    call_command("update_issues")
+    progress.append(progress_message("Finished updating github issues..."))
+
+    progress.append(progress_message("Updating slack activity buckets..."))
+    call_command("fetch_slack_activity")
+    progress.append(progress_message("Finished updating slack activity buckets..."))
+
+    return handled_commits
+
+
+@click.command()
+@click.option(
+    "--user_id",
+    is_flag=False,
+    help="The ID of the user that started this task (For notification purposes)",
+    default=None,
+)
+def command(user_id=None):
+    """A long running chain of tasks to import and update library data."""
+    start = timezone.now()
+
+    user = None
+    if user_id:
+        user = User.objects.filter(id=user_id).first()
+
+    if user:
+        send_notification(
+            user, f"Your task `post_release_tasks` was started at: {start}"
+        )
+    progress = ["___Progress Messages___"]
+    handled_commits = {}
+    try:
+        run_commands(progress)
+        end = timezone.now()
+        progress.append(progress_message(f"All done! Completed in {end - start}"))
+    except Exception:
+        error = traceback.format_exc()
+        message = [
+            f"ERROR: There was an error while running post_release_tasks.\n\n{error}",
+            "\n".join(progress),
+        ]
+        if user:
+            send_notification(
+                user,
+                "\n\n".join(message),
+            )
+        raise
+    else:
+        zero_commit_libraries = [
+            (key, val) for key, val in handled_commits.items() if val == 0
+        ]
+        message = [
+            f"The task `post_release_tasks` was completed. Task took: {end - start}",
+            "\n".join(progress),
+        ]
+        if zero_commit_libraries:
+            zero_commit_message = []
+            zero_commit_message.append(
+                "The import_commits task did not find commits for these libraries."
+            )
+            zero_commit_message.append("The task may need to re-run.")
+            for lib, _ in zero_commit_libraries:
+                zero_commit_message.append(lib)
+            message.append("\n".join(zero_commit_message))
+        if user:
+            send_notification(
+                user,
+                "\n\n".join(message),
+            )

--- a/libraries/management/commands/release_tasks.py
+++ b/libraries/management/commands/release_tasks.py
@@ -18,7 +18,7 @@ User = get_user_model()
 def send_notification(user, message):
     if user.email:
         send_mail(
-            "Task Started: post_release_tasks",
+            "Task Started: release_tasks",
             message,
             settings.DEFAULT_FROM_EMAIL,
             [user.email],
@@ -96,9 +96,7 @@ def command(user_id=None):
         user = User.objects.filter(id=user_id).first()
 
     if user:
-        send_notification(
-            user, f"Your task `post_release_tasks` was started at: {start}"
-        )
+        send_notification(user, f"Your task `release_tasks` was started at: {start}")
     progress = ["___Progress Messages___"]
     handled_commits = {}
     try:
@@ -108,7 +106,7 @@ def command(user_id=None):
     except Exception:
         error = traceback.format_exc()
         message = [
-            f"ERROR: There was an error while running post_release_tasks.\n\n{error}",
+            f"ERROR: There was an error while running release_tasks.\n\n{error}",
             "\n".join(progress),
         ]
         if user:
@@ -122,7 +120,7 @@ def command(user_id=None):
             (key, val) for key, val in handled_commits.items() if val == 0
         ]
         message = [
-            f"The task `post_release_tasks` was completed. Task took: {end - start}",
+            f"The task `release_tasks` was completed. Task took: {end - start}",
             "\n".join(progress),
         ]
         if zero_commit_libraries:

--- a/libraries/management/commands/release_tasks.py
+++ b/libraries/management/commands/release_tasks.py
@@ -100,7 +100,7 @@ def command(user_id=None):
     progress = ["___Progress Messages___"]
     handled_commits = {}
     try:
-        run_commands(progress)
+        handled_commits = run_commands(progress)
         end = timezone.now()
         progress.append(progress_message(f"All done! Completed in {end - start}"))
     except Exception:

--- a/libraries/management/commands/release_tasks.py
+++ b/libraries/management/commands/release_tasks.py
@@ -124,11 +124,10 @@ def command(user_id=None):
             "\n".join(progress),
         ]
         if zero_commit_libraries:
-            zero_commit_message = []
-            zero_commit_message.append(
-                "The import_commits task did not find commits for these libraries."
-            )
-            zero_commit_message.append("The task may need to re-run.")
+            zero_commit_message = [
+                "The import_commits task did not find commits for these libraries.",
+                "The task may need to re-run.",
+            ]
             for lib, _ in zero_commit_libraries:
                 zero_commit_message.append(lib)
             message.append("\n".join(zero_commit_message))

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -194,10 +194,14 @@ def update_authors_and_maintainers():
 
 @app.task
 def update_commits(token=None, clean=False):
+    # dictionary of library_key: int
+    commits_handled: dict[str, int] = {}
     updater = LibraryUpdater(token=token)
     for library in Library.objects.all():
-        updater.update_commits(obj=library, clean=clean)
+        logger.info("Importing commits for library.", library=library)
+        commits_handled[library.key] = updater.update_commits(obj=library, clean=clean)
     logger.info("update_commits finished.")
+    return commits_handled
 
 
 @app.task
@@ -234,4 +238,18 @@ def update_library_version_dependencies(token=None):
     command = ["update_library_version_dependencies"]
     if token:
         command.extend(["--token", token])
+    call_command(*command)
+
+
+@app.task
+def post_release_tasks(user_id=None):
+    """Call the post_release_tasks management command.
+
+    If a user_id is given, that user will receive an email at the beginning
+    and at the end of the task.
+
+    """
+    command = ["post_release_tasks"]
+    if user_id:
+        command.extend(["--user_id", user_id])
     call_command(*command)

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -242,14 +242,14 @@ def update_library_version_dependencies(token=None):
 
 
 @app.task
-def post_release_tasks(user_id=None):
-    """Call the post_release_tasks management command.
+def release_tasks(user_id=None):
+    """Call the release_tasks management command.
 
     If a user_id is given, that user will receive an email at the beginning
     and at the end of the task.
 
     """
-    command = ["post_release_tasks"]
+    command = ["release_tasks"]
     if user_id:
         command.extend(["--user_id", user_id])
     call_command(*command)

--- a/templates/admin/version_change_list.html
+++ b/templates/admin/version_change_list.html
@@ -6,6 +6,12 @@
     {% block object-tools-items %}
         {{ block.super }}
         <li><a href="{% url 'admin:import_new_releases' %}" class="addlink">{% trans "Import New Releases" %}</a></li>
+        <li>
+            <a
+                title='{% trans "Run all required tasks after a new release. Expect this to take up to a few hours." %}'
+                href="{% url 'admin:post_release_tasks' %}" class="addlink">{% trans "Do it all" %}
+            </a>
+        </li>
     {% endblock %}
 </ul>
 {% endblock %}

--- a/templates/admin/version_change_list.html
+++ b/templates/admin/version_change_list.html
@@ -9,7 +9,7 @@
         <li>
             <a
                 title='{% trans "Run all required tasks after a new release. Expect this to take up to a few hours." %}'
-                href="{% url 'admin:post_release_tasks' %}" class="addlink">{% trans "Do it all" %}
+                href="{% url 'admin:release_tasks' %}" class="addlink">{% trans "Do it all" %}
             </a>
         </li>
     {% endblock %}

--- a/versions/admin.py
+++ b/versions/admin.py
@@ -4,6 +4,8 @@ from django.db.models.query import QuerySet
 from django.http import HttpRequest, HttpResponseRedirect
 from django.urls import path
 
+from libraries.tasks import post_release_tasks
+
 from . import models
 from .tasks import (
     import_versions,
@@ -38,8 +40,21 @@ class VersionAdmin(admin.ModelAdmin):
                 self.admin_site.admin_view(self.import_new_releases),
                 name="import_new_releases",
             ),
+            path(
+                "post_release_tasks/",
+                self.admin_site.admin_view(self.post_release_tasks),
+                name="post_release_tasks",
+            ),
         ]
         return my_urls + urls
+
+    def post_release_tasks(self, request):
+        post_release_tasks.delay(user_id=request.user.id)
+        self.message_user(
+            request,
+            "The post_release_task has started, you will receive an email when the task finishes.",  # noqa: E501
+        )
+        return HttpResponseRedirect("../")
 
     def import_new_releases(self, request):
         import_versions.delay(new_versions_only=True)

--- a/versions/admin.py
+++ b/versions/admin.py
@@ -4,7 +4,7 @@ from django.db.models.query import QuerySet
 from django.http import HttpRequest, HttpResponseRedirect
 from django.urls import path
 
-from libraries.tasks import post_release_tasks
+from libraries.tasks import release_tasks
 
 from . import models
 from .tasks import (
@@ -41,18 +41,18 @@ class VersionAdmin(admin.ModelAdmin):
                 name="import_new_releases",
             ),
             path(
-                "post_release_tasks/",
-                self.admin_site.admin_view(self.post_release_tasks),
-                name="post_release_tasks",
+                "release_tasks/",
+                self.admin_site.admin_view(self.release_tasks),
+                name="release_tasks",
             ),
         ]
         return my_urls + urls
 
-    def post_release_tasks(self, request):
-        post_release_tasks.delay(user_id=request.user.id)
+    def release_tasks(self, request):
+        release_tasks.delay(user_id=request.user.id)
         self.message_user(
             request,
-            "The post_release_task has started, you will receive an email when the task finishes.",  # noqa: E501
+            "release_tasks has started, you will receive an email when the task finishes.",  # noqa: E501
         )
         return HttpResponseRedirect("../")
 


### PR DESCRIPTION
- fixes #1519
- add button to version admin to execute task
- use @ locked decorator to ensure only one instance of the task is running at any time.
- If a user_id is given to the command, send that user email notifications when it starts and ends.