### PR TITLE
display author name on library when missing refs #1705

### DIFF
--- a/libraries/views.py
+++ b/libraries/views.py
@@ -374,7 +374,7 @@ class LibraryDetail(VersionAlertMixin, BoostVersionMixin, DetailView):
                 user.commitauthor = SimpleNamespace(
                     github_profile_url="",
                     avatar_url="",
-                    display_name="",
+                    display_name=f"{user.display_name}",
                 )
         return qs
 


### PR DESCRIPTION
If the author email is not associated with a CommitAuthor, display the name from the User model, if it exists