### PR TITLE
Fix inaccurate content type decoding (#1950)

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -516,8 +516,6 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
         req_uri = self.request.build_absolute_uri()
         canonical_uri = generate_canonical_library_uri(req_uri)
 
-        # this decode is needed for some libraries, e.g. assert
-        content = content.decode(chardet.detect(content)["encoding"])
         soup = BeautifulSoup(content, "html.parser")
 
         # handle libraries that expect no processing


### PR DESCRIPTION
This relates to ticket #1950.

Chardet incorrectly detects some utf-8 content as Windows-1252, this works around that by attempting to decode the content as utf-8 first, and then attempting a decode and re-encode if it's not utf-8.

Testing:
Check the links mentioned in the ticket and confirm that they render without strange characters, also that various other libraries aren't broken.