### PR TITLE
Add docs links to library list view

### DIFF
--- a/templates/libraries/_library_categorized_list_item.html
+++ b/templates/libraries/_library_categorized_list_item.html
@@ -13,6 +13,11 @@ onclick="window.location='{% url 'library-detail' library_slug=library_version.l
           {% if library_version.cpp_standard_minimum and library_version.cpp_standard_minimum != 'None' %}{{ library_version.cpp_standard_minimum }}{% else %}03{% endif %}
     </span>
   </td>
+  <td class="py-3 pr-2 align-top">
+    <a class="text-sky-600 dark:text-sky-300 text-base" href="{{ library_version.documentation_url }}" title="Documentation">
+      <i class="fa fa-book icon-link"></i>
+    </a>
+  </td>
   <td class="hidden md:block py-2 pl-3 align-top">{{ library_version.description|default:"No description provide for this version." }}</td>
 </tr>
 <tr class="block md:hidden">

--- a/templates/libraries/_library_grid_list_item.html
+++ b/templates/libraries/_library_grid_list_item.html
@@ -5,7 +5,12 @@
 onclick="window.location='{% url 'library-detail' library_slug=library_version.library.slug version_slug=version_str %}'">
   <div class="">
     <h3 class="pb-2 text-xl md:text-2xl capitalize border-b border-gray-700">
+    <div class="flex justify-between">
       <a class="link-header" href="{% url 'library-detail' library_slug=library_version.library.slug version_slug=version_str %}">{{ library_version.library.name }}</a>
+      <a class="text-sky-600 dark:text-sky-300 text-base" href="{{ library_version.documentation_url }}" title="Documentation">
+        <i class="fa fa-book icon-link"></i>
+      </a>
+    </div>
       {% for author in library.authors.all %}
         {% if author.image %}
           <img src="{{ author.image.url }}" class="inline float-right rounded w-[30px] ml-1" alt="{{ author.display_name }}" />

--- a/templates/libraries/_library_vertical_list_item.html
+++ b/templates/libraries/_library_vertical_list_item.html
@@ -12,6 +12,11 @@ onclick="window.location='{% url 'library-detail' library_slug=library_version.l
           {% if library_version.cpp_standard_minimum and library_version.cpp_standard_minimum != 'None' %}{{ library_version.cpp_standard_minimum }}{% else %}03{% endif %}
     </span>
   </td>
+  <td class="py-3 pr-2 align-top">
+    <a class="text-sky-600 dark:text-sky-300 text-base" href="{{ library_version.documentation_url }}" title="Documentation">
+      <i class="fa fa-book icon-link"></i>
+    </a>
+  </td>
   <td class="hidden md:block py-2 pl-3 align-top">{{ library_version.description|default:"No description provide for this version." }}</td>
 </tr>
 <tr class="block md:hidden pl-1">


### PR DESCRIPTION
Adds a link to each library's documentation page on the Libraries list view, saving a click for users who want to go directly to the docs.

![screenshot_2025-05-14_at_5 50 15___pm_720](https://github.com/user-attachments/assets/1b56fb8d-1346-4049-afdc-e21851dc8c1c)

![screenshot_2025-05-14_at_5 56 04___pm_720](https://github.com/user-attachments/assets/b34bf6b3-30c2-400f-a296-b99d43ac9246)
