### PR TITLE
Detect redriect when getting docs content from db cache

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -348,10 +348,16 @@ class BaseStaticContentTemplateView(TemplateView):
             content_obj = RenderedContent.objects.filter(modified__gte=start_time).get(
                 cache_key=cache_key
             )
-            return {
+            result = {
                 "content": content_obj.content_html,
                 "content_type": content_obj.content_type,
             }
+            if content_obj.content_type.startswith("text/html"):
+                result["redirect"] = get_meta_redirect_from_html(
+                    content_obj.content_html
+                )
+
+            return result
         except RenderedContent.DoesNotExist:
             return None
 


### PR DESCRIPTION
Fixes #1918 

It turns out we were already doing the thing Sam suggested in the ticket (detecting meta redirects and redirecting server-side), but that code was not being triggered when fetching rendered content from the database - only from S3.

This turned out to be a simple fix of calling the detection code in the database fetching branch of code.

Note that to reproduce the bug locally, I needed to turn on the `ENABLE_DB_CACHE` setting, which is off by default. This was the main reason this bug was difficult to track down.

---

QA testing procedure

1. Set the `ENABLE_DB_CACHE` environment variable to True (or as an easy hack, change the default in settings.py for testing)
2. Manually navigate to `/libs/url/`
3. Repeat step 2 now that the page has been cached in the db

On step 3, you should see the incorrect behavior (flicker) on the `master` branch, but the correct behavior (no flicker) on this branch.