### PR TITLE
Add meta charset to library docs template

### DIFF
--- a/templates/original_docs.html
+++ b/templates/original_docs.html
@@ -4,6 +4,7 @@
 <!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE }}" class="toc-hidden">
   <head>
+    <meta charset="utf-8">
     <link href="{% static 'css/header.css' %}">
     <script defer data-domain="preview.boost.org" src="https://plausible.io/js/script.manual.js"></script>
     <script src="{% static 'js/boost-gecko/main.eb9cabc5.js' %}" defer></script>


### PR DESCRIPTION
This turned out to be a simpler fix than expected - adding `<meta charset="utf-8">` to the `head` of the docs template fixed the instances of this shown in the ticket.

Fixes #1815 