### PR TITLE
Unescape special characters

### DIFF
--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -1,4 +1,5 @@
 import re
+from html import unescape
 
 from bs4 import BeautifulSoup, Comment, Tag
 from django.template.loader import render_to_string
@@ -259,6 +260,7 @@ def slightly_modernize_legacy_library_doc_page(content):
             el.getparent().remove(el)
 
     content = html.tostring(root, encoding="unicode", method="html")
+    content = unescape(content)  # avoid escaping special characters like ń
     return content.replace("https://www.boost.org/doc/libs/", "/doc/libs/")
 
 


### PR DESCRIPTION
Fixes an issue seen here: https://www.boost.org/doc/libs/develop/libs/bloom/doc/html/bloom.html#acknowledgements

Before:
![Screenshot 2025-07-03 at 2 44 02 PM](https://github.com/user-attachments/assets/809a7a84-34fd-48f4-afd8-0cd3752bbf2a)

After:
![Screenshot 2025-07-03 at 2 43 07 PM](https://github.com/user-attachments/assets/622457f1-9c0e-44ba-9aaf-0cbb80b42d16)
