### PR TITLE
Adjust DB caching of /develop/ docs

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -282,6 +282,8 @@ CELERY_BROKER_TRANSPORT_OPTIONS = {
 }
 CELERY_RESULT_BACKEND_THREAD_SAFE = True
 CELERY_TASK_ALWAYS_EAGER = env("CELERY_TASK_ALWAYS_EAGER", False)
+# Reduce large amount of logging in redis. Usually 1 day.
+CELERY_TASK_RESULT_EXPIRES = 3600
 
 CACHES = {
     "default": {
@@ -300,7 +302,9 @@ CACHES = {
 ENABLE_DB_CACHE = env.bool("ENABLE_DB_CACHE", default=False)
 
 # Default interval by which to clear the static content cache
-CLEAR_STATIC_CONTENT_CACHE_DAYS = 7
+# New method: "never" clear, just overwrite, so that the id
+# field doesn't expand without bounds.
+CLEAR_STATIC_CONTENT_CACHE_DAYS = 7000
 
 # Hyperkitty
 HYPERKITTY_DATABASE_NAME = env("HYPERKITTY_DATABASE_NAME", default="")


### PR DESCRIPTION
Closes #1848  
DB caching: 
1 hr TTL /develop/ /master/ docs
1 month, other docs

There was a problem before: the renderedcontent table was purged once per week, causing the `id` field to increase by a million every week.   The new strategy (in this PR) is to keep the same `id` field, so it won't continue towards a billion.  
A potential side effect (I investigated to some extent) is by disabling cache purge, anything in the redis cache would remain indefinitely.  However there are no docs cached in redis currently.    Any thoughts on this topic are welcome. Otherwise... I tested this update and it worked correctly.   