### PR TITLE
Refactor docs retrieval, and canonical uri addition (#1857)

### DIFF
--- a/core/boostrenderer.py
+++ b/core/boostrenderer.py
@@ -7,6 +7,7 @@ import boto3
 import structlog
 from botocore.exceptions import ClientError
 from bs4 import BeautifulSoup, Tag
+import chardet
 from django.conf import settings
 from mistletoe import HtmlRenderer
 from mistletoe.span_token import SpanToken
@@ -15,7 +16,6 @@ from pygments.formatter import Formatter
 from pygments.lexers import get_lexer_by_name as get_lexer
 from pygments.lexers import guess_lexer
 from pygments.util import get_bool_opt
-from requests.compat import chardet
 
 logger = structlog.get_logger()
 

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,3 +1,4 @@
+import re
 from enum import Enum
 
 
@@ -7,3 +8,63 @@ class SourceDocType(Enum):
 
 
 SLACK_URL = "https://cpplang.slack.com"
+# possible library versions are: boost_1_53_0_beta1, 1_82_0, 1_55_0b1
+BOOST_LIB_PATH_RE = re.compile(r"^(boost_){0,1}([0-9_]*[0-9]+[^/]*)/(.*)")
+NO_PROCESS_LIBS = [
+    # Do nothing with these - just render contents directly
+    "libs/filesystem",
+    "libs/gil",
+    "libs/hana",
+    "libs/locale",
+    "libs/iostreams",
+    "libs/preprocessor",
+    "libs/serialization",
+    "libs/wave",
+]
+NO_WRAPPER_LIBS = [
+    # Add a header to these, but no wrapper.
+    "libs/array",
+    "libs/assert",
+    "libs/bloom",
+    "libs/charconv",
+    "libs/cobalt",
+    "libs/compat",
+    "libs/container_hash",
+    "libs/describe",
+    "libs/endian",
+    "libs/exception",
+    "libs/hash2",
+    "libs/io",
+    "libs/lambda2",
+    "libs/leaf",
+    "libs/mp11",
+    "libs/predef",
+    "libs/process",
+    "doc/html/process",
+    "libs/property_map_parallel",
+    "libs/qvm",
+    "libs/redis",
+    "libs/smart_ptr",
+    "libs/system",
+    "libs/throw_exception",
+    "libs/unordered",
+    "libs/uuid",
+    "libs/variant2",
+]
+FULLY_MODERNIZED_LIB_VERSIONS = [
+    # FIXME: we should have a way to opt-in via a flag on the library/lib-version.
+    #  Hard-coding these here as a quick fix for now.
+    # TODO: create a ticket for this
+    "tools/",  # Not a library version, but tools are somewhat analogous
+    "1_87_0/libs/charconv",
+    "1_88_0/libs/charconv",
+    "1_89_0/libs/charconv",
+    "latest/libs/charconv",
+    "develop/libs/charconv",
+    "master/libs/charconv",
+    "1_89_0/libs/redis",
+    "latest/libs/redis",
+    "develop/libs/redis",
+    "master/libs/redis",
+    "doc/antora/url",
+]

--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -770,7 +770,6 @@ def is_managed_content_type(content_type: str) -> bool:
         if t in content_type:
             return True
     return False
-    # return ("text/html" or "text/html; charset=utf-8") not in content_type
 
 
 def is_valid_modernize_value(modernize: str) -> bool:

--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -49,6 +49,8 @@ REMOVE_TAGS = [
     ("table", {"cellpadding": "2", "width": "100%"}),
     # Remove the first hr from the page
     ("hr", {}),
+    # remove canonical tags
+    ("link", {"rel": "canonical"}),
 ]
 
 # these tags are only removed on the release page, update REMOVE_TAGS for all pages
@@ -333,6 +335,14 @@ def remove_library_boostlook(soup):
         ):
             tag.decompose()
 
+    return soup
+
+
+def add_canonical_link(soup, canonical_uri):
+    """Add a canonical link to the head of the document."""
+    if canonical_uri and soup.head:
+        canonical_link = soup.new_tag("link", rel="canonical", href=canonical_uri)
+        soup.head.append(canonical_link)
     return soup
 
 

