### PR TITLE
Temporarily disable user profile page

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -73,7 +73,6 @@ from users.views import (
     CustomLoginView,
     CustomSignupView,
     CustomSocialSignupViewView,
-    ProfileView,
     UserViewSet,
     UserAvatar,
     DeleteUserView,
@@ -171,7 +170,8 @@ urlpatterns = (
             DeleteImmediatelyView.as_view(),
             name="profile-delete-immediately",
         ),
-        path("users/<int:pk>/", ProfileView.as_view(), name="profile-user"),
+        # Return a 404 for now. Profile view is not ready.
+        # path("users/<int:pk>/", ProfileView.as_view(), name="profile-user"),
         path("users/avatar/", UserAvatar.as_view(), name="user-avatar"),
         path("api/v1/users/me/", CurrentUserAPIView.as_view(), name="current-user"),
         path(


### PR DESCRIPTION
Currently, the user profile view (located at `/users/<user_id>/`) uses the same template as the edit profile view, and shows all the forms for editing the user. The fields are not shown, and the buttons don't work, but this is certainly not what we want.

![Screenshot 2025-05-23 at 12 56 30 PM](https://github.com/user-attachments/assets/e88db2a3-aa46-4f43-aad7-a71d5dbf7232)

Let's disable this view until we implement something useful (e.g. #1804).