### PR TITLE
refactor: replace noto sans display with noto sans

### DIFF
--- a/docstailwind.config.js
+++ b/docstailwind.config.js
@@ -28,15 +28,15 @@ module.exports = {
       silver: '#B5C9D3',
     },
     extend: {
-      fontFamily: {
-        'sans': [
-          '"Noto Sans"',
-          process.env.ENVIRONMENT_NAME == 'Development Environment' ?
-            'serif'
-          :
-            'sans-serif',
-        ]
-      }
+      // fontFamily: {
+      //   'sans': [
+      //     '"Noto Sans"',
+      //     process.env.ENVIRONMENT_NAME == 'Development Environment' ?
+      //       'serif'
+      //     :
+      //       'sans-serif',
+      //   ]
+      // }
     }
   },
   variants: {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -110,7 +110,6 @@
   kbd,
   samp,
   pre {
-    font-family: 'Noto Mono', monospace;
     /* 1 */
     @apply text-sm text-sky-800 dark:text-sky-200 overflow-x-scroll;
     /* 2 */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,15 +42,15 @@ module.exports = {
           900: '#151E37',
         }
       },
-      fontFamily: {
-        'sans': [
-          '"Noto Sans"',
-          process.env.ENVIRONMENT_NAME == 'Development Environment' ?
-            'serif'
-          :
-            'sans-serif',
-        ],
-      }
+      // fontFamily: {
+      //   'sans': [
+      //     '"Noto Sans"',
+      //     process.env.ENVIRONMENT_NAME == 'Development Environment' ?
+      //       'serif'
+      //     :
+      //       'sans-serif',
+      //   ],
+      // }
     },
   },
   variants: {

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,13 +38,13 @@
     {% block extra_head %}
       <link href="{% static 'css/styles.css' %}" rel="stylesheet">
       <link href="{% static 'css/components.css' %}" rel="stylesheet">
-      <link rel="preload" as="style" href="{% static 'css/fonts.css' %}" rel="stylesheet">
+      {% comment %} <link rel="preload" as="style" href="{% static 'css/fonts.css' %}" rel="stylesheet"> {% endcomment %}
       <link href="{% static 'css/boostlook.css' %}" rel="stylesheet">
     {% endblock %}
 
     {% block css %}{% endblock css %}
     <style>
-    @import url({% static 'css/fonts.css' %});
+    {% comment %} @import url({% static 'css/fonts.css' %}); {% endcomment %}
     {% include "includes/_css_variables.css" %}
     .header-menu-bar {
         padding: 0 1rem;
@@ -324,6 +324,10 @@
         color: #f00;
       }
     </style>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wdth,wght@62.5..100,100..900&family=Noto+Sans:ital,wdth,wght@0,62.5..100,100..900;1,62.5..100,100..900&display=swap" rel="stylesheet">
   </head>
 
   <body x-init="() => {const m = localStorage.getItem('colorMode');

--- a/templates/docs_libs_placeholder.html
+++ b/templates/docs_libs_placeholder.html
@@ -3,7 +3,7 @@
 
 {% block extra_head %}
   <link href="{% static 'css/styles.css' %}" rel="stylesheet" />
-  <link rel="preload" data-modernizer="boost-legacy-docs-extra-head" href="{% static 'css/fonts.css' %}" rel="stylesheet" />
+  {% comment %} <link rel="preload" data-modernizer="boost-legacy-docs-extra-head" href="{% static 'css/fonts.css' %}" rel="stylesheet" /> {% endcomment %}
   {% if not skip_use_boostlook %}
     <link rel="preload" data-modernizer="boost-legacy-docs-extra-head" href="{% static 'css/boostlook.css' %}" rel="stylesheet" />
   {% endif %}

--- a/userguidetailwind.config.js
+++ b/userguidetailwind.config.js
@@ -29,15 +29,15 @@ module.exports = {
       active: '#1565c0',
     },
     extend: {
-      fontFamily: {
-        'sans': [
-          '"Noto Sans"',
-          process.env.ENVIRONMENT_NAME == 'Development Environment' ?
-            'serif'
-          :
-            'sans-serif',
-        ]
-      }
+      // fontFamily: {
+      //   'sans': [
+      //     '"Noto Sans"',
+      //     process.env.ENVIRONMENT_NAME == 'Development Environment' ?
+      //       'serif'
+      //     :
+      //       'sans-serif',
+      //   ]
+      // }
     },
   },
   variants: {


### PR DESCRIPTION
- Standardizes typography by replacing "Noto Sans Display" with "Noto Sans"
- Comments out redundant font family declarations in Tailwind configs
- Updates font variation settings for improved rendering
- Ensures consistent typography across all site templates
- Simplifies font management and maintenance