--- a/core/tests/test_htmlhelper.py
+++ b/core/tests/test_htmlhelper.py
@@ -65,7 +65,7 @@ def _build_tag(tag_name, tag_attrs, inner="Something"):
     tag = f"<{tag_name}"
     if tag_attrs:
         tag += " " + " ".join(f'{k}="{v}"' for k, v in tag_attrs.items())
-    if tag_name == "img":
+    if tag_name in ["img", "link"]:
         tag += "/>"
     elif tag_name == "hr":
         tag += ">"

--- a/core/tests/test_htmlhelper.py
+++ b/core/tests/test_htmlhelper.py
@@ -16,6 +16,7 @@ from core.htmlhelper import (
     remove_release_classes,
     remove_tables,
     remove_tags,
+    remove_unwanted,
     style_links,
     modernize_release_notes,
 )
@@ -86,9 +87,8 @@ def _build_expected_body(expected_body):
 
 def test_modernize_legacy_page_unchanged_empty():
     original = """Something else"""
-
-    result = modernize_legacy_page(original, base_html=BASE_HTML)
-
+    soup = BeautifulSoup(original, "html.parser")
+    result = modernize_legacy_page(soup, base_html=BASE_HTML)
     assertHTMLEqual(result, original)
 
 
@@ -97,8 +97,8 @@ def test_modernize_legacy_page_unchanged_simple():
     <html>
     </html>
     """
-
-    result = modernize_legacy_page(original, base_html="")
+    soup = BeautifulSoup(original, "html.parser")
+    result = modernize_legacy_page(soup, base_html="")
 
     assertHTMLEqual(result, original)
 
@@ -112,7 +112,8 @@ def test_modernize_legacy_page_unchanged_no_head():
     </html>
     """
 
-    result = modernize_legacy_page(original, base_html="")
+    soup = BeautifulSoup(original, "html.parser")
+    result = modernize_legacy_page(soup, base_html="")
 
     assertHTMLEqual(result, original)
 
@@ -126,7 +127,8 @@ def test_modernize_legacy_page_unchanged_no_body():
     </html>
     """
 
-    result = modernize_legacy_page(original, base_html="")
+    soup = BeautifulSoup(original, "html.parser")
+    result = modernize_legacy_page(soup, base_html="")
 
     assertHTMLEqual(result, original)
 
@@ -137,7 +139,8 @@ def test_modernize_legacy_page_adds_head_if_missing():
     </html>
     """
 
-    result = modernize_legacy_page(original, base_html=BASE_HTML)
+    soup = BeautifulSoup(original, "html.parser")
+    result = modernize_legacy_page(soup, base_html=BASE_HTML)
 
     expected = f"""<!DOCTYPE html>
     <html>
@@ -160,7 +163,8 @@ def test_modernize_legacy_page_appends_head_if_existing():
     </html>
     """
 
-    result = modernize_legacy_page(original, base_html=BASE_HTML)
+    soup = BeautifulSoup(original, "html.parser")
+    result = modernize_legacy_page(soup, base_html=BASE_HTML)
 
     expected = f"""<!DOCTYPE html>
     <html>
@@ -184,7 +188,8 @@ def test_modernize_legacy_page_mangles_body():
     </html>
     """
 
-    result = modernize_legacy_page(original, base_html=BASE_HTML)
+    soup = BeautifulSoup(original, "html.parser")
+    result = modernize_legacy_page(soup, base_html=BASE_HTML)
 
     expected = f"""<!DOCTYPE html>
     <html>
@@ -216,7 +221,11 @@ def test_modernize_legacy_page_remove_first_tag_found(tag_name, tag_attrs):
     </html>
     """
 
-    result = modernize_legacy_page(original, base_html=BASE_HTML)
+    soup = BeautifulSoup(original, "html.parser")
+    soup = remove_unwanted(soup)
+    result = modernize_legacy_page(
+        soup, base_html=BASE_HTML, skip_replace_boostlook=True
+    )
 
     body = _build_expected_body(LEGACY_BODY + tag)
     expected = f"""<!DOCTYPE html>
@@ -250,7 +259,9 @@ def test_modernize_legacy_page_remove_all_tags_found(tag_name, tag_attrs):
     </html>
     """
 
