### PR TITLE
adjust display of news type on the homepage refs #1657

### DIFF
--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -212,7 +212,7 @@
             <div class="pt-0">
               <h2 class="flex items-center pb-2 mb-3 text-lg md:text-2xl lg:text-2xl font-semibold mr-4 border-b border-gray-400 dark:border-slate">
                 {% avatar user=entry.author %}
-                <span class="text-sm ml-4 bg-white rounded-full dark:text-gray-300 w-[36px] dark:bg-slate">
+                <span class="text-sm ml-5 bg-white rounded-full dark:text-gray-300 w-[30px] dark:bg-charcoal">
                   {% if entry.tag == "link" %}
                     <i class="fas fa-link"></i>
                   {% elif entry.tag == "news" %}


### PR DESCRIPTION
make the oval the same color as the background, center the type icon between user pic and title