### PR TITLE
Handle missing version library for /libs/library_name (#1942)

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -26,7 +26,7 @@ from core.views import (
     RedirectToDocsView,
     RedirectToHTMLDocsView,
     RedirectToHTMLToolsView,
-    RedirectToLibraryView,
+    RedirectToLibrariesView,
     RedirectToReleaseView,
     RedirectToToolsView,
     StaticContentTemplateView,
@@ -404,7 +404,7 @@ urlpatterns = (
         ),
         re_path(
             r"^doc/libs/(?P<requested_version>[^/]+)/?$",
-            RedirectToLibraryView.as_view(),
+            RedirectToLibrariesView.as_view(),
             name="redirect-to-library-page",
         ),
         re_path(

--- a/config/urls.py
+++ b/config/urls.py
@@ -39,6 +39,7 @@ from libraries.api import LibrarySearchView
 from libraries.views import (
     LibraryDetail,
     LibraryListDispatcher,
+    LibraryMissingVersionView,
     CommitAuthorEmailCreateView,
     VerifyCommitEmailView,
     CommitEmailResendView,
@@ -234,6 +235,11 @@ urlpatterns = (
             "library/<boostversionslug:version_slug>/<slug:library_slug>/",
             LibraryDetail.as_view(),
             name="library-detail",
+        ),
+        path(
+            "library/<boostversionslug:version_slug>/<slug:library_slug>/missing/",
+            LibraryMissingVersionView.as_view(),
+            name="library-detail-version-missing",
         ),
         path(
             "libraries/commit_author_email_create/",

--- a/core/views.py
+++ b/core/views.py
@@ -902,7 +902,7 @@ class RedirectToReleaseView(BaseRedirectView):
         return HttpResponseRedirect(new_path)
 
 
-class RedirectToLibraryView(BaseRedirectView):
+class RedirectToLibrariesView(BaseRedirectView):
     """View to redirect to a versioned libraries page."""
 
     def get(self, request, requested_version):

--- a/templates/libraries/missing_version.html
+++ b/templates/libraries/missing_version.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+
+{% block title %}{{ object.display_name }} - Version Not Available{% endblock %}
+{% block description %}
+    The {{ object.display_name }} library is not available in {{ selected_version.display_name }}.
+{% endblock %}
+
+{% block content %}
+  <main class="content">
+    <meta http-equiv="refresh" content="30;url={% url 'library-detail' version_slug=LATEST_RELEASE_URL_PATH_STR library_slug=object.slug %}">
+    <div class="pt-3 md:pt-4 md:pb-1 px-0 mb-0 w-full md:mb-2">
+      <div class="flex-auto mb-2 w-full">
+        <div id="overview">
+          <span class="mx-3 text-xl md:text-3xl text-orange">{{ object.display_name }}</span>
+        </div>
+      </div>
+    </div>
+
+    <section class="p-6 my-4 bg-white md:rounded-lg md:shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
+      <div class="flex items-center">
+        <i class="fas fa-exclamation-triangle text-orange mr-3 text-2xl"></i>
+        <h2 class="text-2xl">{{ object.display_name|capfirst }} Not Available for {{ selected_version.display_name }}</h2>
+      </div>
+
+      <div class="whitespace-normal mb-6">
+
+        <div class="flex justify-center mb-6 pb-4 border-b border-gray-200 dark:border-gray-600">
+          <div class="flex items-center text-blue-800 dark:text-blue-200 text-sm">
+            <i class="fas fa-clock mr-2"></i>
+            <p>
+              You will be automatically redirected to {{ object.display_name }} for the latest Boost version in
+              <span id="countdown">30</span> seconds if no option is selected.
+            </p>
+          </div>
+        </div>
+
+        <div class="flex flex-col items-center space-y-4">
+          <div>
+            <a href="{% url 'library-detail' version_slug=LATEST_RELEASE_URL_PATH_STR library_slug=object.slug %}"
+               class="inline-flex items-center px-4 py-2 bg-orange text-white rounded-md hover:bg-orange-600 transition-colors">
+              <i class="fas fa-book mr-2"></i>
+              View {{ object.display_name }} in Current Version
+            </a>
+          </div>
+
+          <div>
+            <a href="{% url 'libraries-list' version_slug=version_str library_view_str=library_view_str %}"
+               class="inline-flex items-center px-4 py-2 bg-orange text-white rounded-md hover:bg-orange-600 transition-colors">
+              <i class="fas fa-list mr-2"></i>
+              Browse All Libraries in {{ selected_version.display_name }}
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    let seconds = 30;
+    const countdownElement = document.getElementById('countdown');
+
+    const timer = setInterval(() => {
+      seconds--;
+      countdownElement.textContent = seconds;
+
+      if (seconds <= 0) {
+        clearInterval(timer);
+      }
+    }, 1000);
+
+  </script>
+{% endblock %}


### PR DESCRIPTION
This is related to ticket #1942.

Adds redirect to view which
1. prompts user choose between viewing the current Boost version's libraries or the homepage for the "latest" version of the Library
2. automatically redirects user to "latest" version

<img width="1602" height="879" alt="missing_bloom" src="https://github.com/user-attachments/assets/6c8e10ed-b1e8-4ff4-805f-09b780d4a86f" />

Testing: 
1. Select a boost version earlier than the addition of the version of boost in which the library was added. e.g. mqtt was added 1.88, bloom in 1.89, so pick $version - 1 of those.
2. Visit /lib/library_name, you should get redirected to the view above. 