### PR TITLE
Don't crash for missing profile image

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -286,7 +286,11 @@ class User(BaseUser):
 
     def get_thumbnail_url(self):
         # convenience method for templates
-        if self.image and self.image_thumbnail:
+        if (
+            self.image
+            and self.image.storage.exists(self.image.name)
+            and self.image_thumbnail
+        ):
             return getattr(self.image_thumbnail, "url", None)
 
     @property


### PR DESCRIPTION
Testing locally, I was missing the image for my profile picture, and the entire site (all pages with the header) was crashing. This change makes the profile image property fail gracefully when the image file is missing.