-    result = modernize_legacy_page(original, base_html=BASE_HTML)
+    soup = BeautifulSoup(original, "html.parser")
+    soup = remove_unwanted(soup)
+    result = modernize_legacy_page(soup, base_html=BASE_HTML)
 
     expected = f"""<!DOCTYPE html>
     <html>
@@ -287,7 +298,9 @@ def test_modernize_legacy_page_remove_only_css_class(tag_name, tag_attrs):
     </html>
     """
 
-    result = modernize_legacy_page(original, base_html=BASE_HTML)
+    soup = BeautifulSoup(original, "html.parser")
+    soup = remove_unwanted(soup)
+    result = modernize_legacy_page(soup, base_html=BASE_HTML)
 
     # Build expected result
     tag_attrs.pop("class")

--- a/core/views.py
+++ b/core/views.py
@@ -380,8 +380,8 @@ class BaseStaticContentTemplateView(TemplateView):
 
         # Check if the content is an HTML file. If so, check for a meta redirect.
         if content_type.startswith("text/html"):
-            result["redirect"] = get_meta_redirect_from_html(content)
-            if not result.get("redirect") and "spirit-nav".encode() not in content:
+            has_redirect = get_meta_redirect_from_html(content)
+            if not has_redirect and "spirit-nav".encode() not in content:
                 # Yes, this is a little gross, but it's the best we could think of.
                 # The 'assert', 'url' libraries (1.89) are examples that set this,
                 # is essentially everything that's not an antoradoc. Perfect is the
@@ -554,6 +554,8 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
         result = self.get_from_database(cache_key)
         if not result and (result := self.get_from_s3(content_path)):
             self.save_to_database(cache_key, result)
+
+        result["redirect"] = get_meta_redirect_from_html(result["content"])
 
         if result is None:
             logger.info(

--- a/core/views.py
+++ b/core/views.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin
 import requests
 import structlog
 from bs4 import BeautifulSoup
+import chardet
 from dateutil.parser import parse
 from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin
@@ -24,7 +25,6 @@ from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
-from requests.compat import chardet
 
 from config.settings import ENABLE_DB_CACHE
 from libraries.constants import LATEST_RELEASE_URL_PATH_STR

--- a/core/views.py
+++ b/core/views.py
@@ -1,5 +1,4 @@
 import os
-import re
 from django.utils import timezone
 
 from urllib.parse import urljoin
@@ -40,13 +39,20 @@ from .boostrenderer import (
     get_meta_redirect_from_html,
     get_s3_client,
 )
-from .constants import SourceDocType
+from .constants import SourceDocType, BOOST_LIB_PATH_RE
 from .htmlhelper import (
     modernize_legacy_page,
     convert_name_to_id,
     modernize_preprocessor_docs,
-    slightly_modernize_legacy_library_doc_page,
     remove_library_boostlook,
+    is_in_no_process_libs,
+    is_in_fully_modernized_libs,
+    is_in_no_wrapper_libs,
+    is_managed_content_type,
+    is_valid_modernize_value,
+    get_is_iframe_destination,
+    remove_unwanted,
+    minimize_uris,
 )
 from .markdown import process_md
 from .models import RenderedContent
@@ -336,7 +342,7 @@ class BaseStaticContentTemplateView(TemplateView):
         cached_result = static_content_cache.get(cache_key)
         return cached_result if cached_result else None
 
-    def get_from_database(self, cache_key):
+    def get_from_database(self, cache_key) -> dict[str, str | bytes] | None:
         rendered_content_cache_time = 2628288
         dev_docs = ["static_content_develop/", "static_content_master/"]
         for substring in dev_docs:
@@ -349,7 +355,7 @@ class BaseStaticContentTemplateView(TemplateView):
                 cache_key=cache_key
             )
             return {
-                "content": content_obj.content_html,
+                "content": content_obj.content_html.encode("utf-8"),
                 "content_type": content_obj.content_type,
             }
         except RenderedContent.DoesNotExist:
@@ -357,29 +363,31 @@ class BaseStaticContentTemplateView(TemplateView):
 
     def get_from_s3(self, content_path):
         result = get_content_from_s3(key=content_path)
-        if result and result.get("content"):
-            content = result.get("content")
-            content_type = result.get("content_type")
-            result["source_content_type"] = None
+        if not result:
+            return None
 
