### PR TITLE
Improved error processing

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import tempfile
 from PIL import Image
@@ -41,3 +43,16 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "asciidoctor" in item.keywords:
             item.add_marker(skip_asciidoctor)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_github_token_env_variable():
+    # I wanted to use pytest_env but skip_if_set=true only applies if the env var
+    # is not set at all, not if the env var is empty, so this is needed anyway.
+    VAR_NAME = "GITHUB_TOKEN"  # Replace with your actual variable name
+    VAR_DEFAULT_VALUE = "top-secret"
+    current_value = os.getenv(VAR_NAME)
+
+    if not current_value:
+        os.environ[VAR_NAME] = VAR_DEFAULT_VALUE
+        print(f"Env variable '{VAR_NAME}' not set. Forced to {VAR_DEFAULT_VALUE=}.")

--- a/core/boostrenderer.py
+++ b/core/boostrenderer.py
@@ -160,6 +160,15 @@ def get_s3_client():
     )
 
 
+def does_s3_key_exist(client, bucket_name, s3_key):
+    try:
+        client.head_object(Bucket=bucket_name, Key=s3_key.lstrip("/"))
+        return True
+    except ClientError:
+        logger.debug(f"{s3_key} does not exist in {bucket_name}")
+        return False
+
+
 def get_s3_keys(content_path, config_filename=None):
     """
     Get the S3 key for a given content path

--- a/core/githubhelper.py
+++ b/core/githubhelper.py
@@ -311,9 +311,7 @@ class GithubAPIClient:
         # This usually happens because the library does not have a `meta/libraries.json`
         # in the requested tag. More likely to happen with older versions of libraries.
         except requests.exceptions.HTTPError:
-            self.logger.exception(
-                "get_library_metadata_failed", repo=repo_slug, url=url
-            )
+            self.logger.warning(f"get_library_metadata_failed {repo_slug=}, {url=}")
             return None
         else:
             return response.json()

--- a/core/githubhelper.py
+++ b/core/githubhelper.py
@@ -62,6 +62,8 @@ class GithubAPIClient:
             "cmake",
             "more",
         ]
+        if not self.token:
+            raise ValueError("No GitHub token provided or set in environment.")
 
     def initialize_api(self) -> GhApi:
         """

--- a/core/githubhelper.py
+++ b/core/githubhelper.py
@@ -357,7 +357,14 @@ class GithubAPIClient:
             repo_slug = self.repo_slug
         if not ref:
             ref = self.ref
-        return self.api.git.get_ref(owner=self.owner, repo=repo_slug, ref=ref)
+        try:
+            ref_response = self.api.git.get_ref(
+                owner=self.owner, repo=repo_slug, ref=ref
+            )
+        except OSError as e:
+            logger.warning("get_ref_failed", repo=repo_slug, ref=ref, exc_msg=str(e))
+            raise ValueError(f"Could not get ref for {repo_slug} and {ref}")
+        return ref_response
 
     def get_repo(self, repo_slug: str = None) -> dict:
         """

--- a/env.template
+++ b/env.template
@@ -14,7 +14,7 @@ DJANGO_DEBUG=1
 # Don't use this secret key in production obviously
 SECRET_KEY="top-secret"
 
-GITHUB_TOKEN="top-secret"
+GITHUB_TOKEN=
 
 # AWS_ACCESS_KEY_ID="changeme"
 # AWS_SECRET_ACCESS_KEY="changeme"

--- a/justfile
+++ b/justfile
@@ -126,3 +126,6 @@ alias shell := console
 
 @pip-compile-upgrade:  ## Upgrade existing Python dependencies to their latest versions
     just pip-compile --upgrade
+
+@manage args:
+    docker compose run --rm web python manage.py {{ args }}

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -74,9 +74,8 @@ def get_and_store_library_version_documentation_urls_for_version(version_pk):
             library_version.save()
         except LibraryVersion.DoesNotExist:
             logger.info(
-                "get_library_version_documentation_urls_version_does_not_exist",
-                library_name=library_name,
-                version_slug=version.slug,
+                f"get_library_version_documentation_urls_version_does_not_exist"
+                f"{library_name=} {version.slug=}",
             )
             continue
         except LibraryVersion.MultipleObjectsReturned:

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -75,7 +75,7 @@ def import_versions(
 def import_release_notes():
     """Imports release notes from the existing rendered
     release notes in the repository."""
-    for version in Version.objects.active():
+    for version in Version.objects.exclude(name__in=["master", "develop"]).active():
         store_release_notes_task.delay(str(version.pk))
     store_release_notes_in_progress_task.delay()
 

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -262,10 +262,12 @@ def import_library_versions(version_name, token=None, version_type="tag"):
     # Get the gitmodules file for the version, which contains library data
     # The master and develop branches are not tags, so we retrieve their data
     # from the heads/ namespace instead of tags/
-    if version_type == "tag":
-        ref = client.get_ref(ref=f"tags/{version_name}")
-    else:
-        ref = client.get_ref(ref=f"heads/{version_name}")
+    ref_s = f"tags/{version_name}" if version_type == "tag" else f"heads/{version_name}"
+    try:
+        ref = client.get_ref(ref=ref_s)
+    except ValueError:
+        logger.info(f"import_library_versions_invalid_ref {ref_s=}")
+        return
 
     raw_gitmodules = client.get_gitmodules(ref=ref)
     if not raw_gitmodules:


### PR DESCRIPTION
This is related to ticket #1550 

In this PR there is:

* Improved missing s3 key handling in import_release_notes
  * Now logs warning instead of an exception being raised 
* Excluded master and develop from release imports. 
* Changed 404 exception to logged warning for library meta data that isn't found.
* Now raises a clear exception when the github token isn't set.
  * Sam, you requested a check be made against 'top-secret'. For a value that's explicitly required to be set in the .env in order to function (by comparison top-secret is fine for local django SECRET_KEY) I think it's better to just not set a default value in the first place. We all just need to make sure we delete "top-secret" locally now. It shouldn't occur for new checkouts after this PR. Let me know if there's a reason you don't like that and I'll add an explicit check for that value.
* Added a `just manage {args}` just file command so we don't need to shell into the container to run commands. 