### PR TITLE
Add check for dependency addition/removal counts on release page (#1703)

### DIFF
--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -125,20 +125,29 @@
         class="p-6 my-4 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
         <h2 class="text-2xl mt-0">Dependencies</h2>
         <div>
-          There {{ deps.added|pluralize:"was,were" }}
-          <span class="text-red-700">
-            {{ deps.added }} dependenc{{ deps.added|pluralize:"y,ies"}} added
-          </span>
-          <span>
-            (in {{ deps.increased_dep_lib_count }} librar{{ deps.increased_dep_lib_count|pluralize:"y,ies" }})
-          </span>
-          and
-          <span class="text-[rgb(14,174,96)] dark:text-green">
-            {{ deps.removed }} dependenc{{ deps.removed|pluralize:"y,ies"}} removed
-          </span>
-          <span>
-            (in {{ deps.decreased_dep_lib_count }} librar{{ deps.decreased_dep_lib_count|pluralize:"y,ies" }})
-          </span>
+          {% if deps.added %}
+            There {{ deps.added|pluralize:"was,were" }}
+            <span class="text-red-700">
+              {{ deps.added }} dependenc{{ deps.added|pluralize:"y,ies"}} added
+            </span>
+            <span>
+              (in {{ deps.increased_dep_lib_count }} librar{{ deps.increased_dep_lib_count|pluralize:"y,ies" }})
+            </span>
+          {% endif %}
+          {% if deps.added and deps.removed %}
+            and
+          {% endif %}
+          {% if deps.removed %}
+            {% if not deps.added %}
+              There {{ deps.removed|pluralize:"was,were" }}
+            {% endif %}
+            <span class="text-[rgb(14,174,96)] dark:text-green">
+              {{ deps.removed }} dependenc{{ deps.removed|pluralize:"y,ies"}} removed
+            </span>
+            <span>
+              (in {{ deps.decreased_dep_lib_count }} librar{{ deps.decreased_dep_lib_count|pluralize:"y,ies" }})
+            </span>
+          {% endif %}
           this release.
         </div>
       </section>

--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -120,37 +120,39 @@
       </section>
     {% endif %}
 
-    {% if deps.added or deps.removed %}
-      <section id="dependencyChanges"
-        class="p-6 my-4 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
-        <h2 class="text-2xl mt-0">Dependencies</h2>
-        <div>
-          {% if deps.added %}
-            There {{ deps.added|pluralize:"was,were" }}
-            <span class="text-red-700">
-              {{ deps.added }} dependenc{{ deps.added|pluralize:"y,ies"}} added
-            </span>
-            <span>
-              (in {{ deps.increased_dep_lib_count }} librar{{ deps.increased_dep_lib_count|pluralize:"y,ies" }})
-            </span>
-          {% endif %}
-          {% if deps.added and deps.removed %}
-            and
-          {% endif %}
-          {% if deps.removed %}
-            {% if not deps.added %}
-              There {{ deps.removed|pluralize:"was,were" }}
+    {% if not version.beta %}
+      {% if deps.added or deps.removed %}
+        <section id="dependencyChanges"
+          class="p-6 my-4 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
+          <h2 class="text-2xl mt-0">Dependencies</h2>
+          <div>
+            {% if deps.added %}
+              There {{ deps.added|pluralize:"was,were" }}
+              <span class="text-red-700">
+                {{ deps.added }} dependenc{{ deps.added|pluralize:"y,ies"}} added
+              </span>
+              <span>
+                (in {{ deps.increased_dep_lib_count }} librar{{ deps.increased_dep_lib_count|pluralize:"y,ies" }})
+              </span>
             {% endif %}
-            <span class="text-[rgb(14,174,96)] dark:text-green">
-              {{ deps.removed }} dependenc{{ deps.removed|pluralize:"y,ies"}} removed
-            </span>
-            <span>
-              (in {{ deps.decreased_dep_lib_count }} librar{{ deps.decreased_dep_lib_count|pluralize:"y,ies" }})
-            </span>
-          {% endif %}
-          this release.
-        </div>
-      </section>
+            {% if deps.added and deps.removed %}
+              and
+            {% endif %}
+            {% if deps.removed %}
+              {% if not deps.added %}
+                There {{ deps.removed|pluralize:"was,were" }}
+              {% endif %}
+              <span class="text-[rgb(14,174,96)] dark:text-green">
+                {{ deps.removed }} dependenc{{ deps.removed|pluralize:"y,ies"}} removed
+              </span>
+              <span>
+                (in {{ deps.decreased_dep_lib_count }} librar{{ deps.decreased_dep_lib_count|pluralize:"y,ies" }})
+              </span>
+            {% endif %}
+            this release.
+          </div>
+        </section>
+      {% endif %}
     {% endif %}
 
     {% if top_contributors_release %}


### PR DESCRIPTION
Screenshot only shows removed. Both will show when both exist, or only added will show up if only added has a value > 0.

![removed_only](https://github.com/user-attachments/assets/febd2dc3-59b8-4ebc-9d62-8fd1f45dda90)