-            # Check if the content is an asciidoc file. If so, convert it to HTML.
-            # todo: confirm necessary: not clear where this is still needed, as the
-            #  content type for library docs is set to text/html, maybe descriptions and
-            #  release notes
-            if content_type == "text/asciidoc":
-                result["content"] = self.convert_adoc_to_html(content)
+        content = result.get("content")
+        content_type = result.get("content_type")
+        result["source_content_type"] = None
 
-            # Check if the content is an HTML file. If so, check for a meta redirect.
-            if content_type.startswith("text/html"):
-                result["redirect"] = get_meta_redirect_from_html(content)
-            if content_type.startswith("text/html") and not result.get("redirect"):
-                # yes, this is a little gross, but it's the best we could think of
-                if "spirit-nav".encode() not in content:
-                    # this is not strictly accurate, this is essentially everything
-                    #  that's not an antoradoc. Perfect is the enemy of good enough.
-                    result["source_content_type"] = SourceDocType.ASCIIDOC
+        # Check if the content is an asciidoc file. If so, convert it to HTML.
+        # todo: confirm necessary: not clear where this is still needed, as the
+        #  content type for library docs is set to text/html, maybe descriptions and
+        #  release notes
+        if content_type == "text/asciidoc":
+            result["content"] = self.convert_adoc_to_html(content)
 
-            return result
+        # Check if the content is an HTML file. If so, check for a meta redirect.
+        if content_type.startswith("text/html"):
+            result["redirect"] = get_meta_redirect_from_html(content)
+            if not result.get("redirect") and "spirit-nav".encode() not in content:
+                # Yes, this is a little gross, but it's the best we could think of.
+                # The 'assert', 'url' libraries (1.89) are examples that set this,
+                # is essentially everything that's not an antoradoc. Perfect is the
+                # enemy of good enough.
+                result["source_content_type"] = SourceDocType.ASCIIDOC
+
+        return result
 
     def get_template_names(self):
         content_type = self.content_dict.get("content_type")
@@ -445,10 +453,6 @@ class StaticContentTemplateView(BaseStaticContentTemplateView):
         return content
 
 
-# possible library versions are: boost_1_53_0_beta1, 1_82_0, 1_55_0b1
-BOOST_LIB_PATH_RE = re.compile(r"^(boost_){0,1}([0-9_]*[0-9]+[^/]*)/(.*)")
-
-
 def normalize_boost_doc_path(content_path: str) -> str:
     content_path = content_path.lstrip("boost_")
     if content_path.startswith(LATEST_RELEASE_URL_PATH_STR):
@@ -470,66 +474,6 @@ def normalize_boost_doc_path(content_path: str) -> str:
     return f"/archives/{content_path}"
 
 
