### PR TITLE
Return 404 for missing release slashes (#1929)

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -8,6 +8,7 @@ class SourceDocType(Enum):
 
 
 SLACK_URL = "https://cpplang.slack.com"
+STATIC_CONTENT_EARLY_EXIT_PATH_PREFIXES = ("releases/",)
 # possible library versions are: boost_1_53_0_beta1, 1_82_0, 1_55_0b1
 BOOST_LIB_PATH_RE = re.compile(r"^(boost_){0,1}([0-9_]*[0-9]+[^/]*)/(.*)")
 NO_PROCESS_LIBS = [


### PR DESCRIPTION
This is related to ticket #1929.

Fixed urls missing trailing slashes getting redirected by content view handler, now returns a 404 for nginx to redirect appropriately. Added this as a tuple because we may end up adding more in the future.

This also fixes /releases/latest having the same symptom.

Testing:
Local: confirm the url with a trailing slash works and  there's a 404 for the ones without a trailing slash.
Stage: confirm the url with a trailing slash works and when accessing the url without a slash, that there's a redirect to the url with a slash.