### PR TITLE
Show boostdep data in library/release detail and report.

### DIFF
--- a/libraries/forms.py
+++ b/libraries/forms.py
@@ -665,6 +665,15 @@ class CreateReportForm(CreateReportFullForm):
             "new_user_count": new_user_count,
         }
 
+    def _get_dependency_data(self, library_order, version):
+        diffs_by_id = {
+            x["library_id"]: x for x in version.get_dependency_diffs().values()
+        }
+        diffs = []
+        for lib_id in library_order:
+            diffs.append(diffs_by_id.get(lib_id, {}))
+        return diffs
+
     def get_stats(self):
         version = self.cleaned_data["version"]
 
@@ -705,15 +714,16 @@ class CreateReportForm(CreateReportFullForm):
         )
         library_data = [
             {
-                "library": a,
-                "full_count": b,
-                "version_count": c,
-                "top_contributors_release": d,
-                "new_contributors_count": e,
-                "issues": f,
-                "library_version": g,
+                "library": item[0],
+                "full_count": item[1],
+                "version_count": item[2],
+                "top_contributors_release": item[3],
+                "new_contributors_count": item[4],
+                "issues": item[5],
+                "library_version": item[6],
+                "deps": item[7],
             }
-            for a, b, c, d, e, f, g in zip(
+            for item in zip(
                 sorted(list(libraries), key=lambda x: library_order.index(x.id)),
                 self._get_library_full_counts(libraries, library_order),
                 self._get_library_version_counts(libraries, library_order),
@@ -721,6 +731,7 @@ class CreateReportForm(CreateReportFullForm):
                 self._count_new_contributors(libraries, library_order),
                 self._count_issues(libraries, library_order, version),
                 self._get_library_versions(library_order, version),
+                self._get_dependency_data(library_order, version),
             )
         ]
         library_data = [

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -276,6 +276,7 @@ class LibraryDetail(VersionAlertMixin, BoostVersionMixin, DetailView):
         )
         # Populate the commit graphs
         context["commit_data_by_release"] = self.get_commit_data_by_release()
+        context["dependency_diff"] = self.get_dependency_diff(library_version)
 
         # Populate the library description
         client = GithubAPIClient(repo_slug=self.object.github_repo)
@@ -284,6 +285,12 @@ class LibraryDetail(VersionAlertMixin, BoostVersionMixin, DetailView):
             or README_MISSING
         )
         return context
