### PR TITLE
adjust layout/spacing in mailing lists card for mobile refs #1663

### DIFF
--- a/templates/community_temp.html
+++ b/templates/community_temp.html
@@ -12,18 +12,18 @@
       <div class="p-6 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
         <h5 class="text-2xl leading-tight text-orange">Mailing Lists</h5>
         <p class="py-1 my-2 border-b pb-4 border-gray-700 text-slate dark:text-white">Discover the Boost library community with options tailored to developers, casual users, and enthusiasts.</p>
-        <div class="grid grid-cols-3">
-          <a href="https://lists.boost.org/mailman/listinfo.cgi/boost" class="p-3 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">
+        <div class="grid lg:grid-cols-3">
+          <a href="https://lists.boost.org/mailman/listinfo.cgi/boost" class="px-2 py-3 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">
             <h6 class="pb-1 text-sm md:text-base">Developers</h6>
             <i class="fa fa-helmet-safety"></i>
           </a>
 
-          <a href="https://lists.boost.org/mailman/listinfo.cgi/boost-users" class="order-3 p-3 text-center rounded-lg cursor-pointer lg:order-2 lg:col-span-1 hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">
+          <a href="https://lists.boost.org/mailman/listinfo.cgi/boost-users" class="order-3 px-2 py-3 text-center rounded-lg cursor-pointer lg:order-2 lg:col-span-1 hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">
             <h6 class="pb-1 text-sm md:text-base">Users</h6>
             <i class="fa fa-user fa-lg"></i>
           </a>
 
-          <a href="https://lists.boost.org/mailman/listinfo.cgi/boost-announce" class="order-2 p-3 text-center rounded-lg cursor-pointer lg:order-3 hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">
+          <a href="https://lists.boost.org/mailman/listinfo.cgi/boost-announce" class="order-2 px-2 py-3 text-center rounded-lg cursor-pointer lg:order-3 hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">
             <h6 class="pb-1 text-sm md:text-base">Announcements</h6>
             <i class="fa fa-bullhorn"></i>
           </a>


### PR DESCRIPTION
For narrower browsers, the items will appear vertically

<img width="404" alt="Screenshot 2025-03-14 at 13 10 28" src="https://github.com/user-attachments/assets/070bb789-cef2-4308-8d53-ed098d285333" />
