### PR TITLE
HPA - horizontal pod autoscaler

### DIFF
--- a/kube/boost/templates/hpa.yaml
+++ b/kube/boost/templates/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: boost
+spec:
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 50
+        type: Utilization
+    type: Resource
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: boost


### PR DESCRIPTION
There are two django pods in each environment. The autoscaler sets min:2 and max: 8. It will stay at the minimum level unless cpu goes above 50%.