### PR TITLE
Improve docs performance - postgres caching (#1828)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -285,6 +285,8 @@ CACHES = {
     },
 }
 
+ENABLE_DB_CACHE = env.bool("ENABLE_DB_CACHE", default=False)
+
 # Default interval by which to clear the static content cache
 CLEAR_STATIC_CONTENT_CACHE_DAYS = 7
 

--- a/core/admin.py
+++ b/core/admin.py
@@ -4,7 +4,7 @@ from .models import RenderedContent, SiteSettings
 
 @admin.register(RenderedContent)
 class RenderedContentAdmin(admin.ModelAdmin):
-    list_display = ("cache_key", "content_type")
+    list_display = ("cache_key", "content_type", "modified")
     search_fields = ("cache_key",)
 
 

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -84,4 +84,3 @@ def save_rendered_content(cache_key, content_type, content_html, last_updated_at
         obj_id=obj.id,
         obj_created=created,
     )
-    return obj

--- a/env.template
+++ b/env.template
@@ -42,6 +42,9 @@ MAILMAN_ADMIN_USER=""
 MAILMAN_ADMIN_EMAIL=""
 SERVE_FROM_DOMAIN=localhost
 
+# Postgres caching of pages, currently only used for docs
+ENABLE_DB_CACHE=True
+
 # Celery settings
 CELERY_BROKER=redis://redis:6379/0
 CELERY_BACKEND=redis://redis:6379/0

--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -191,6 +191,9 @@ Env:
     value: redis://redis:6379/0
   - name: CELERY_BACKEND
     value: redis://redis:6379/0
+  # postgres caching of s3 text file content
+  - name: ENABLE_DB_CACHE
+    value: "true"
 
 # Volumes
 Volumes:

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -191,6 +191,9 @@ Env:
     value: redis://redis:6379/0
   - name: CELERY_BACKEND
     value: redis://redis:6379/0
+  # postgres caching of s3 text file content
+  - name: ENABLE_DB_CACHE
+    value: "true"
 
 # Volumes
 Volumes:

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -191,6 +191,9 @@ Env:
     value: redis://redis:6379/0
   - name: CELERY_BACKEND
     value: redis://redis:6379/0
+  # postgres caching of s3 text file content
+  - name: ENABLE_DB_CACHE
+    value: "true"
 
 # Volumes
 Volumes:

--- a/kube/boost/values.yaml
+++ b/kube/boost/values.yaml
@@ -167,6 +167,9 @@ Env:
   # Static content cache timeout
   - name: STATIC_CACHE_TIMEOUT
     value: "60"
+  # postgres caching of s3 text file content
+  - name: ENABLE_DB_CACHE
+    value: "true"
 
 # Volumes
 Volumes:


### PR DESCRIPTION
Currently the workflow for docs is:

1. Query against Redis which returns nothing
2. Query against Postgres which returns nothing 
3. Item fetch from s3.

This eliminates the redis layer (too high cost for the benefit) and updates the `save_to_database()` function so we now actually store docs which it wasn't previously doing.

The change in terms of DB queries is now: on the first access/crawl by a bot there'll be a write on each page, and from that point on the query on each page will actually return the content instead of returning empty.

For that reason I wouldn't expect this to significantly impact performance, 1 write or read isn't significant, they won't occur in parallel.

For staging the database storage disk size should be ok:

```psql
postgres=# SHOW data_directory;
      data_directory
---------------------------
 /disk2/postgres-data/main ```

and

```sh
postgres@staging-db1-2:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
...
/dev/sdb        748G  3.4G  706G   1% /disk2
```

Production will need to be checked.

This PR also eliminate a cause of logged error in the `save_rendered_content` task.