### PR TITLE
Fix plausible logging on doc_libs_placeholder based pages (#1579)

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -477,9 +477,13 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
             )
             context["content"] = soup.prettify()
         else:
-            # potentially pass version if needed for HTML modification
+            # Potentially pass version if needed for HTML modification.
+            # We disable plausible to prevent redundant 'about:srcdoc' tracking,
+            # tracking is covered by docsiframe.html
             base_html = render_to_string(
-                "docs_libs_placeholder.html", context, request=self.request
+                "docs_libs_placeholder.html",
+                {**context, **{"disable_plausible": True}},
+                request=self.request,
             )
             context["content"] = modernize_legacy_page(
                 content,

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,9 +5,11 @@
 <html lang="{{ LANGUAGE_CODE }}">
 
   <head>
-    <script defer
+    {% if not disable_plausible %}
+      <script defer
             data-domain="preview.boost.org"
             src="https://plausible.io/js/script.manual.js"></script>
+   {% endif %}
     <title>{% block title %}Boost{% endblock %}</title>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
The issue we were seeing was that while pages were being logged, we were still seeing "srcdoc" in the recorded plausible dashboard's entries.

Going through some tests it appeared that certain source types (exhibited in accumulators, lambda) were logging the page *and* "about:srcdoc". 

This was because the code path for those types put the content through doc_libs_placeholder.html which included plausible script tags, while the other pages didn't go through that file. 

The context/content is then passed into docsiframe.html which already imports for the plausible script (as it extends base.html).

This change disables plausible for doc_libs_placeholder.html while still having it enabled by default for all other pages.