### PR TITLE
Add SLL header env vars

### DIFF
--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -191,6 +191,11 @@ Env:
     value: redis://redis:6379/0
   - name: CELERY_BACKEND
     value: redis://redis:6379/0
+  # SSL header settings
+  - name: SECURE_PROXY_SSL_HEADER_NAME
+    value: "HTTP_X_FORWARDED_PROTO"
+  - name: SECURE_PROXY_SSL_HEADER_VALUE
+    value: "https"
 
 # Volumes
 Volumes:


### PR DESCRIPTION
This is somewhat of a shot in the dark to try and fix an issue with font urls being redirected to http scheme when appending a slash. @sdarwin doesn't think the issue is in Django, so this won't fix the problem if he's right about that (there are other reasons this could not work too!), but it's low risk, and I will revert it if it doesn't work and/or causes problems on stage.