### PR TITLE
Resolve issue with docs content spacing (#1953)

### DIFF
--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -180,7 +180,7 @@ def modernize_legacy_page(
 
     if soup.html is None:
         # Not an HTML file we care about
-        return soup.prettify(formatter="html")
+        return str(soup)
 
     # Remove CSS classes that produce visual harm
     for tag_name, tag_attrs in REMOVE_CSS_CLASSES:
@@ -231,7 +231,7 @@ def modernize_legacy_page(
     # Remove tags from the base template
     soup = hide_tags(soup, HIDE_TAGS_BASE)
 
-    return soup.prettify(formatter="html")
+    return str(soup)
 
 
 def minimize_uris(content: str) -> str:

--- a/core/views.py
+++ b/core/views.py
@@ -528,7 +528,7 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
         soup = self._required_modernization_changes(soup)
 
         context = {
-            "content": str(soup.prettify()),
+            "content": str(soup),
             "canonical_uri": canonical_uri if canonical_uri != req_uri else None,
         }
         template_name = "original_docs.html"


### PR DESCRIPTION
This PR relates to ticket #1953.

"pretty" formatting on output of docs parsing was causing whitespace to be inserted in ways that were breaking the docs.

This fix removes that formatting. The core/views.py fix is what specifically resolves this, but I've removed two others as preventative measures, they're not necessary to have anyway.

testing:
locally the fixed /doc/libs/1_89_0/libs/beast/doc/html/beast/ref/boost__beast__buffer_bytes.html should look like:
<img width="1453" height="50" alt="spacing_fixed" src="https://github.com/user-attachments/assets/824053ba-02ea-4dba-aeea-b377d9977fbe" />
