### PR TITLE
Fix an issue with docs boostlook wrapper div

### DIFF
--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -131,8 +131,12 @@ def wrap_main_body_elements(
     elements_to_wrap = []
     wrapper_div = result.new_tag("div")
     if original_docs_type:
-        # add a class based on the original docs type
-        wrapper_div["class"] = f"source-docs-{original_docs_type.value} boostlook"
+        # add classes based on the original docs type
+        class_list = [f"source-docs-{original_docs_type.value}"]
+        if original_docs_type != SourceDocType.ANTORA:
+            # Antora docs have a boostlook class already; others need it.
+            class_list.append("boostlook")
+        wrapper_div["class"] = " ".join(class_list)
     for index, element in enumerate(result.find("body").children):
         if is_end_comment(element):
             start_index = index

--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -4,7 +4,7 @@ from bs4 import BeautifulSoup, Comment
 from django.template.loader import render_to_string
 
 from core.boostrenderer import get_body_from_html
-
+from core.constants import SourceDocType
 
 # List HTML elements (with relevant attributes) to remove the FIRST occurrence
 REMOVE_TAGS = [
@@ -118,15 +118,18 @@ def _replace_body(result, original_body, base_body):
         result.body.body.unwrap()
 
 
-def wrap_main_body_elements(result, original_docs_type=None):
-    def is_end_comment(element):
+def wrap_main_body_elements(
+    result: BeautifulSoup, original_docs_type: SourceDocType | None = None
+):
+    def is_end_comment(html_element):
         return (
-            isinstance(element, Comment) and element == " END Manually appending items "
+            isinstance(html_element, Comment)
+            and html_element == " END Manually appending items "
         )
 
     start_index = None
     elements_to_wrap = []
-    wrapper_div = result.new_tag("div", id="todo-remove-boost-legacy-docs-wrapper")
+    wrapper_div = result.new_tag("div")
     if original_docs_type:
         # add a class based on the original docs type
         wrapper_div["class"] = f"source-docs-{original_docs_type.value} boostlook"
@@ -149,7 +152,7 @@ def modernize_legacy_page(
     base_html,
     head_selector="head",
     insert_body=True,
-    original_docs_type=None,
+    original_docs_type: SourceDocType | None = None,
     skip_replace_boostlook=False,
     show_footer=True,
     show_navbar=True,


### PR DESCRIPTION
- Removes the no-longer-required wrapper div's id.
- Only adds `boostlook` class to non-Antora docs
- Includes a hack that continues to add "-antora" to pages with no known original doc type (e.g. Beast)

Antora doc looks better:
![Screenshot 2025-04-08 at 11 52 41 AM](https://github.com/user-attachments/assets/c5ee4cd6-e321-4e54-82c1-72589feff65f)

Non-Antora doc unchanged:
![Screenshot 2025-04-08 at 5 39 05 PM](https://github.com/user-attachments/assets/8382df06-2114-47ac-b04c-ac9bcee258f3)
