### PR TITLE
Updated references of boost.io to boost.org (#1870)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Django based website that will power a new Boost website. See the [documentati
 Links:
 
 - https://www.stage.boost.cppalliance.org/ - staging
-- https://www.boost.io/ - production
+- https://www.boost.org/ - production
 
 ---
 

--- a/static/css/boostlook.css
+++ b/static/css/boostlook.css
@@ -25,7 +25,7 @@
  * The framework supports these main documentation templates:
  *
  * 1. AsciiDoctor Template:
- * example: https://www.boost.io/doc/libs/1_87_0/libs/charconv/doc/html/charconv.html
+ * example: https://www.boost.org/doc/libs/1_87_0/libs/charconv/doc/html/charconv.html
  * <div class="boostlook">
  *   <div class="header">
  *     <h1>Title</h1>
@@ -41,7 +41,7 @@
  * </div>
  *
  * 2. Antora Template:
- * example: https://www.boost.io/doc/libs/1_87_0/doc/antora/url/index.html
+ * example: https://www.boost.org/doc/libs/1_87_0/doc/antora/url/index.html
  * <div class="boostlook">
  *   <div id="header">
  *     <div id="toc" class="nav-container toc2">Navigation</div>
@@ -57,7 +57,7 @@
  * </div>
  *
  * 3. Quickbook Template:
- * example: https://www.boost.io/doc/libs/1_87_0/doc/html/accumulators.html
+ * example: https://www.boost.org/doc/libs/1_87_0/doc/html/accumulators.html
  * <div class="boostlook">
  *    <div class="spirit-nav">Navigation</div>
  *    <div class="chapter">  <!-- might also be .section, .refentry, .document, or .book -->
@@ -69,7 +69,7 @@
  * </div>
  *
  * 4. README Template:
- * example: https://www.boost.io/library/1.87.0/beast/
+ * example: https://www.boost.org/library/1.87.0/beast/
  * <section id="libraryReadMe" class="boostlook">ReadMe Content</section>
  */
 

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -84,8 +84,8 @@ def do_scheduled_user_deletions():
 @shared_task
 def send_account_deleted_email(email):
     send_mail(
-        "Your boost.io account has been deleted",
-        "Your account on boost.io has been deleted.",
+        "Your boost.org account has been deleted",
+        "Your account on boost.org has been deleted.",
         settings.DEFAULT_FROM_EMAIL,
         [email],
     )


### PR DESCRIPTION
As well as leaving references to archives.boost.io as they were, as requested, this also leaves references to regression.boost.io in place. https://regression.boost.org doesn't resolve.