### PR TITLE
Fix data migration dependency issue

### DIFF
--- a/versions/migrations/0015_drop_review_generated_stub_users.py
+++ b/versions/migrations/0015_drop_review_generated_stub_users.py
@@ -23,6 +23,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("versions", "0014_version_sponsor_message"),
+        ("users", "0015_user_delete_permanently_at"),
     ]
 
     operations = [


### PR DESCRIPTION
A data migration needed to be run _after_ a certain user migration took place. Ran into this on a fresh db install.