### PR TITLE
Added filter to remove all non-static boostlook.css on library docs (#1684)

### DIFF
--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -148,6 +148,7 @@ def modernize_legacy_page(
     head_selector="head",
     insert_body=True,
     original_docs_type=None,
+    skip_replace_boostlook=False,
     show_footer=True,
     show_navbar=True,
 ):
@@ -177,7 +178,8 @@ def modernize_legacy_page(
             tag.attrs.pop("class")
 
     result = convert_name_to_id(result)
-    result = remove_library_boostlook(result)
+    if not skip_replace_boostlook:
+        result = remove_library_boostlook(result)
 
     # Use the base HTML to later extract the <head> and (part of) the <body>
     placeholder = BeautifulSoup(base_html, "html.parser")

--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -177,6 +177,7 @@ def modernize_legacy_page(
             tag.attrs.pop("class")
 
     result = convert_name_to_id(result)
+    result = remove_library_boostlook(result)
 
     # Use the base HTML to later extract the <head> and (part of) the <body>
     placeholder = BeautifulSoup(base_html, "html.parser")
@@ -287,6 +288,17 @@ def convert_name_to_id(soup):
     for tag in soup.find_all(attrs={"name": True}):
         tag["id"] = tag["name"]
         del tag["name"]
+
+    return soup
+
+
+def remove_library_boostlook(soup):
+    for tag in soup.find_all("link"):
+        if (
+            tag.get("href").endswith("boostlook.css")
+            and tag.get("href") != "/static/css/boostlook.css"
+        ):
+            tag.decompose()
 
     return soup
 

--- a/core/views.py
+++ b/core/views.py
@@ -34,7 +34,11 @@ from .boostrenderer import (
     get_s3_client,
 )
 from .constants import SourceDocType
-from .htmlhelper import modernize_legacy_page, convert_name_to_id
+from .htmlhelper import (
+    modernize_legacy_page,
+    convert_name_to_id,
+    remove_library_boostlook,
+)
 from .markdown import process_md
 from .models import RenderedContent
 from .tasks import (
@@ -473,6 +477,7 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
             extracted_content = content.decode(chardet.detect(content)["encoding"])
             soup = BeautifulSoup(extracted_content, "html.parser")
             soup = convert_name_to_id(soup)
+            soup = remove_library_boostlook(soup)
             soup.find("head").append(
                 soup.new_tag("script", src=f"{STATIC_URL}js/theme_handling.js")
             )

--- a/core/views.py
+++ b/core/views.py
@@ -472,7 +472,7 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
         )
 
         context["hide_footer"] = True
-        context["skip_use_boostbook_v2"] = "/antora/" in self.kwargs.get("content_path")
+        context["skip_use_boostlook"] = "/antora/" in self.kwargs.get("content_path")
         if source_content_type == SourceDocType.ASCIIDOC:
             extracted_content = content.decode(chardet.detect(content)["encoding"])
             soup = BeautifulSoup(extracted_content, "html.parser")
@@ -497,6 +497,7 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
                 insert_body=insert_body,
                 head_selector=head_selector,
                 original_docs_type=SourceDocType.ANTORA,
+                skip_replace_boostlook=context["skip_use_boostlook"],
                 show_footer=False,
                 show_navbar=False,
             )

--- a/templates/docs_libs_placeholder.html
+++ b/templates/docs_libs_placeholder.html
@@ -4,7 +4,9 @@
 {% block extra_head %}
   <link href="{% static 'css/styles.css' %}" rel="stylesheet" />
   <link rel="preload" data-modernizer="boost-legacy-docs-extra-head" href="{% static 'css/fonts.css' %}" rel="stylesheet" />
-  <link rel="preload" data-modernizer="boost-legacy-docs-extra-head" href="{% static 'css/boostlook.css' %}" rel="stylesheet" />
+  {% if not skip_use_boostlook %}
+    <link rel="preload" data-modernizer="boost-legacy-docs-extra-head" href="{% static 'css/boostlook.css' %}" rel="stylesheet" />
+  {% endif %}
   {% comment %}These style tweaks ensure that legacy doc pages are rendered decently. Specifically, the <img /> tag is heavily used in nav bar for tutorial navigation.<style data-modernizer="boost-legacy-docs-extra-head">
                                                                                                                                                                          img {
                                                                                                                                                                            display: inline-block;


### PR DESCRIPTION
After discussing what I was seeing with Julio it seems we need to just filter out the libraries' baked in boostlook.css links which will leave us with the `latest` one as it is on the server at any point in time.