### PR TITLE
Fix announcements link text wrapping on community page

### DIFF
--- a/templates/community.html
+++ b/templates/community.html
@@ -12,7 +12,7 @@
       <div class="p-6 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
         <h5 class="text-2xl leading-tight text-orange">Mailing List / Forum</h5>
         <p class="py-1 my-2 border-b pb-4 border-gray-700 text-slate dark:text-white">Discover the Boost library community with options tailored to developers, casual users, and enthusiasts.</p>
-        <div class="grid grid-cols-2 lg:grid-cols-4">
+        <div class="grid grid-cols-2">
           <a href="https://lists.boost.org/mailman3/lists/boost.lists.boost.org/" class="px-2 py-3 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">
             <h6 class="pb-1 text-sm md:text-base">Developers</h6>
             <i class="fa fa-helmet-safety"></i>


### PR DESCRIPTION
### Summary
Addresses text wrapping issues with announcements links on the community page. Removes the 4-column class for large devices. Fixes #1933

### Preview 
<img width="1864" height="1178" alt="Screenshot 2025-09-24 at 1 44 47 PM" src="https://github.com/user-attachments/assets/f9101516-4de6-4ffb-a8a9-c5329e164acd" />
