### PR TITLE
Fix bug with stale news moderation link and add tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -53,6 +53,9 @@ alias shell := console
 @test_pytest:  ## runs pytest
     -docker compose run --rm -e DEBUG_TOOLBAR="False" web pytest -s --create-db
 
+@test_pytest_lf:  ## runs last failed pytest tests
+    -docker compose run --rm -e DEBUG_TOOLBAR="False" web pytest -s --create-db --lf
+
 @test_pytest_asciidoctor:  ## runs asciidoctor tests
     -docker compose run --rm -e DEBUG_TOOLBAR="False" web pytest -m asciidoctor -s --create-db
 

--- a/news/views.py
+++ b/news/views.py
@@ -150,7 +150,10 @@ class EntryDetailView(DetailView):
             context["next_url"] = next_url
         context["next"] = get_published_or_none(self.object.get_next_by_publish_at)
         context["prev"] = get_published_or_none(self.object.get_previous_by_publish_at)
-        category_kwarg = {f"{self.object.tag}__isnull": False}
+        if self.object.tag:
+            category_kwarg = {f"{self.object.tag}__isnull": False}
+        else:
+            category_kwarg = {}
         context["next_in_category"] = get_published_or_none(
             partial(self.object.get_next_by_publish_at, **category_kwarg)
         )
@@ -180,10 +183,10 @@ class EntryModerationMagicApproveView(View):
             moderator = User.objects.get(id=moderator_id)
         except SignatureExpired:
             message = _("This link has expired.")
-            if not request.user.is_authenticated():
+            if not request.user.is_authenticated:
                 message += _(" Please login to continue.")
             messages.warning(request, message)
-            return redirect(reverse_lazy("news-moderate"), permanent=True)
+            return redirect(reverse_lazy("news-moderate"))
         except (BadData, User.DoesNotExist):
             return HttpResponseForbidden("Invalid magic link.")
 
@@ -195,7 +198,7 @@ class EntryModerationMagicApproveView(View):
         except Entry.AlreadyApprovedError:
             messages.warning(request, _("This entry has already been approved."))
 
-        return redirect(entry, permanent=True)
+        return redirect(entry)
 
 
 class EntryCreateView(LoginRequiredMixin, SuccessMessageMixin, CreateView):


### PR DESCRIPTION
There was a small bug with the code handling expired news moderation magic links. This PR fixes that and adds several tests for this view to prevent future regression.

### Steps for testing

I recommend going through these steps first on the develop branch to verify it fails with a server error, then on this branch to verify it doesn't crash.

1. Set MAGIC_LINK_EXPIRATION to a short duration (perhaps 5 minutes — it's currently set to 24h).
2. Create a new news item as a non‑moderator.
3. Sign out, and click the link before it expires — you should be taken to the news item’s detail page, and the news item should be approved.
4. Wait until the magic link expires.
5. Sign out (if logged in), and click the now‑expired link:
  a. On develop, you should see a server error.
  b. On this branch, you should be redirected to the login page with a message saying the link has expired.
6. Sign in as a moderator and click the expired link again:
  a. On develop, you should see a server error.
  b. On this branch, you should be redirected to the moderation list with a message saying the link has expired.