### PR TITLE
fix text colors on community page refs #1662

### DIFF
--- a/templates/community_temp.html
+++ b/templates/community_temp.html
@@ -9,7 +9,7 @@
 {% block content %}
   <div class="py-0 px-0 md:py-6 md:px-3">
     <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
-      <div class="p-6 text-white bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
+      <div class="p-6 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
         <h5 class="text-2xl leading-tight text-orange">Mailing Lists</h5>
         <p class="py-1 my-2 border-b pb-4 border-gray-700 text-slate dark:text-white">Discover the Boost library community with options tailored to developers, casual users, and enthusiasts.</p>
         <div class="grid grid-cols-3">
@@ -44,10 +44,10 @@
         </div>
       </div>
 
-      <div class="p-6 text-white bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
+      <div class="p-6 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
         <h5 class="text-2xl leading-tight text-orange">Cpplang Slack Workspace</h5>
 
-        <p class="py-1 my-2 border-b pb-4 border-gray-700 text-slate">A vibrant hub for real-time discussions with Boost authors, maintainers, and contributors. Dive into one of the largest searchable databases for Boost/C++ insights and history. Join now.</p>
+        <p class="py-1 my-2 border-b pb-4 border-gray-700">A vibrant hub for real-time discussions with Boost authors, maintainers, and contributors. Dive into one of the largest searchable databases for Boost/C++ insights and history. Join now.</p>
 
         <div class="flex flex-col">
           <a href="https://cppalliance.org/slack/" class="flex p-3 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">Join Cpplang Slack</a>


### PR DESCRIPTION
Make sure Mailing Lists and Slack text is visible in both light and dark modes