-NO_PROCESS_LIBS = [
-    # Do nothing with these - just render contents directly
-    "libs/filesystem",
-    "libs/gil",
-    "libs/hana",
-    "libs/locale",
-    "libs/iostreams",
-    "libs/preprocessor",
-    "libs/serialization",
-    "libs/wave",
-]
-
-NO_WRAPPER_LIBS = [
-    # Add a header to these, but no wrapper.
-    "libs/array",
-    "libs/assert",
-    "libs/bloom",
-    "libs/charconv",
-    "libs/cobalt",
-    "libs/compat",
-    "libs/container_hash",
-    "libs/describe",
-    "libs/endian",
-    "libs/exception",
-    "libs/hash2",
-    "libs/io",
-    "libs/lambda2",
-    "libs/leaf",
-    "libs/mp11",
-    "libs/predef",
-    "libs/process",
-    "doc/html/process",
-    "libs/property_map_parallel",
-    "libs/qvm",
-    "libs/redis",
-    "libs/smart_ptr",
-    "libs/system",
-    "libs/throw_exception",
-    "libs/unordered",
-    "libs/uuid",
-    "libs/variant2",
-]
-
-FULLY_MODERNIZED_LIB_VERSIONS = [
-    # FIXME: we should have a way to opt-in via a flag on the library/lib-version.
-    #  Hard-coding these here as a quick fix for now.
-    "tools/",  # Not a library version, but tools are somewhat analogous
-    "1_87_0/libs/charconv",
-    "1_88_0/libs/charconv",
-    "1_89_0/libs/charconv",
-    "latest/libs/charconv",
-    "develop/libs/charconv",
-    "master/libs/charconv",
-    "1_89_0/libs/redis",
-    "develop/libs/redis",
-    "master/libs/redis",
-    "doc/antora/url",
-]
-
-
 class DocLibsTemplateView(BaseStaticContentTemplateView):
     allowed_db_save_types = {
         "text/asciidoc",
@@ -542,35 +486,56 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
         legacy_url = normalize_boost_doc_path(content_path)
         return super().get_from_s3(legacy_url)
 
-    def process_content(self, content):
+    def process_content(self, content: bytes):
         """Replace page header with the local one."""
-
-        if any(
-            lib_slug in self.request.path for lib_slug in FULLY_MODERNIZED_LIB_VERSIONS
-        ):
-            # Return a fully modernized version in an iframe
-            return self._fully_modernize_content(content)
-
-        if any(lib_slug in self.request.path for lib_slug in NO_PROCESS_LIBS):
-            # Just render raw HTML for some pages
-            return content
-
         content_type = self.content_dict.get("content_type")
         modernize = self.request.GET.get("modernize", "med").lower()
         if (
-            "text/html" or "text/html; charset=utf-8"
-        ) not in content_type or modernize not in ("max", "med", "min"):
-            # eventually check for more things, for example ensure this HTML
-            # was not generate from Antora builders.
+            not is_managed_content_type(content_type)
+            or not is_valid_modernize_value(modernize)
+            or get_is_iframe_destination(self.request.headers)
+        ):
             return content
+        # everything from this point should be html
 
-        new_content = slightly_modernize_legacy_library_doc_page(content)
+        # this decode is needed for some libraries, e.g. assert
+        content = content.decode(chardet.detect(content)["encoding"])
+        soup = BeautifulSoup(content, "html.parser")
 
-        context = {"content": new_content}
-        if any(lib_slug in self.request.path for lib_slug in NO_WRAPPER_LIBS):
+        # handle libraries that expect no processing
+        if is_in_no_process_libs(self.request.path):
+            soup = self._required_content_changes(soup)
+            return str(soup)
+
+        soup = self._required_modernization_changes(soup)
+
+        context = {
+            "content": str(soup.prettify()),
+        }
+        template_name = "original_docs.html"
+
+        if is_in_fully_modernized_libs(self.request.path):
+            # prepare a fully modernized version in an iframe
+            logger.info(f"fully modernized lib {self.request.path=}")
+            context_update = self._fully_modernize_content(
+                soup, self.establish_source_content_type(self.request.path)
+            )
+            context.update(context_update)
+            template_name = "docsiframe.html"
+
+        if is_in_no_wrapper_libs(self.request.path):
             context["no_wrapper"] = True
 
-        return render_to_string("original_docs.html", context, request=self.request)
+        context["content"] = self._required_content_string_changes(context["content"])
+
+        return render_to_string(template_name, context, request=self.request)
+
+    def establish_source_content_type(self, path: str) -> SourceDocType:
+        source_content_type = self.content_dict.get("source_content_type")
+        if source_content_type is None and SourceDocType.ANTORA.value in path:
+            # hacky, but solves an edge case
+            source_content_type = SourceDocType.ANTORA
+        return source_content_type
 
     def get_content(self, content_path):
         """Return content from database (cache) or S3."""
@@ -596,43 +561,45 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
 
         return result
 
-    def _fully_modernize_content(self, content):
+    @staticmethod
+    def _required_content_changes(content: BeautifulSoup) -> BeautifulSoup:
+        """
+        Processing for all html content, things that apply no matter the source
+        """
+
+        return content
+
+    @staticmethod
+    def _required_content_string_changes(content: str) -> str:
+        """
+        String-based processing for all html content, things that apply no matter the source
+        """
+        content = minimize_uris(content)
+        return content
+
+    @staticmethod
+    def _required_modernization_changes(content: BeautifulSoup):
+        """
+        Absolute base processing for libraries that have opted in to boostlook
+        modernization
+        """
+        content = remove_unwanted(content)
+
+        return content
+
+    def _fully_modernize_content(
+        self,
+        soup: BeautifulSoup,
+        source_content_type: SourceDocType,
+        modernize: str = "med",
+    ):
         """For libraries that have opted in to boostlook modernization"""
