### PR TITLE
Make user guide docs full width for consistency

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -642,6 +642,7 @@ class UserGuideTemplateView(BaseStaticContentTemplateView):
             "docs_libs_placeholder.html", context, request=self.request
         )
         context["hide_footer"] = True
+        context["full_width"] = True
         context["content"] = modernize_legacy_page(
             content,
             base_html,


### PR DESCRIPTION
**Description:**
Sets `full_width = True` in `UserGuideTemplateView` to match library documentation layout. Only affects user guide pages.

**Screenshots:**

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/5516c4cd-33de-43d4-8402-89d69950520a" />
