### PR TITLE
update review schedule links

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -79,8 +79,6 @@ from versions.converters import BoostVersionSlugConverter
 from versions.feeds import AtomVersionFeed, RSSVersionFeed
 from versions.views import (
     InProgressReleaseNotesView,
-    PastReviewListView,
-    ScheduledReviewListView,
     VersionDetail,
     ReportPreviewView,
     ReportPreviewGenerateView,
@@ -309,7 +307,13 @@ urlpatterns = (
         ),
         path(
             "review/past/",
-            PastReviewListView.as_view(),
+            RedirectView.as_view(
+                url=reverse_lazy(
+                    "docs-user-guide",
+                    kwargs={"content_path": "formal-reviews/review-results.html"},
+                ),
+                permanent=True,
+            ),
             name="review-past",
         ),
         path(
@@ -319,7 +323,13 @@ urlpatterns = (
         ),
         path(
             "review/upcoming/",
-            ScheduledReviewListView.as_view(),
+            RedirectView.as_view(
+                url=reverse_lazy(
+                    "docs-user-guide",
+                    kwargs={"content_path": "formal-reviews/review-results.html"},
+                ),
+                permanent=True,
+            ),
             name="review-upcoming",
         ),
         path(

--- a/templates/docs_temp.html
+++ b/templates/docs_temp.html
@@ -110,10 +110,7 @@
             <a class="list-item text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="{% url 'review-process' %}">Submission Process</a>
           </div>
           <div class="w-auto ml-6 mr-2">
-            <a class="list-item text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="{% url 'review-past' %}">Past Review Results and Milestones</a>
-          </div>
-          <div class="w-auto ml-6 mr-2">
-            <a class="list-item text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="{% url 'review-upcoming' %}">Upcoming Reviews</a>
+            <a class="list-item text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="{% url 'review-upcoming' %}">Review Schedule - Current and Past</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
* redirect past and upcoming review links to new location
* update links on /docs

https://github.com/boostorg/website-v2-docs/issues/424

We can't redirect to anchors on a page, so I updated both links to point to the new page, and combined the links on /docs