-        content_type = self.content_dict.get("content_type")
-        source_content_type = self.content_dict.get("source_content_type")
-        if (
-            source_content_type is None
-            and SourceDocType.ANTORA.value in self.request.path
-        ):
-            # hacky, but solves an edge case
-            source_content_type = SourceDocType.ANTORA
-        # Is the request coming from an iframe? If so, let's disable the modernization.
-        sec_fetch_destination = self.request.headers.get("Sec-Fetch-Dest", "")
-        is_iframe_destination = sec_fetch_destination in ["iframe", "frame"]
-
-        modernize = self.request.GET.get("modernize", "med").lower()
-
-        if (
-            ("text/html" or "text/html; charset=utf-8") not in content_type
-            or modernize not in ("max", "med", "min")
-            or is_iframe_destination
-        ):
-            # eventually check for more things, for example ensure this HTML
-            # was not generate from Antora builders.
-            return content
-
-        context = {"disable_theme_switcher": False}
-        insert_body = modernize == "max"
-        head_selector = (
-            "head"
-            if modernize in ("max", "med")
-            else {"data-modernizer": "boost-legacy-docs-extra-head"}
-        )
-
-        context["hide_footer"] = True
+        context = {"disable_theme_switcher": False, "hide_footer": True}
         if source_content_type == SourceDocType.ASCIIDOC:
-            extracted_content = content.decode(chardet.detect(content)["encoding"])
-            soup = BeautifulSoup(extracted_content, "html.parser")
+            # This was used but then changed to make docs look like the original files.
+            # No libraries currently run this path, but keeping it because there's a
+            #  possibility this changes back. There was a different parsing used, see
+            #  git history.
             soup = convert_name_to_id(soup)
             soup = remove_library_boostlook(soup)
             soup.find("head").append(
@@ -648,8 +615,14 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
                 {**context, **{"disable_plausible": True}},
                 request=self.request,
             )
+            insert_body: bool = modernize == "max"
+            head_selector = (
+                "head"
+                if modernize in ("max", "med")
+                else {"data-modernizer": "boost-legacy-docs-extra-head"}
+            )
             context["content"] = modernize_legacy_page(
-                content,
+                soup,
                 base_html,
                 insert_body=insert_body,
                 head_selector=head_selector,
@@ -657,8 +630,9 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
                 show_footer=False,
                 show_navbar=False,
             )
+
         context["full_width"] = True
-        return render_to_string("docsiframe.html", context, request=self.request)
+        return context
 
 
 class UserGuideTemplateView(BaseStaticContentTemplateView):
@@ -671,14 +645,16 @@ class UserGuideTemplateView(BaseStaticContentTemplateView):
         content_type = self.content_dict.get("content_type")
         modernize = self.request.GET.get("modernize", "med").lower()
 
-        if (
-            "text/html" or "text/html; charset=utf-8"
-        ) not in content_type or modernize not in ("max", "med", "min"):
+        if not is_managed_content_type(content_type) or not is_valid_modernize_value(
+            modernize
+        ):
             # eventually check for more things, for example ensure this HTML
             # was not generate from Antora builders.
             return content
 
         context = {"disable_theme_switcher": False}
+        # TODO: investigate if this base_html + template can be removed completely,
+        #  seems unused
         base_html = render_to_string(
             "userguide_placeholder.html", context, request=self.request
         )
@@ -695,8 +671,9 @@ class UserGuideTemplateView(BaseStaticContentTemplateView):
         )
         context["hide_footer"] = True
         context["full_width"] = True
