### PR TITLE
Mask missing kibrary dependency data handling

### DIFF
--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -137,41 +137,45 @@
     </section>
     {% endif %}
 
-    {% if dependency_diff.previous_dependencies and dependency_diff.current_dependencies %}
     <section class="p-6 pt-1 my-4 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
       <h2 class="text-2xl">Dependencies</h2>
-      <div class="flex gap-x-4 gap-y-2 flex-wrap">
-        {% for dep in dependency_diff.current_dependencies %}
-          <div>
-            {{ dep.name }}
-          </div>
-        {% endfor %}
-      </div>
-
-      {% if dependency_diff.added %}
-        <h4 class="mt-3">Added</h4>
-        <div class="flex gap-x-4 flex-wrap">
+      {% if dependency_diff.previous_dependencies and dependency_diff.current_dependencies %}
+        <div class="flex gap-x-4 gap-y-2 flex-wrap">
           {% for dep in dependency_diff.current_dependencies %}
-            {% if dep.name in dependency_diff.added %}
-              <div>{{ dep.name }}</div>
-            {% endif %}
+            <div>
+              {{ dep.name }}
+            </div>
           {% endfor %}
         </div>
-      {% endif %}
 
-      {% if dependency_diff.removed %}
-        <h4 class="mt-3">Removed</h4>
-        <div class="flex gap-x-4 flex-wrap">
-          {% for dep in dependency_diff.previous_dependencies %}
-            {% if dep.name in dependency_diff.removed %}
-              <div>{{ dep.name }}</div>
-            {% endif %}
-          {% endfor %}
+        {% if dependency_diff.added %}
+          <h4 class="mt-3">Added</h4>
+          <div class="flex gap-x-4 flex-wrap">
+            {% for dep in dependency_diff.current_dependencies %}
+              {% if dep.name in dependency_diff.added %}
+                <div>{{ dep.name }}</div>
+              {% endif %}
+            {% endfor %}
+          </div>
+        {% endif %}
+
+        {% if dependency_diff.removed %}
+          <h4 class="mt-3">Removed</h4>
+          <div class="flex gap-x-4 flex-wrap">
+            {% for dep in dependency_diff.previous_dependencies %}
+              {% if dep.name in dependency_diff.removed %}
+                <div>{{ dep.name }}</div>
+              {% endif %}
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% elif dependencies_not_calculated %}
+        <div class="text-sm">
+          Library dependencies will be generated soon, please check back later.
         </div>
       {% endif %}
 
     </section>
-    {% endif %}
 
     {% if description %}
       <section id="libraryReadMe"

--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -81,8 +81,12 @@
                   </div>
                 </div>
               </div>
+              {% elif dependencies_not_calculated %}
+                <div class="text-base whitespace-normal text-sm">
+                  Library dependency calculations will be generated soon, please check back later.
+                </div>
+              {% endif %}
             </div>
-          {% endif %}
         {% endif %}
 
         </div>

--- a/versions/exceptions.py
+++ b/versions/exceptions.py
@@ -1,0 +1,4 @@
+class BoostImportedDataException(Exception):
+    """Custom exception for Boost data errors."""
+
+    pass


### PR DESCRIPTION
Added hiding of dependencies when the dependency import process hasn't run (Ticket #1703)

This applies to both the library details page dependency listing and the dependency calculations on the releases page.

After discussion with Rob we're displaying the following messages rather than just hiding the incorrect values (to preempt issue reports).

<img width="1563" height="1142" alt="dependencies_1" src="https://github.com/user-attachments/assets/2ff82954-44b6-4e53-9ff8-e7c6c0e932ec" />
<img width="1617" height="859" alt="dependencies_2" src="https://github.com/user-attachments/assets/e4446b6e-d9d3-462d-acb7-bc55095ce804" />
