### PR TITLE
Schedule report tasks and add report preview view

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -24,9 +24,10 @@ def debug_task(self):
     print(f"Request: {self.request!r}")
 
 
-# Schedule Celery tasks
 @app.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):
+    """Schedule Celery tasks via CeleryBeat."""
+
     # Update library data from GitHub. Executes daily at 7:05 AM
     sender.add_periodic_task(
         crontab(hour=7, minute=5),
@@ -55,4 +56,10 @@ def setup_periodic_tasks(sender, **kwargs):
     sender.add_periodic_task(
         datetime.timedelta(minutes=61),
         app.signature("users.tasks.do_scheduled_user_deletions"),
+    )
+
+    # Update data required for release report. Executes Saturday evenings.
+    sender.add_periodic_task(
+        crontab(day_of_week="sat", hour=20, minute=3),
+        app.signature("libraries.tasks.release_tasks", generate_report=True),
     )

--- a/config/urls.py
+++ b/config/urls.py
@@ -81,6 +81,7 @@ from versions.views import (
     PastReviewListView,
     ScheduledReviewListView,
     VersionDetail,
+    ReportPreviewView,
 )
 
 djdt_urls = []
@@ -181,6 +182,11 @@ urlpatterns = (
             "releases/<boostversionslug:version_slug>/",
             VersionDetail.as_view(),
             name="release-detail",
+        ),
+        path(
+            "releases/<boostversionslug:version_slug>/report",
+            ReportPreviewView.as_view(),
+            name="release-report-preview",
         ),
         path(
             "donate/",

--- a/libraries/management/commands/release_tasks.py
+++ b/libraries/management/commands/release_tasks.py
@@ -1,4 +1,5 @@
 import traceback
+from contextlib import suppress
 
 import djclick as click
 
@@ -7,18 +8,21 @@ from django.utils import timezone
 from django.core.management import call_command
 from django.contrib.auth import get_user_model
 from django.conf import settings
+from slack_sdk.errors import SlackApiError
 
+from core.githubhelper import GithubAPIClient
+from libraries.forms import CreateReportForm
 from libraries.tasks import update_commits
-from slack.management.commands.fetch_slack_activity import locked
-
+from slack.management.commands.fetch_slack_activity import get_my_channels, locked
+from versions.models import Version
 
 User = get_user_model()
 
 
-def send_notification(user, message):
+def send_notification(user, message, subject="Task Started: release_tasks"):
     if user.email:
         send_mail(
-            "Task Started: release_tasks",
+            subject,
             message,
             settings.DEFAULT_FROM_EMAIL,
             [user.email],
@@ -31,24 +35,27 @@ def progress_message(message: str):
 
 
 @locked(1138692)
-def run_commands(progress: list[str]):
+def run_commands(progress: list[str], generate_report: bool = False):
     if not settings.SLACK_BOT_TOKEN:
         raise ValueError("SLACK_BOT_TOKEN is not set.")
     handled_commits = {}
     progress.append(progress_message("Importing versions..."))
     call_command("import_versions", "--new")
     progress.append(progress_message("Finished importing versions."))
+    latest_version: Version = Version.objects.most_recent()
+    latest_version_name = latest_version.name
 
     progress.append(progress_message("Importing most recent beta version..."))
     call_command("import_beta_release", "--delete-versions")
     progress.append(progress_message("Finished importing most recent beta version."))
 
-    progress.append(progress_message("Importing libraries"))
+    progress.append(progress_message("Importing libraries..."))
     call_command("update_libraries")
     progress.append(progress_message("Finished importing libraries."))
 
     progress.append(progress_message("Saving library-version relationships..."))
-    call_command("import_library_versions")
+    latest_version_number = latest_version_name.lstrip("boost-")
+    call_command("import_library_versions", min_release=latest_version_number)
     progress.append(progress_message("Finished saving library-version relationships."))
 
     progress.append(progress_message("Adding library maintainers..."))
@@ -64,12 +71,12 @@ def run_commands(progress: list[str]):
     progress.append(progress_message("Finished adding library version authors."))
 
     progress.append(progress_message("Importing git commits..."))
-    handled_commits = update_commits()
-    progress.append(progress_message("Finished importing commits..."))
+    handled_commits = update_commits(min_version=latest_version_name)
+    progress.append(progress_message("Finished importing commits."))
 
     progress.append(progress_message("Syncing mailinglist statistics..."))
     call_command("sync_mailinglist_stats")
-    progress.append(progress_message("Finished syncing mailinglist statistics..."))
+    progress.append(progress_message("Finished syncing mailinglist statistics."))
 
     progress.append(progress_message("Updating github issues..."))
     call_command("update_issues")
@@ -77,9 +84,44 @@ def run_commands(progress: list[str]):
 
     progress.append(progress_message("Updating slack activity buckets..."))
     call_command("fetch_slack_activity")
-    progress.append(progress_message("Finished updating slack activity buckets..."))
+    progress.append(progress_message("Finished updating slack activity buckets."))
+
+    if generate_report:
+        progress.append(
+            progress_message(f"Generating report for {latest_version_name}...")
+        )
+        form = CreateReportForm({"version": latest_version.id})
+        form.cache_html()
+        progress.append(
+            progress_message(f"Finished generating report for {latest_version_name}.")
+        )
 
     return handled_commits
+
+
+def check_credentials() -> list[str]:
+    """This management command requires access to Slack and GitHub APIs.
+    Checks that credentials are available and valid.
+
+    Returns a list of credentials that are invalid or missing.
+
+    Good return: []
+    Bad return: ["GITHUB_TOKEN", "SLACK_BOT_TOKEN"]
+    """
+    bad_credentials = ["GITHUB_TOKEN", "SLACK_BOT_TOKEN"]
+    if settings.GITHUB_TOKEN:
+        client = GithubAPIClient(settings.GITHUB_TOKEN)
+        if client.is_authenticated():
+            # If this is true, the GitHub token is good
+            bad_credentials.remove("GITHUB_TOKEN")
+
+    if settings.SLACK_BOT_TOKEN:
+        with suppress(SlackApiError):  # just breaks on this error
+            next(get_my_channels())
+            # If we get this far, the Slack token is good
+            bad_credentials.remove("SLACK_BOT_TOKEN")
+
+    return bad_credentials
 
 
 @click.command()
@@ -89,7 +131,13 @@ def run_commands(progress: list[str]):
     help="The ID of the user that started this task (For notification purposes)",
     default=None,
 )
-def command(user_id=None):
+@click.option(
+    "--generate_report",
+    is_flag=True,
+    help="Generate a report at the end of the command",
+    default=False,
+)
+def command(user_id=None, generate_report=False):
     """A long running chain of tasks to import and update library data."""
     start = timezone.now()
 
@@ -97,12 +145,23 @@ def command(user_id=None):
     if user_id:
         user = User.objects.filter(id=user_id).first()
 
+    progress = ["___Progress Messages___"]
+    if missing_creds := check_credentials():
+        progress.append(
+            progress_message(f"Missing credentials {', '.join(missing_creds)}")
+        )
+        if user:
+            send_notification(
+                user,
+                message="Your task `release_tasks` failed.",
+                subject="Task Failed: release_tasks",
+            )
+        return
     if user:
         send_notification(user, f"Your task `release_tasks` was started at: {start}")
-    progress = ["___Progress Messages___"]
-    handled_commits = {}
+
     try:
-        handled_commits = run_commands(progress)
+        handled_commits = run_commands(progress, generate_report)
         end = timezone.now()
         progress.append(progress_message(f"All done! Completed in {end - start}"))
     except Exception:
@@ -117,24 +176,24 @@ def command(user_id=None):
                 "\n\n".join(message),
             )
         raise
-    else:
-        zero_commit_libraries = [
-            (key, val) for key, val in handled_commits.items() if val == 0
+
+    zero_commit_libraries = [
+        (key, val) for key, val in handled_commits.items() if val == 0
+    ]
+    message = [
+        f"The task `release_tasks` was completed. Task took: {end - start}",
+        "\n".join(progress),
+    ]
+    if zero_commit_libraries:
+        zero_commit_message = [
+            "The import_commits task did not find commits for these libraries.",
+            "The task may need to re-run.",
         ]
-        message = [
-            f"The task `release_tasks` was completed. Task took: {end - start}",
-            "\n".join(progress),
-        ]
-        if zero_commit_libraries:
-            zero_commit_message = [
-                "The import_commits task did not find commits for these libraries.",
-                "The task may need to re-run.",
-            ]
-            for lib, _ in zero_commit_libraries:
-                zero_commit_message.append(lib)
-            message.append("\n".join(zero_commit_message))
-        if user:
-            send_notification(
-                user,
-                "\n\n".join(message),
-            )
+        for lib, _ in zero_commit_libraries:
+            zero_commit_message.append(lib)
+        message.append("\n".join(zero_commit_message))
+    if user:
+        send_notification(
+            user,
+            "\n\n".join(message),
+        )

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -192,13 +192,15 @@ def update_authors_and_maintainers():
 
 
 @app.task
-def update_commits(token=None, clean=False):
+def update_commits(token=None, clean=False, min_version=""):
     # dictionary of library_key: int
     commits_handled: dict[str, int] = {}
     updater = LibraryUpdater(token=token)
     for library in Library.objects.all():
         logger.info("Importing commits for library.", library=library)
-        commits_handled[library.key] = updater.update_commits(obj=library, clean=clean)
+        commits_handled[library.key] = updater.update_commits(
+            library=library, clean=clean, min_version=min_version
+        )
     logger.info("update_commits finished.")
     return commits_handled
 
@@ -241,7 +243,7 @@ def update_library_version_dependencies(token=None):
 
 
 @app.task
-def release_tasks(user_id=None):
+def release_tasks(user_id=None, generate_report=False):
     """Call the release_tasks management command.
 
     If a user_id is given, that user will receive an email at the beginning
@@ -251,4 +253,6 @@ def release_tasks(user_id=None):
     command = ["release_tasks"]
     if user_id:
         command.extend(["--user_id", user_id])
+    if generate_report:
+        command.append("--generate_report")
     call_command(*command)

--- a/versions/admin.py
+++ b/versions/admin.py
@@ -50,7 +50,7 @@ class VersionAdmin(admin.ModelAdmin):
         return my_urls + urls
 
     def release_tasks(self, request):
-        release_tasks.delay(user_id=request.user.id)
+        release_tasks.delay(user_id=request.user.id, generate_report=True)
         self.message_user(
             request,
             "release_tasks has started, you will receive an email when the task finishes.",  # noqa: E501

--- a/versions/models.py
+++ b/versions/models.py
@@ -205,7 +205,7 @@ class Version(models.Model):
 
     @cached_property
     def release_notes_cache_key(self):
-        """Returns the cahe key used to access the release notes in the
+        """Returns the cache key used to access the release notes in the
         RenderedContent model."""
         version = "-".join(self.cleaned_version_parts)
         return f"release_notes_boost-{version}"


### PR DESCRIPTION
- Significantly improved the speed of the "Do Everything" (DE) button by restricting the data imports to the most recent two versions (for diffing), when before they were importing _everything_, taking hours. Should now take less than an hour to complete.
- Added actual report generation and caching to the DE button (this takes only a few extra seconds)
- Added a weekly scheduled task that runs the DE process
- Added a url and view for staff only that shows the cached report for a given version if it exists, available at `/releases/<version_slug>/report`

Note: I have not implemented PDF rendering. I can do so if we really want it.

Fixes #1603 