### PR TITLE
Add unaccent lookup to username in user admin search

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -58,7 +58,7 @@ class EmailUserAdmin(UserAdmin):
         "valid_email",
         "claimed",
     )
-    search_fields = ("email", "display_name")
+    search_fields = ("email", "display_name__unaccent")
 
 
 admin.site.register(User, EmailUserAdmin)


### PR DESCRIPTION
Adds `__unaccent` lookup to user display name field for admin search.

![Screenshot 2025-03-10 at 1 31 01 PM](https://github.com/user-attachments/assets/54df4b4e-58a8-43cc-a566-6002752f2d9c)
