### PR TITLE
Adjust settings of kubernetes autoscaler

### DIFF
--- a/kube/boost/templates/hpa.yaml
+++ b/kube/boost/templates/hpa.yaml
@@ -3,13 +3,13 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: boost
 spec:
-  minReplicas: 2
-  maxReplicas: 8
+  minReplicas: 3
+  maxReplicas: 12
   metrics:
   - resource:
       name: cpu
       target:
-        averageUtilization: 50
+        averageUtilization: 23
         type: Utilization
     type: Resource
   scaleTargetRef:

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -13,13 +13,13 @@ replicaCount: "2"
 
 wsgiResources:
   limits:
-    cpu: "3500m"
+    cpu: "2500m"
     ephemeral-storage: 1Gi
-    memory: 4Gi
+    memory: 2500Mi
   requests:
-    cpu: "3500m"
+    cpu: "2500m"
     ephemeral-storage: 1Gi
-    memory: 4Gi
+    memory: 2500Mi
 
 ## NOTE ##
 # set publcFqdn to the target domain. `www` will be prepended to the domain


### PR DESCRIPTION
Lower the CPU threshold for scaling pods.  Memory above 2GB is current not used and so over-provisioning is an unnecessary expense. Increase later if necessary. Similar case with CPU setting.  
