### PR TITLE
Added override functionality for github issues links

### DIFF
--- a/libraries/constants.py
+++ b/libraries/constants.py
@@ -352,6 +352,11 @@ README_MISSING = (
     "consider contributing one."
 )
 
+LIBRARY_GITHUB_URL_OVERRIDES = {
+    # library.slug: url
+    "outcome": "https://github.com/ned14/outcome/issues",
+}
+
 DEFAULT_LIBRARIES_LANDING_VIEW = "grid"
 SELECTED_BOOST_VERSION_COOKIE_NAME = "boost_version"
 SELECTED_LIBRARY_VIEW_COOKIE_NAME = "library_view"

--- a/libraries/models.py
+++ b/libraries/models.py
@@ -14,6 +14,7 @@ from core.models import RenderedContent
 from core.asciidoc import convert_adoc_to_html
 from libraries.managers import IssueManager
 from mailing_list.models import EmailData
+from .constants import LIBRARY_GITHUB_URL_OVERRIDES
 
 from .utils import generate_random_string, write_content_to_tempfile
 
@@ -339,7 +340,10 @@ class Library(models.Model):
         if not self.github_owner or not self.github_repo:
             raise ValueError("Invalid GitHub owner or repository")
 
-        return f"https://github.com/{self.github_owner}/{self.github_repo}/issues"
+        return LIBRARY_GITHUB_URL_OVERRIDES.get(
+            self.slug,
+            f"https://github.com/{self.github_owner}/{self.github_repo}/issues",
+        )
 
 
 class LibraryVersion(models.Model):

--- a/libraries/tests/test_models.py
+++ b/libraries/tests/test_models.py
@@ -36,6 +36,17 @@ def test_get_issues_link(library):
     assert expected == result
 
 
+def test_get_issues_link_override():
+    outcome_library = baker.make(
+        "libraries.Library",
+        name="Outcome",
+        slug="outcome",
+        github_url="https://github.com/boostorg/outcome",
+    )
+    expected = "https://github.com/ned14/outcome/issues"
+    assert outcome_library.github_issues_url == expected
+
+
 def test_category_creation(category):
     assert category.name is not None
 


### PR DESCRIPTION
This is related to ticket #935.

For now it's only set up with the Outcome library. The original ticket mentioned asio works the same way but looking at the Asio git repo it looks like they're using github issues.

There was discussion in that thread of looking at the repo and checking if they're a fork or issues are closed. Given there's no reliably consistent programmatic way to account for each edge case those would introduce and we'd need the overriding url anyway, it's simpler to just check the override map for an existing key as this PR does. 

Happy to change it if anyone feels that's worth the effort and can map out all the edge cases.