+        soup = BeautifulSoup(content, "html.parser")
         context["content"] = modernize_legacy_page(
-            content,
+            soup,
             base_html,
             insert_body=insert_body,
             head_selector=head_selector,

--- a/justfile
+++ b/justfile
@@ -50,8 +50,8 @@ alias shell := console
     docker compose --file {{COMPOSE_FILE}} build --force-rm
     docker compose --file docker-compose.yml run --rm web python manage.py migrate --noinput
 
-@test_pytest:  ## runs pytest
-    -docker compose run --rm -e DEBUG_TOOLBAR="False" web pytest -s --create-db
+@test_pytest *args:  ## runs pytest (optional: test file/pattern, -v for verbose, -vv for very verbose)
+    -docker compose run --rm -e DEBUG_TOOLBAR="False" web pytest -s --create-db {{ args }}
 
 @test_pytest_lf:  ## runs last failed pytest tests
     -docker compose run --rm -e DEBUG_TOOLBAR="False" web pytest -s --create-db --lf

--- a/libraries/utils.py
+++ b/libraries/utils.py
@@ -182,6 +182,16 @@ def library_doc_latest_transform(url):
     return url
 
 
+def generate_canonical_library_uri(uri):
+    matches = re.match(
+        r"(?P<domainpath>https?://[^/]+(?:/[^/]+){2}/?)(?P<version>[^/]+)(?P<docpath>/[\S]+)",
+        uri,
+    )
+    if matches.group("version") == LATEST_RELEASE_URL_PATH_STR:
+        return uri
+    return f"{matches.group('domainpath')}{LATEST_RELEASE_URL_PATH_STR}{matches.group('docpath')}"
+
+
 def get_documentation_url(library_version, latest):
     """Get the documentation URL for the current library."""
 

--- a/pycharm_debugger.py
+++ b/pycharm_debugger.py
@@ -4,10 +4,5 @@ def set_trace():
     # this ip address is for the gateway IP, equivalent to host.docker.internal which
     #  isn't available on all platforms
     gateway_ip = "172.17.0.1"
-    pydevd_pycharm.settrace(
-        host=gateway_ip,
-        port=12345,  # Use the same port number configured in PyCharm
-        stdoutToServer=True,
-        stderrToServer=True,
-        suspend=False,
-    )
+    # Use the same port number configured in PyCharm
+    pydevd_pycharm.settrace(host=gateway_ip, port=12345, suspend=False)

--- a/requirements.in
+++ b/requirements.in
@@ -76,3 +76,4 @@ elasticsearch>7,<8
 ghapi
 requests
 slack_sdk
+chardet

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,8 @@ cffi==1.17.1
     #   cryptography
 cfgv==3.4.0
     # via pre-commit
+chardet==5.2.0
+    # via -r ./requirements.in
 charset-normalizer==3.4.3
     # via requests
 click==8.2.1

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,10 +22,12 @@
     <meta class="meta-theme" name="theme-color" content="#FAFAFA" data-dark="#18181B" data-light="#FAFAFA">
     <meta class="meta-theme" name="color-scheme" content="light" data-dark="dark" data-light="light">
 
-        <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css">
+    {% if canonical_uri %}<link rel="canonical" href="{{ canonical_uri }}">{% endif %}
+
     <script src="https://cdn.jsdelivr.net/npm/@ryangjchandler/alpine-clipboard@2.x.x/dist/alpine-clipboard.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@alpinejs/persist@3.x.x/dist/cdn.min.js" defer></script>
     <script src="//unpkg.com/alpinejs" defer></script>

--- a/templates/original_docs.html
+++ b/templates/original_docs.html
@@ -8,6 +8,7 @@
     <link href="{% static 'css/header.css' %}">
     <script defer data-domain="boost.org" src="https://plausible.io/js/script.manual.js"></script>
     <script src="{% static 'js/boost-gecko/main.C3hPHS6-.js' %}" defer></script>
+    {% if canonical_uri %}<link rel="canonical" href="{{ canonical_uri }}">{% endif %}
   </head>
   <style>
     body {


### PR DESCRIPTION
This ended up being a bigger change because the code had gotten confusing over time and it was in need of a refactor. Resolves a couple of bugs I saw too. Should be tested extensively that different doc types are rendering as they were before.

* Refactored content retrieval for cleaner code and easier reuse
* Fixed preprocessor encoding type breaking django debug toolbar 
* Added args support for pytest to justfile
* Added canonical uris for versions that aren't the latest
* Performed redirect in docs after `get_from_s3` and `get_from_db` calls (alternative to the PR for ticket #1918)

Fixes:
* Latest redis is now rendering correctly
* Some logic that would have overfit was corrected
* Updated pycharm configuration for pydevd-pycharm 252.25557.178