### PR TITLE
nginx slash redirect uses https

### DIFF
--- a/kube/boost/templates/configmap-nginx.yaml
+++ b/kube/boost/templates/configmap-nginx.yaml
@@ -63,7 +63,12 @@ data:
 
       location @django2 {
           if ($uri !~* /$ ) {
-              rewrite  ^(.*)$  $1/ redirect;
+              # "basic" redirect, adding a slash:
+              # rewrite  ^(.*)$  $1/ redirect;
+              #
+              # instead, redirect everything to https
+              # (since nginx is only seeing http at the pod)
+              rewrite  ^(.*)$  https://$host$1/ redirect;
           }
           proxy_pass http://unix:/run/gunicorn.sock;
       }


### PR DESCRIPTION
Within the 1000's of pages of boost documentation it sometimes happens that visitors go to a webpage that ought to be a directory and should have a / slash on the end.  So, if a page fails to load, nginx tries a second time, adding a slash / , and that often solves it.    A small issue is that nginx is only seeing http connections, and redirects to http.   That will still work for most situations, because http is redirected yet again, at the LB.   This PR modification directly uses https when adding the slash.  