+
+    def get_dependency_diff(self, library_version):
+        diffs = library_version.version.get_dependency_diffs(
+            library=library_version.library
+        )
+        return diffs.get(library_version.library.name, {})
 
     def get_commit_data_by_release(self):
         qs = (

--- a/templates/admin/release_report_detail.html
+++ b/templates/admin/release_report_detail.html
@@ -350,7 +350,7 @@
                 {% endwith %}
                 <div>
                   There {{ item.issues.opened|pluralize:"was,were" }} {{ item.issues.opened }} issue{{ item.issues.opened|pluralize }} opened
-                  There {{ item.issues.closed|pluralize:"was,were" }} {{ item.issues.closed }} issue{{ item.issues.closed|pluralize }} closed
+                  and {{ item.issues.closed|pluralize:"was,were" }} {{ item.issues.closed }} issue{{ item.issues.closed|pluralize }} closed
                 </div>
                 {% if item.deps.added or item.deps.removed %}
                   <div>

--- a/templates/admin/release_report_detail.html
+++ b/templates/admin/release_report_detail.html
@@ -349,9 +349,16 @@
                   {% endif %}
                 {% endwith %}
                 <div>
-                  There {{ item.issues.opened|pluralize:"was,were" }} {{ item.issues.opened }} issue{{ item.issues.opened|pluralize }} opened.
-                  There {{ item.issues.closed|pluralize:"was,were" }} {{ item.issues.closed }} issue{{ item.issues.closed|pluralize }} closed.
+                  There {{ item.issues.opened|pluralize:"was,were" }} {{ item.issues.opened }} issue{{ item.issues.opened|pluralize }} opened
+                  There {{ item.issues.closed|pluralize:"was,were" }} {{ item.issues.closed }} issue{{ item.issues.closed|pluralize }} closed
                 </div>
+                {% if item.deps.added or item.deps.removed %}
+                  <div>
+                    There {{ item.deps.added|length|pluralize:"was,were" }} {{ item.deps.added|length }} dependenc{{ item.deps.added|length|pluralize:"y,ies" }} added
+                    and
+                    {{ item.deps.removed|length }} dependenc{{ item.deps.removed|length|pluralize:"y,ies" }} removed
+                  </div>
+                {% endif %}
               </div>
             </div>
           </div>

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -138,22 +138,37 @@
 
     {% if dependency_diff.previous_dependencies and dependency_diff.current_dependencies %}
     <section class="p-6 pt-1 my-4 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
-      <h2 class="text-2xl">Dependencies ({{ dependency_diff.current_dependencies|length }})</h2>
-      <div class="flex gap-4 flex-wrap">
-        {% for dep in dependency_diff.both %}
-          <div
-            {% if dep.name in dependency_diff.added %}
-            class="text-red-700"
-            title="{{ dep.name }} was added as a dependency in {{ selected_version.display_name }}"
-            {% elif dep.name in dependency_diff.removed %}
-            class="text-green line-through"
-            title="{{ dep.name }} was removed as a dependency in {{ selected_version.display_name }}"
-            {% endif %}
-            >
+      <h2 class="text-2xl">Dependencies</h2>
+      <div class="flex gap-x-4 gap-y-2 flex-wrap">
+        {% for dep in dependency_diff.current_dependencies %}
+          <div>
             {{ dep.name }}
           </div>
         {% endfor %}
       </div>
+
+      {% if dependency_diff.added %}
+        <h3 class="my-3">Added</h3>
+        <div class="flex gap-x-4 flex-wrap">
+          {% for dep in dependency_diff.current_dependencies %}
+            {% if dep.name in dependency_diff.added %}
+              <div>{{ dep.name }}</div>
+            {% endif %}
+          {% endfor %}
+        </div>
+      {% endif %}
+
+      {% if dependency_diff.removed %}
+        <h3 class="my-3">Removed</h3>
+        <div class="flex gap-x-4 flex-wrap">
+          {% for dep in dependency_diff.previous_dependencies %}
+            {% if dep.name in dependency_diff.removed %}
+              <div>{{ dep.name }}</div>
+            {% endif %}
+          {% endfor %}
+        </div>
+      {% endif %}
+
     </section>
     {% endif %}
 

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -136,6 +136,27 @@
     </section>
     {% endif %}
 
+    {% if dependency_diff.previous_dependencies and dependency_diff.current_dependencies %}
+    <section class="p-6 pt-1 my-4 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
+      <h2 class="text-2xl">Dependencies ({{ dependency_diff.current_dependencies|length }})</h2>
+      <div class="flex gap-4 flex-wrap">
+        {% for dep in dependency_diff.both %}
+          <div
+            {% if dep.name in dependency_diff.added %}
+            class="text-red-700"
+            title="{{ dep.name }} was added as a dependency in {{ selected_version.display_name }}"
+            {% elif dep.name in dependency_diff.removed %}
+            class="text-green line-through"
+            title="{{ dep.name }} was removed as a dependency in {{ selected_version.display_name }}"
+            {% endif %}
+            >
+            {{ dep.name }}
+          </div>
+        {% endfor %}
+      </div>
+    </section>
+    {% endif %}
+
     {% if description %}
       <section id="libraryReadMe"
         class="boostlook p-6 my-4 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -148,7 +148,7 @@
       </div>
 
       {% if dependency_diff.added %}
-        <h3 class="my-3">Added</h3>
+        <h4 class="mt-3">Added</h4>
         <div class="flex gap-x-4 flex-wrap">
           {% for dep in dependency_diff.current_dependencies %}
             {% if dep.name in dependency_diff.added %}
@@ -159,7 +159,7 @@
       {% endif %}
 
       {% if dependency_diff.removed %}
-        <h3 class="my-3">Removed</h3>
+        <h4 class="mt-3">Removed</h4>
         <div class="flex gap-x-4 flex-wrap">
           {% for dep in dependency_diff.previous_dependencies %}
             {% if dep.name in dependency_diff.removed %}

--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -120,6 +120,30 @@
       </section>
     {% endif %}
 
+    {% if deps.added or deps.removed %}
+      <section id="dependencyChanges"
+        class="p-6 my-4 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
+        <h2 class="text-2xl mt-0">Dependencies</h2>
+        <div>
+          There {{ deps.added|pluralize:"was,were" }}
+          <span class="text-red-700">
+            {{ deps.added }} dependenc{{ deps.added|pluralize:"y,ies"}} added
+          </span>
+          <span>
+            (in {{ deps.increased_dep_lib_count }} librar{{ deps.increased_dep_lib_count|pluralize:"y,ies" }})
+          </span>
+          and
+          <span class="text-green">
+            {{ deps.removed }} dependenc{{ deps.removed|pluralize:"y,ies"}} removed
+          </span>
+          <span>
+            (in {{ deps.decreased_dep_lib_count }} librar{{ deps.decreased_dep_lib_count|pluralize:"y,ies" }})
+          </span>
+          this release.
+        </div>
+      </section>
+    {% endif %}
+
     {% if top_contributors_release %}
       <section id="releaseContributors"
         class="p-6 my-4 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">

--- a/versions/models.py
+++ b/versions/models.py
@@ -115,8 +115,12 @@ class Version(models.Model):
                     "library_id": current_lv.library_id,
                     "added": list(current_dependencies - old_dependencies),
                     "removed": list(old_dependencies - current_dependencies),
-                    "previous_dependencies": prev_dep_objects,
-                    "current_dependencies": current_dep_objects,
+                    "previous_dependencies": sorted(
+                        prev_dep_objects, key=lambda x: x.name.lower()
+                    ),
+                    "current_dependencies": sorted(
+                        current_dep_objects, key=lambda x: x.name.lower()
+                    ),
                     "both": sorted(
                         list(set(prev_dep_objects) | set(current_dep_objects)),
                         key=lambda x: x.name.lower(),

--- a/versions/views.py
+++ b/versions/views.py
@@ -59,12 +59,24 @@ class VersionDetail(BoostVersionMixin, VersionAlertMixin, DetailView):
         context["top_contributors_release"] = self.get_top_contributors_release(obj)
 
         context["documentation_url"] = obj.documentation_url
+        context["deps"] = self.get_library_version_dependencies(obj)
         if context["version_str"] == LATEST_RELEASE_URL_PATH_STR:
             context["documentation_url"] = library_doc_latest_transform(
                 obj.documentation_url
             )
             context["version_alert"] = False
         return context
+
+    def get_library_version_dependencies(self, version: Version):
+        diffs = version.get_dependency_diffs()
+        added = [len(x["added"]) for x in diffs.values() if x["added"]]
+        removed = [len(x["removed"]) for x in diffs.values() if x["removed"]]
+        return {
+            "added": sum(added),
+            "removed": sum(removed),
+            "increased_dep_lib_count": len(added),
+            "decreased_dep_lib_count": len(removed),
+        }
 
     def get_top_contributors_release(self, version: Version):
         version_commits = Commit.objects.filter(library_version__version=version)


### PR DESCRIPTION
- fixes #1336
- If a libraryversion does not have any known dependencies in the version in question or the prior version, stats are not shown.  There is the case where if a library goes from 0 to n dependencies or vice-versa, that stat will not be shown.  If this is a necessary feature, more work will need to be done to facilitate it.  We are only keeping a many-to-many relationship of LibraryVersions to Libraries so we cannot distinguish between if there are no dependencies or if we were not able to fetch them through the boostdep github action.