### PR TITLE
ipv6 on GKE Gateway

### DIFF
--- a/kube/boost/templates/gateway.yaml
+++ b/kube/boost/templates/gateway.yaml
@@ -19,6 +19,10 @@ spec:
   addresses:
     - type: NamedAddress
       value: {{ .Values.gatewayStaticIp }}
+{{- if .Values.gatewayStaticIpv6 }}
+    - type: NamedAddress
+      value: {{ .Values.gatewayStaticIpv6 }}
+{{- end }}
 
 ---
 kind: HTTPRoute

--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -239,5 +239,6 @@ managedCertName: managed-cert-cppal-dev,managed-cert-cppal-dev2
 secretCertName: boostorgcert
 ingressStaticIp: cppal-dev-ingress1
 gatewayStaticIp: cppal-dev-ingress1
+gatewayStaticIpv6: cppal-dev-gateway-ipv6
 redisInstall: false
 celeryInstall: true

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -238,5 +238,6 @@ managedCertName: managed-cert-boost-production,managed-cert-boost-production2
 secretCertName: boostorgcert
 ingressStaticIp: boost-production-ingress1
 gatewayStaticIp: boost-io-ingress1
+gatewayStaticIpv6: production-gateway-ipv6
 redisInstall: false
 celeryInstall: true

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -238,5 +238,6 @@ managedCertName: managed-cert-boost-stage,managed-cert-boost-stage2
 secretCertName: boostorgcert
 ingressStaticIp: boost-stage-ingress1
 gatewayStaticIp: boost-stage-ingress1
+gatewayStaticIpv6: stage-gateway-ipv6
 redisInstall: false
 celeryInstall: true


### PR DESCRIPTION
Assign an ipv6 address to the google load balancer, so the apex domain redirect also supports ipv6.