### PR TITLE
News moderation email magic links

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -490,7 +490,7 @@ SERVER_EMAIL = "errors@cppalliance.org"
 
 # Deployed email configuration
 if LOCAL_DEVELOPMENT:
-    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 else:
     EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
     ANYMAIL = {

--- a/config/urls.py
+++ b/config/urls.py
@@ -46,6 +46,7 @@ from news.views import (
     EntryDeleteView,
     EntryDetailView,
     EntryListView,
+    EntryModerationDetailView,
     EntryModerationListView,
     EntryUpdateView,
     LinkCreateView,
@@ -229,6 +230,11 @@ urlpatterns = (
         path("news/add/poll/", PollCreateView.as_view(), name="news-poll-create"),
         path("news/add/video/", VideoCreateView.as_view(), name="news-video-create"),
         path("news/moderate/", EntryModerationListView.as_view(), name="news-moderate"),
+        path(
+            "news/moderate/<slug:slug>/",
+            EntryModerationDetailView.as_view(),
+            name="news-moderate-detail",
+        ),
         path("news/entry/<slug:slug>/", EntryDetailView.as_view(), name="news-detail"),
         path(
             "news/entry/<slug:slug>/approve/",

--- a/config/urls.py
+++ b/config/urls.py
@@ -48,6 +48,7 @@ from news.views import (
     EntryListView,
     EntryModerationDetailView,
     EntryModerationListView,
+    EntryModerationMagicApproveView,
     EntryUpdateView,
     LinkCreateView,
     LinkListView,
@@ -234,6 +235,11 @@ urlpatterns = (
             "news/moderate/<slug:slug>/",
             EntryModerationDetailView.as_view(),
             name="news-moderate-detail",
+        ),
+        path(
+            "news/moderate/magic/<str:token>/",
+            EntryModerationMagicApproveView.as_view(),
+            name="news-magic-approve",
         ),
         path("news/entry/<slug:slug>/", EntryDetailView.as_view(), name="news-detail"),
         path(

--- a/news/constants.py
+++ b/news/constants.py
@@ -1,0 +1,2 @@
+NEWS_APPROVAL_SALT = "news-approval"
+MAGIC_LINK_EXPIRATION = 3600 * 24  # 24h

--- a/news/notifications.py
+++ b/news/notifications.py
@@ -16,6 +16,7 @@ from .acl import moderators
 
 User = get_user_model()
 NEWS_APPROVAL_SALT = "news-approval"
+MAGIC_LINK_EXPIRATION = 3600 * 24  # 24h
 
 
 def send_email_news_approved(request, entry):
@@ -70,6 +71,7 @@ def send_email_news_needs_moderation(request, entry):
         "entry": entry,
         "detail_url": request.build_absolute_uri(entry.get_absolute_url()),
         "moderate_url": request.build_absolute_uri(reverse("news-moderate")),
+        "expiration_hours": int(MAGIC_LINK_EXPIRATION / 3600),
     }
 
     subject = "Boost.org: News entry needs moderation"

--- a/news/notifications.py
+++ b/news/notifications.py
@@ -89,6 +89,7 @@ def send_email_news_needs_moderation(request, entry):
         msg.attach_alternative(html_body, "text/html")
         messages.append(msg)
     get_connection().send_messages(messages)
+    return len(messages)
 
 
 def send_email_news_posted(request, entry):

--- a/news/notifications.py
+++ b/news/notifications.py
@@ -1,13 +1,21 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.mail import EmailMessage, get_connection, send_mail, send_mass_mail
+from django.core.mail import (
+    EmailMessage,
+    get_connection,
+    send_mail,
+    EmailMultiAlternatives,
+)
 from django.template import Template, Context
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+from itsdangerous.url_safe import URLSafeTimedSerializer
 
 from .acl import moderators
 
 User = get_user_model()
+NEWS_APPROVAL_SALT = "news-approval"
 
 
 def send_email_news_approved(request, entry):
@@ -38,47 +46,49 @@ def send_email_news_approved(request, entry):
     )
 
 
+def generate_magic_approval_link(entry_slug: str, moderator_id: int):
+    """Generate a magic link token for approving a news entry."""
+    serializer = URLSafeTimedSerializer(settings.SECRET_KEY)
+    token = serializer.dumps(
+        {"entry_slug": entry_slug, "moderator_id": moderator_id},
+        salt=NEWS_APPROVAL_SALT,
+    )
+    url = reverse("news-magic-approve", args=[token])
+    return url
+
+
 def send_email_news_needs_moderation(request, entry):
-    recipient_list = sorted(
-        u.email
+    recipient_list = [
+        u
         for u in moderators().select_related("preferences").only("email")
         if entry.tag in u.preferences.allow_notification_others_news_needs_moderation
-    )
+    ]
     if not recipient_list:
         return False
 
-    template = Template(
-        "Hello! You are receiving this email because you are a Boost news moderator.\n"
-        "The user {{ user.get_display_name|default:user.email }} has submitted a "
-        "new {{ newstype }} that requires moderation:\n\n"
-        "{{ title }}\n\n"
-        "You can view, approve or delete this item at: {{ detail_url }}.\n\n"
-        "The complete list of news pending moderation can be found at: {{ url }}\n\n"
-        "Thank you, the Boost moderator team."
-    )
-
-    body = template.render(
-        Context(
-            {
-                "entry": entry,
-                "user": entry.author,
-                "newstype": entry.tag,
-                "detail_url": mark_safe(
-                    request.build_absolute_uri(entry.get_absolute_url())
-                ),
-                "url": mark_safe(request.build_absolute_uri(reverse("news-moderate"))),
-                "title": mark_safe(entry.title),
-            }
-        )
-    )
+    context = {
+        "entry": entry,
+        "detail_url": request.build_absolute_uri(entry.get_absolute_url()),
+        "moderate_url": request.build_absolute_uri(reverse("news-moderate")),
+    }
 
     subject = "Boost.org: News entry needs moderation"
     from_address = settings.DEFAULT_FROM_EMAIL
     # Send each recipient their own email
-    emails = [
-        (subject, body, from_address, [recipient]) for recipient in recipient_list
-    ]
-    return send_mass_mail(emails)
+    messages = []
+    for moderator in recipient_list:
+        magic_link_url = generate_magic_approval_link(
+            entry_slug=entry.slug, moderator_id=moderator.id
+        )
+        context["approval_magic_link"] = request.build_absolute_uri(magic_link_url)
+        text_body = render_to_string("news/emails/needs_moderation.txt", context)
+        html_body = render_to_string("news/emails/needs_moderation.html", context)
+        msg = EmailMultiAlternatives(
+            subject, text_body, from_address, [moderator.email]
+        )
+        msg.attach_alternative(html_body, "text/html")
+        messages.append(msg)
+    get_connection().send_messages(messages)
 
 
 def send_email_news_posted(request, entry):

--- a/news/notifications.py
+++ b/news/notifications.py
@@ -13,10 +13,9 @@ from django.utils.safestring import mark_safe
 from itsdangerous.url_safe import URLSafeTimedSerializer
 
 from .acl import moderators
+from .constants import NEWS_APPROVAL_SALT, MAGIC_LINK_EXPIRATION
 
 User = get_user_model()
-NEWS_APPROVAL_SALT = "news-approval"
-MAGIC_LINK_EXPIRATION = 3600 * 24  # 24h
 
 
 def send_email_news_approved(request, entry):

--- a/news/notifications.py
+++ b/news/notifications.py
@@ -1,5 +1,6 @@
+from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.mail import EmailMessage, get_connection, send_mail
+from django.core.mail import EmailMessage, get_connection, send_mail, send_mass_mail
 from django.template import Template, Context
 from django.urls import reverse
 from django.utils.safestring import mark_safe
@@ -72,12 +73,12 @@ def send_email_news_needs_moderation(request, entry):
     )
 
     subject = "Boost.org: News entry needs moderation"
-    return send_mail(
-        subject=subject,
-        message=body,
-        from_email=None,
-        recipient_list=recipient_list,
-    )
+    from_address = settings.DEFAULT_FROM_EMAIL
+    # Send each recipient their own email
+    emails = [
+        (subject, body, from_address, [recipient]) for recipient in recipient_list
+    ]
+    return send_mass_mail(emails)
 
 
 def send_email_news_posted(request, entry):

--- a/news/tests/test_notifications.py
+++ b/news/tests/test_notifications.py
@@ -7,13 +7,13 @@ from django.utils.html import escape
 from django.urls import reverse
 from itsdangerous import URLSafeTimedSerializer
 
+from ..constants import NEWS_APPROVAL_SALT
 from ..models import NEWS_MODELS
 from ..notifications import (
     send_email_news_approved,
     send_email_news_needs_moderation,
     send_email_news_posted,
     generate_magic_approval_link,
-    NEWS_APPROVAL_SALT,
 )
 from users.models import Preferences
 
@@ -124,7 +124,6 @@ def test_send_email_news_needs_moderation(
 
 def test_generate_magic_approval_link(make_entry, make_user):
     entry = make_entry()
-    # entry = make_entry(NEWS_MODELS[0])
     moderator = make_user(groups={"moderator": ["news.*"]}, email="mod@x.com")
     url = generate_magic_approval_link(entry.slug, moderator.id)
 

--- a/news/tests/test_notifications.py
+++ b/news/tests/test_notifications.py
@@ -97,8 +97,8 @@ def test_send_email_news_needs_moderation(
     with tp.assertNumQueriesLessThan(2, verbose=True):
         result = send_email_news_needs_moderation(request, entry)
 
-    assert result == 1
-    assert len(mail.outbox) == 1
+    assert result == 4
+    assert len(mail.outbox) == 4
     msg = mail.outbox[0]
     assert "news entry needs moderation" in msg.subject.lower()
     assert entry.title in msg.body
@@ -107,9 +107,15 @@ def test_send_email_news_needs_moderation(
     assert entry.author.email in msg.body
     assert request.build_absolute_uri(entry.get_absolute_url()) in msg.body
     assert request.build_absolute_uri(reverse("news-moderate")) in msg.body
-    assert msg.recipients() == sorted(
-        [other_moderator.email, moderator_user.email, superuser.email, forth.email]
-    )
+    recipients = []
+    for msg in mail.outbox:
+        recipients.extend(msg.recipients())
+    assert set(recipients) == {
+        other_moderator.email,
+        moderator_user.email,
+        superuser.email,
+        forth.email,
+    }
 
 
 @pytest.mark.parametrize("model_class", NEWS_MODELS)

--- a/news/tests/test_notifications.py
+++ b/news/tests/test_notifications.py
@@ -1,15 +1,19 @@
 from datetime import date
 
 import pytest
+from django.conf import settings
 from django.core import mail
 from django.utils.html import escape
 from django.urls import reverse
+from itsdangerous import URLSafeTimedSerializer
 
 from ..models import NEWS_MODELS
 from ..notifications import (
     send_email_news_approved,
     send_email_news_needs_moderation,
     send_email_news_posted,
+    generate_magic_approval_link,
+    NEWS_APPROVAL_SALT,
 )
 from users.models import Preferences
 
@@ -116,6 +120,28 @@ def test_send_email_news_needs_moderation(
         superuser.email,
         forth.email,
     }
+
+
+def test_generate_magic_approval_link(make_entry, make_user):
+    entry = make_entry()
+    # entry = make_entry(NEWS_MODELS[0])
+    moderator = make_user(groups={"moderator": ["news.*"]}, email="mod@x.com")
+    url = generate_magic_approval_link(entry.slug, moderator.id)
+
+    dummy_token = "dummy-token"
+    expected_base_url = (
+        reverse("news-magic-approve", kwargs={"token": dummy_token})
+        .replace(dummy_token, "")
+        .rstrip("/")
+    )
+    assert url.startswith(expected_base_url)
+
+    token = url.split(expected_base_url)[-1].strip("/")
+    serializer = URLSafeTimedSerializer(settings.SECRET_KEY)
+    data = serializer.loads(token, salt=NEWS_APPROVAL_SALT)
+
+    assert data["entry_slug"] == entry.slug
+    assert data["moderator_id"] == moderator.id
 
 
 @pytest.mark.parametrize("model_class", NEWS_MODELS)

--- a/news/views.py
+++ b/news/views.py
@@ -129,7 +129,8 @@ class EntryDetailView(DetailView):
     template_name = "news/detail.html"
 
     def get_object(self, *args, **kwargs):
-        # Published news are available to anyone, otherwise to authors only
+        # Published news are available to anyone,
+        # otherwise to authors and moderators only
         result = super().get_object(*args, **kwargs)
         if not result.can_view(self.request.user):
             raise Http404()
@@ -146,6 +147,9 @@ class EntryDetailView(DetailView):
         context["user_can_edit"] = self.object.can_edit(self.request.user)
         context["user_can_delete"] = self.object.can_delete(self.request.user)
         return context
+
+
+class EntryModerationDetailView(LoginRequiredMixin, EntryDetailView): ...
 
 
 class EntryCreateView(LoginRequiredMixin, SuccessMessageMixin, CreateView):

--- a/news/views.py
+++ b/news/views.py
@@ -33,6 +33,7 @@ from .notifications import (
     send_email_news_needs_moderation,
     send_email_news_posted,
     NEWS_APPROVAL_SALT,
+    MAGIC_LINK_EXPIRATION,
 )
 
 User = get_user_model()
@@ -164,7 +165,9 @@ class EntryModerationMagicApproveView(View):
     def get(self, request, token, *args, **kwargs):
         serializer = URLSafeTimedSerializer(settings.SECRET_KEY)
         try:
-            data = serializer.loads(token, salt=NEWS_APPROVAL_SALT, max_age=3600)  # 1h
+            data = serializer.loads(
+                token, salt=NEWS_APPROVAL_SALT, max_age=MAGIC_LINK_EXPIRATION
+            )
             entry_slug = data["entry_slug"]
             moderator_id = data["moderator_id"]
             moderator = User.objects.get(id=moderator_id)

--- a/news/views.py
+++ b/news/views.py
@@ -26,14 +26,13 @@ from django.views.generic.detail import SingleObjectMixin
 from itsdangerous import URLSafeTimedSerializer, SignatureExpired, BadData
 
 from .acl import can_approve
+from .constants import NEWS_APPROVAL_SALT, MAGIC_LINK_EXPIRATION
 from .forms import BlogPostForm, EntryForm, LinkForm, NewsForm, PollForm, VideoForm
 from .models import BlogPost, Entry, Link, News, Poll, Video
 from .notifications import (
     send_email_news_approved,
     send_email_news_needs_moderation,
     send_email_news_posted,
-    NEWS_APPROVAL_SALT,
-    MAGIC_LINK_EXPIRATION,
 )
 
 User = get_user_model()

--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ psycogreen
 gevent==24.2.1
 gunicorn
 interrogate
+itsdangerous
 psycopg2-binary
 whitenoise
 django-click

--- a/requirements.txt
+++ b/requirements.txt
@@ -188,6 +188,8 @@ interrogate==1.7.0
     # via -r ./requirements.in
 ipython==8.28.0
     # via -r ./requirements.in
+itsdangerous==2.2.0
+    # via -r ./requirements.in
 jedi==0.19.1
     # via ipython
 jmespath==1.0.1

--- a/templates/news/emails/needs_moderation.html
+++ b/templates/news/emails/needs_moderation.html
@@ -1,20 +1,223 @@
-<p>Hello! You are receiving this email because you are a Boost news moderator.</p>
-<p>
-  The user {{ entry.author.get_display_name|default:entry.author.email }} has submitted a
-  new {{ entry.tag }} that requires moderation:
-</p>
+<html><head>
+    <!-- Compiled with Bootstrap Email version: 1.3.1 -->
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="x-apple-disable-message-reformatting">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="format-detection" content="telephone=no, date=no, address=no, email=no">
+    <style type="text/css">
+      body,table,td{font-family:Helvetica,Arial,sans-serif !important}.ExternalClass{width:100%}.ExternalClass,.ExternalClass p,.ExternalClass span,.ExternalClass font,.ExternalClass td,.ExternalClass div{line-height:150%}a{text-decoration:none}*{color:inherit}a[x-apple-data-detectors],u+#body a,#MessageViewBody a{color:inherit;text-decoration:none;font-size:inherit;font-family:inherit;font-weight:inherit;line-height:inherit}img{-ms-interpolation-mode:bicubic}table:not([class^=s-]){font-family:Helvetica,Arial,sans-serif;mso-table-lspace:0pt;mso-table-rspace:0pt;border-spacing:0px;border-collapse:collapse}table:not([class^=s-]) td{border-spacing:0px;border-collapse:collapse}@media screen and (max-width: 600px){.w-full,.w-full>tbody>tr>td{width:100% !important}.w-24,.w-24>tbody>tr>td{width:96px !important}.w-40,.w-40>tbody>tr>td{width:160px !important}.p-lg-10:not(table),.p-lg-10:not(.btn)>tbody>tr>td,.p-lg-10.btn td a{padding:0 !important}.p-3:not(table),.p-3:not(.btn)>tbody>tr>td,.p-3.btn td a{padding:12px !important}.p-6:not(table),.p-6:not(.btn)>tbody>tr>td,.p-6.btn td a{padding:24px !important}*[class*=s-lg-]>tbody>tr>td{font-size:0 !important;line-height:0 !important;height:0 !important}.s-4>tbody>tr>td{font-size:16px !important;line-height:16px !important;height:16px !important}.s-6>tbody>tr>td{font-size:24px !important;line-height:24px !important;height:24px !important}.s-10>tbody>tr>td{font-size:40px !important;line-height:40px !important;height:40px !important}}
+    </style>
+  </head>
+  <body class="bg-light" style="outline: 0; width: 100%; min-width: 100%; height: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-family: Helvetica, Arial, sans-serif; line-height: 24px; font-weight: normal; font-size: 16px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; color: #000000; margin: 0; padding: 0; border-width: 0;" bgcolor="#f7fafc">
+    <table class="bg-light body" valign="top" role="presentation" border="0" cellpadding="0" cellspacing="0" style="outline: 0; width: 100%; min-width: 100%; height: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-family: Helvetica, Arial, sans-serif; line-height: 24px; font-weight: normal; font-size: 16px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; color: #000000; margin: 0; padding: 0; border-width: 0;" bgcolor="#f7fafc">
+      <tbody>
+        <tr>
+          <td valign="top" style="line-height: 24px; font-size: 16px; margin: 0;" align="left" bgcolor="#f7fafc">
+            <table class="container" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;">
+              <tbody>
+                <tr>
+                  <td align="center" style="line-height: 24px; font-size: 16px; margin: 0; padding: 0 16px;">
+                    <!--[if (gte mso 9)|(IE)]>
+                      <table align="center" role="presentation">
+                        <tbody>
+                          <tr>
+                            <td width="600">
+                    <![endif]-->
+                    <table align="center" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%; max-width: 600px; margin: 0 auto;">
+                      <tbody>
+                        <tr>
+                          <td style="line-height: 24px; font-size: 16px; margin: 0;" align="left">
+                            <table class="s-10 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+                              <tbody>
+                                <tr>
+                                  <td style="line-height: 40px; font-size: 40px; width: 100%; height: 40px; margin: 0;" align="left" width="100%" height="40">
+                                    &nbsp;
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table class="ax-center" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
+                              <tbody>
+                                <tr>
+                                  <td style="line-height: 24px; font-size: 16px; margin: 0;" align="left">
+                                    <img class="w-24" src="https://boost.io/static/img/Boost_Symbol_Transparent.svg" style="height: auto; line-height: 100%; outline: none; text-decoration: none; display: block; width: 96px; border-style: none; border-width: 0;" width="96">
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table class="s-10 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+                              <tbody>
+                                <tr>
+                                  <td style="line-height: 40px; font-size: 40px; width: 100%; height: 40px; margin: 0;" align="left" width="100%" height="40">
+                                    &nbsp;
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <div>
+                              <h2 style="padding-top: 0; padding-bottom: 0; font-weight: 800 !important; vertical-align: baseline; font-size: 24px; line-height: 36px; margin: 0;" align="left">
+                                Boost.org news entry awaiting moderation
+                              </h2>
+                              <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+                                <tbody>
+                                  <tr>
+                                    <td style="line-height: 16px; font-size: 16px; width: 100%; height: 16px; margin: 0;" align="left" width="100%" height="16">
+                                      &nbsp;
+                                    </td>
+                                  </tr>
+                                </tbody>
+                              </table>
+                              <p class="" style="line-height: 24px; font-size: 16px; width: 100%; margin: 0;" align="left">
+                                Hello! You are receiving this email because you are a Boost news moderator. <br/>
+                                The user <strong>{{ entry.author.get_display_name|default:entry.author.email }}</strong> has submitted a new {{ entry.tag }} that requires moderation:
+                              </p>
+                            </div>
 
-<hr>
-<h4>{{ entry.title }}</h4>
-{{ entry.content|linebreaks }}
-<hr>
+                            {# Entry preview #}
+                            <table class="s-10 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+                              <tbody>
+                                <tr>
+                                  <td style="line-height: 40px; font-size: 40px; width: 100%; height: 40px; margin: 0;" align="left" width="100%" height="40">
+                                    &nbsp;
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table class="card p-6 p-lg-10 space-y-4" role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-radius: 6px; border-collapse: separate !important; width: 100%; overflow: hidden; border: 1px solid #e2e8f0;" bgcolor="#ffffff">
+                              <tbody>
+                                <tr>
+                                  <td style="line-height: 24px; font-size: 16px; width: 100%; margin: 0; padding: 40px;" align="left" bgcolor="#ffffff">
+                                    <h1 class="h3 fw-700" style="padding-top: 0; padding-bottom: 0; font-weight: 700 !important; vertical-align: baseline; font-size: 28px; line-height: 33.6px; margin: 0;" align="left">
+                                      {{ entry.title }}
+                                    </h1>
+                                    <table class="s-4 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+                                      <tbody>
+                                        <tr>
+                                          <td style="line-height: 16px; font-size: 16px; width: 100%; height: 16px; margin: 0;" align="left" width="100%" height="16">
+                                            &nbsp;
+                                          </td>
+                                        </tr>
+                                      </tbody>
+                                    </table>
+                                    <p class="" style="line-height: 24px; font-size: 16px; width: 100%; margin: 0;" align="left">
+                                      {{ entry.content|linebreaksbr }}
+                                    </p>
+                                    <table class="s-4 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+                                      <tbody>
+                                        <tr>
+                                          <td style="line-height: 16px; font-size: 16px; width: 100%; height: 16px; margin: 0;" align="left" width="100%" height="16">
+                                            &nbsp;
+                                          </td>
+                                        </tr>
+                                      </tbody>
+                                    </table>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            {# End Entry Preview #}
 
-<p>You can click the button below to instantly approve this news item (this link is valid for 1 hour):</p>
+                            <table class="s-10 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+                              <tbody>
+                                <tr>
+                                  <td style="line-height: 40px; font-size: 40px; width: 100%; height: 40px; margin: 0;" align="left" width="100%" height="40">
+                                    &nbsp;
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <div style="color: #383c45;">
+                              You can instantly approve this entry without logging in by clicking the button below. This link will expire in 1 hour. <br/>
+                            </div>
+                            <table class="w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+                              <tbody>
+                                <tr>
+                                  <td style="line-height: 20px; font-size: 20px; width: 100%; height: 20px; margin: 0;" align="left" width="100%" height="20">
+                                    &nbsp;
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table class="btn btn-primary p-3 fw-700" role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-radius: 6px; border-collapse: separate !important; font-weight: 700 !important;">
+                              <tbody>
+                                <tr>
+                                  <td style="line-height: 24px; font-size: 16px; border-radius: 6px; font-weight: 700 !important; margin: 0;" align="center" bgcolor="#0d6efd">
+                                    <a href="{{ approval_magic_link }}" style="color: #ffffff; font-size: 16px; font-family: Helvetica, Arial, sans-serif; text-decoration: none; border-radius: 6px; line-height: 20px; display: block; font-weight: 700 !important; white-space: nowrap; background-color: orange; padding: 12px;">
+                                      Approve Now
+                                    </a>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table class="s-6 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+                              <tbody>
+                                <tr>
+                                  <td style="line-height: 24px; font-size: 24px; width: 100%; height: 24px; margin: 0;" align="left" width="100%" height="24">
+                                    &nbsp;
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <div class="text-muted" style="color: #718096;">
+                              You can also <a style="color:#1A01CC;text-decoration:underline;" href="{{ detail_url }}">view, approve, or delete this item here</a>. <br/>
+                              The complete list of news pending moderation <a style="color:#1A01CC;text-decoration:underline;" href="{{ moderate_url }}">can be found here</a>. <br/><br/>
+                              Thank you, the Boost moderator team. <br/>
+                            </div>
+                            <table class="s-6 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+                              <tbody>
+                                <tr>
+                                  <td style="line-height: 24px; font-size: 24px; width: 100%; height: 24px; margin: 0;" align="left" width="100%" height="24">
+                                    &nbsp;
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table class="s-6 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+                              <tbody>
+                                <tr>
+                                  <td style="line-height: 24px; font-size: 24px; width: 100%; height: 24px; margin: 0;" align="left" width="100%" height="24">
+                                    &nbsp;
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table class="s-6 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+                              <tbody>
+                                <tr>
+                                  <td style="line-height: 24px; font-size: 24px; width: 100%; height: 24px; margin: 0;" align="left" width="100%" height="24">
+                                    &nbsp;
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table class="s-6 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+                              <tbody>
+                                <tr>
+                                  <td style="line-height: 24px; font-size: 24px; width: 100%; height: 24px; margin: 0;" align="left" width="100%" height="24">
+                                    &nbsp;
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <!--[if (gte mso 9)|(IE)]>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+                    <![endif]-->
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
-<a href="{{ approval_magic_link }}">
-  <span style="background-color:orange;padding:12px;color:white;border-radius:4px;">Approve Now</span>
-</a>
 
-<p>You can also view, approve or delete this item at: {{ detail_url }}</p>
-<p>The complete list of news pending moderation can be found at: {{ moderate_url }}</p>
-<p>Thank you, the Boost moderator team.</p>
+</body></html>

--- a/templates/news/emails/needs_moderation.html
+++ b/templates/news/emails/needs_moderation.html
@@ -1,4 +1,7 @@
-<html><head>
+{% load humanize %}
+
+<html>
+  <head>
     <!-- Compiled with Bootstrap Email version: 1.3.1 -->
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
@@ -128,7 +131,8 @@
                               </tbody>
                             </table>
                             <div style="color: #383c45;">
-                              You can instantly approve this entry without logging in by clicking the button below. This link will expire in 1 hour. <br/>
+                              You can instantly approve this entry without logging in by clicking the button below. This link will expire in
+                              {{ expiration_hours }} hour{{ expiration_hours|pluralize }}. <br/>
                             </div>
                             <table class="w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
                               <tbody>

--- a/templates/news/emails/needs_moderation.html
+++ b/templates/news/emails/needs_moderation.html
@@ -1,0 +1,20 @@
+<p>Hello! You are receiving this email because you are a Boost news moderator.</p>
+<p>
+  The user {{ entry.author.get_display_name|default:entry.author.email }} has submitted a
+  new {{ entry.tag }} that requires moderation:
+</p>
+
+<hr>
+<h4>{{ entry.title }}</h4>
+{{ entry.content|linebreaks }}
+<hr>
+
+<p>You can click the button below to instantly approve this news item (this link is valid for 1 hour):</p>
+
+<a href="{{ approval_magic_link }}">
+  <span style="background-color:orange;padding:12px;color:white;border-radius:4px;">Approve Now</span>
+</a>
+
+<p>You can also view, approve or delete this item at: {{ detail_url }}</p>
+<p>The complete list of news pending moderation can be found at: {{ moderate_url }}</p>
+<p>Thank you, the Boost moderator team.</p>

--- a/templates/news/emails/needs_moderation.txt
+++ b/templates/news/emails/needs_moderation.txt
@@ -3,11 +3,11 @@ Hello! You are receiving this email because you are a Boost news moderator.
 The user {{ entry.author.get_display_name|default:entry.author.email }} has submitted a new {{ entry.tag }} that requires moderation:
 
 ---
-
+{% autoescape off %}
 {{ entry.title }}
 
 {{ entry.content }}
-
+{% endautoescape %}
 ---
 
 You can use the link below to instantly approve this news item (this link is valid for 1 hour):

--- a/templates/news/emails/needs_moderation.txt
+++ b/templates/news/emails/needs_moderation.txt
@@ -1,3 +1,5 @@
+{% load humanize %}
+
 Hello! You are receiving this email because you are a Boost news moderator.
 
 The user {{ entry.author.get_display_name|default:entry.author.email }} has submitted a new {{ entry.tag }} that requires moderation:
@@ -10,7 +12,8 @@ The user {{ entry.author.get_display_name|default:entry.author.email }} has subm
 {% endautoescape %}
 ---
 
-You can use the link below to instantly approve this news item (this link is valid for 1 hour):
+You can instantly approve this entry without logging in by using the link below.
+This link will expire in {{ expiration_hours }} hour{{ expiration_hours|pluralize }}.
 
 {{ approval_magic_link }}
 

--- a/templates/news/emails/needs_moderation.txt
+++ b/templates/news/emails/needs_moderation.txt
@@ -1,0 +1,21 @@
+Hello! You are receiving this email because you are a Boost news moderator.
+
+The user {{ entry.author.get_display_name|default:entry.author.email }} has submitted a new {{ entry.tag }} that requires moderation:
+
+---
+
+{{ entry.title }}
+
+{{ entry.content }}
+
+---
+
+You can use the link below to instantly approve this news item (this link is valid for 1 hour):
+
+{{ approval_magic_link }}
+
+You can also view, approve or delete this item at: {{ detail_url }}
+
+The complete list of news pending moderation can be found at: {{ moderate_url }}
+
+Thank you, the Boost moderator team.

--- a/templates/news/moderation.html
+++ b/templates/news/moderation.html
@@ -19,7 +19,7 @@
             </div>
             <div class="w-5/6 text-xl">
               <p>
-                <a class="text-orange hover:text-info-600 focus:text-info-600 active:text-info-700" href="{{ entry.get_absolute_url }}?next={{ request.path|urlencode }}">{{ entry.tag|capfirst }}: {{ entry.title }}</a>
+                <a class="text-orange hover:text-info-600 focus:text-info-600 active:text-info-700" href="{% url 'news-moderate-detail' slug=entry.slug %}?next={{ request.path|urlencode }}">{{ entry.tag|capfirst }}: {{ entry.title }}</a>
                 {% blocktrans with author_email=entry.author.email %}by {{ author_email }}
                 {% endblocktrans %}
               </p>


### PR DESCRIPTION
- Email is sent to individual moderators rather than one group email
- Email is HTML with txt fallback
- Email contains magic link to approve news entry without requiring login
  - Link expires 24h after it's generated
- Graceful handling of case where news item has already been approved by another moderator
- Non-magic moderation link now redirects to login page instead of 404ing for unauthenticated users

Here's what the email looks like:

![Screenshot 2025-01-15 at 12 23 37 PM](https://github.com/user-attachments/assets/42cd107b-fc2a-43d2-ada3-71395434e5a5)

Fixes #1586 
