### PR TITLE
fix docs anchor scrolling with custom margins (#1665)

### DIFF
--- a/templates/docsiframe.html
+++ b/templates/docsiframe.html
@@ -7,6 +7,7 @@
         id="docsiframe"
     ></iframe>
     <script>
+      debugger;
       function iframeCustomizations(iframe) {
         let iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
         {#resizeIframe(iframe);#}
@@ -24,7 +25,17 @@
       function scrollToAnchor(iframeDoc, hash) {
         const targetElement = iframeDoc.getElementById(hash);
         if (targetElement) {
-          targetElement.scrollIntoView({behavior: 'smooth'});
+          // Add space above the target element - more space on mobile
+          const isMobile = window.innerWidth < 768;
+          const topMargin = isMobile ? 50 : 14;
+
+          const y = targetElement.getBoundingClientRect().top +
+                    iframeDoc.defaultView.pageYOffset - topMargin;
+
+          iframeDoc.defaultView.scrollTo({
+            top: y,
+            behavior: 'smooth'
+          });
         }
       }
 


### PR DESCRIPTION
### Description
- add offset margins to prevent header overlap
- apply larger top margin on mobile devices
- use scrollTo instead of scrollIntoView for better control

References issue #1665

### Preview

**Mobile:**
https://github.com/user-attachments/assets/b151b2af-89af-44f0-b6a2-4323c5275b94

**Desktop:**
<img width="1512" alt="Screenshot 2025-04-14 at 5 08 19 PM" src="https://github.com/user-attachments/assets/036d7b77-b296-4d5d-80b1-7d8daa0ce551" />

### To-do
- [ ] copy link functionality
