### PR TITLE
Disable boostlook legacy wrapper and remove any inlined boostlook.css style - WIP

### DIFF
--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -1,3 +1,5 @@
+import re
+
 from bs4 import BeautifulSoup, Comment
 from django.template.loader import render_to_string
 
@@ -124,7 +126,7 @@ def wrap_main_body_elements(result, original_docs_type=None):
 
     start_index = None
     elements_to_wrap = []
-    wrapper_div = result.new_tag("div", id="boost-legacy-docs-wrapper")
+    wrapper_div = result.new_tag("div", id="todo-remove-boost-legacy-docs-wrapper")
     if original_docs_type:
         # add a class based on the original docs type
         wrapper_div["class"] = f"source-docs-{original_docs_type.value} boostlook"
@@ -180,6 +182,7 @@ def modernize_legacy_page(
     result = convert_name_to_id(result)
     if not skip_replace_boostlook:
         result = remove_library_boostlook(result)
+    result = remove_embedded_boostlook(result)
 
     # Use the base HTML to later extract the <head> and (part of) the <body>
     placeholder = BeautifulSoup(base_html, "html.parser")
@@ -476,6 +479,12 @@ def remove_tables(soup, class_name):
     for table in soup.find_all("table", class_=class_name):
         table.decompose()
 
+    return soup
+
+
+def remove_embedded_boostlook(soup):
+    for style in soup.find_all("style", text=re.compile(r"\.boostlook")):
+        style.decompose()
     return soup
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -249,43 +249,6 @@
     }
 
     /* asciidoc layout base */
-      #boost-legacy-docs-wrapper {
-        margin: auto;
-        max-width: 80rem;
-        overflow: hidden;
-        position: relative;
-        margin-top: 1rem;
-      }
-
-     #boost-legacy-docs-wrapper:not(:has(article.doc)) #toc.toc2 {
-        position: fixed !important;
-        top: 3.5rem;
-        border-top-width: 0 !important;
-        border-bottom-width: 0 !important;
-        z-index: 1000;
-        padding: 1.25em 1em;
-        max-height: calc(100vh - 4rem);
-        height: fit-content;
-        overflow: auto;
-        position: absolute;
-        left: 1rem;
-        -webkit-transform: translateZ(0);
-
-     }
-
-    #boost-legacy-docs-wrapper #header>h1:first-child {
-      margin-top: .5rem !important;
-      color: var(--header-color) !important;
-    }
-
-    #boost-legacy-docs-wrapper > #header,
-    #boost-legacy-docs-wrapper > #content,
-    #boost-legacy-docs-wrapper > #footer,
-    #boost-legacy-docs-wrapper > #footnotes {
-      width: auto;
-      max-width: 62rem;
-     margin-left: 15rem;
-    }
 
     .main-footer {
       max-width: 80rem !important;
@@ -310,52 +273,13 @@
       }
     }
 
-    @media screen and (min-width: 1280px) {
-      #boost-legacy-docs-wrapper:not(:has(article.doc)) #toc.toc2 {
-        position: fixed !important;
-        width: 20em;
-        left: calc((100% - 79rem) / 2) !important;
-        -webkit-transform: translateZ(0);
-      }
-
-      #boost-legacy-docs-wrapper > #header,
-        #boost-legacy-docs-wrapper > #content,
-        #boost-legacy-docs-wrapper > #footer,
-        #boost-legacy-docs-wrapper > #footnotes {
-          margin-left: 20rem;
-          max-width: 59rem !important;
-        }
-
-
-    }
 
     @media screen and (max-width: 769px) {
-      #boost-legacy-docs-wrapper:not(:has(article.doc))#toc.toc2 {
-            width: 100%;
-            left: 0;
-            top: 0;
-            margin-top: 4rem;
-            -webkit-transform: none;
-            padding: 0;
-            padding-left: 1rem;
-      }
 
       .source-docs-asciidoc #header  #toc.toc2 {
          position: relative !important;
          height: auto;
       }
-
-      #boost-legacy-docs-wrapper {
-        margin-top:0;
-      }
-
-      #boost-legacy-docs-wrapper > #header,
-        #boost-legacy-docs-wrapper > #content,
-        #boost-legacy-docs-wrapper > #footer,
-        #boost-legacy-docs-wrapper > #footnotes {
-          margin-left: 0rem;
-          max-width: 100% !important;
-        }
 
         .main-footer {
           margin-left: 0 !important;


### PR DESCRIPTION
This is a work in progress to test some CSS/allow further shared development.

When this is complete I will completely remove the beautiful soup that adds the wrapper class as well as the related styles.

Removed inlined boostlook.css contents and disabled remove-boost-legacy-docs-wrapper (#1707)

There's still a left margin on charconv that will need adjusting but this should be a good jumping off point