### PR TITLE
Improved logging formatting

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -251,7 +251,19 @@ root.setLevel(logging.INFO)
 
 
 handler = logging.StreamHandler(sys.stdout)
-handler.setFormatter(jsonlogger.JsonFormatter())
+handler.setFormatter(
+    jsonlogger.JsonFormatter(
+        "%(name)s %(levelname)s %(filename)s:%(lineno)d %(message)s"
+    )
+)
+
+if LOCAL_DEVELOPMENT:
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(filename)s:%(lineno)d - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
 
 root.addHandler(handler)
 

--- a/versions/management/commands/import_archives_release_data.py
+++ b/versions/management/commands/import_archives_release_data.py
@@ -3,6 +3,7 @@ import djclick as click
 import requests
 
 from django.conf import settings
+import structlog
 
 from versions.models import Version
 from versions.releases import (
@@ -16,6 +17,8 @@ from versions.releases import (
 from structlog import get_logger
 
 logger = get_logger(__name__)
+
+logger = structlog.get_logger()
 
 
 @click.command()
@@ -71,7 +74,7 @@ def command(release: str, new: bool):
                     data = get_archives_download_data(url)
                 download_data.append(data)
             except (requests.exceptions.HTTPError, ValueError):
-                print(f"Skipping {url}; error retrieving download data")
+                logger.warning(f"Skipping {url}; error retrieving download data")
                 continue
             logger.info(f"Data for {v.name=} at {url=}: {download_data=}")
             store_release_downloads_for_version(v, download_data)


### PR DESCRIPTION
This PR changes how logging is output.

* Production logs are in json format consistently (previously django only). Should allow better filtering in the google cloud console. 
* Celery logging messages should no longer all be one status (error)
* Development logs are in an improved text format.
* All logs now include the file and line number, giving better traceability and allowing for less verbose log strings in code. We can now remove `get_library_version_documentation_urls_version_does_not_exist` in the example below and know where the log originated.
* Also replaced some prints with `logger` use.

Text log format:
```
celery-worker-1                  | 2025-08-26 19:22:48 [INFO] tasks.py:78 - get_library_version_documentation_urls_version_does_not_existlibrary_name='Tribool' version.slug='boost-1-89-0-beta1'
```


JSON Log Format:
```js
{ "name": "core.githubhelper", "levelname": "WARNING", "filename": "githubhelper.py", "lineno": 329, "message": "get_library_metadata_failed repo_slug='bloom', url='https://raw.githubusercontent.com/boostorg/bloom/boost-1.89.0.beta1/meta/libraries.json'", "logger": "core.githubhelper", "level": "warning", "timestamp": "2025-08-26T19:22:47.781117Z" }
```