### PR TITLE
Pull username/fullname from GitHub (#1639)

### DIFF
--- a/templates/admin/release_report_detail.html
+++ b/templates/admin/release_report_detail.html
@@ -160,12 +160,12 @@ body {
             {% for user in committee_members|dictsort:"display_name" %}
               <figure class="w-32 m-2">
 <!--                 {% if user.hq_image %} -->
-<!--                   <img src="{{ user.hq_image_render.url }}" alt="{{ user.first_name }} {{ user.last_name }}" /> -->
+<!--                   <img src="{{ user.hq_image_render.url }}" alt="{{ user.display_name }}" /> -->
 <!--                 {% else %} -->
 <!--                   <img src="{% static 'img/Boost_Symbol_Transparent.svg' %}" alt="" /> -->
 <!--                 {% endif %} -->
                 {% avatar user=user is_link=False image_size="w-32 h-32" icon_size="text-8xl" %}
-                <figcaption class="p-1">{{user.first_name}} {{user.last_name}}</figcaption>
+                <figcaption class="p-1">{{user.display_name}}</figcaption>
               </figure>
             {% endfor %}
            </div>

--- a/users/models.py
+++ b/users/models.py
@@ -256,7 +256,7 @@ class User(BaseUser):
     # elapsed.
     delete_permanently_at = models.DateTimeField(null=True, editable=False)
 
-    def save_image_from_github(self, avatar_url):
+    def save_image_from_provider(self, avatar_url):
         response = requests.get(avatar_url)
         filename = f"{self.profile_image_filename_root}.png"
         os.path.join(settings.MEDIA_ROOT, "media", "profile-images", filename)


### PR DESCRIPTION
This relates to Ticket #1639, to add support for setting the display name from Github SSO data when accounts are set up.

This also update the code to add support for that and the avatar from Google's SSO process.