### PR TITLE
Improve k8s gateway-api redirects

### DIFF
--- a/kube/boost/templates/configmap-nginx.yaml
+++ b/kube/boost/templates/configmap-nginx.yaml
@@ -8,25 +8,29 @@ data:
     server {
       listen 80;
       server_name {{.Values.publicFqdn}};
-      return 301 $scheme://www.{{.Values.publicFqdn}}$request_uri;
+      # return 301 $scheme://www.{{.Values.publicFqdn}}$request_uri;
+      return 301 https://www.{{.Values.publicFqdn}}$request_uri;
     }
 
     server {
       listen 80;
       server_name {{.Values.publicFqdn2}};
-      return 301 $scheme://www.{{.Values.publicFqdn2}}$request_uri;
+      # return 301 $scheme://www.{{.Values.publicFqdn2}}$request_uri;
+      return 301 https://www.{{.Values.publicFqdn2}}$request_uri;
     }
 
     server {
       listen 80;
       server_name {{.Values.publicFqdn3}};
-      return 301 $scheme://www.{{.Values.publicFqdn3}}$request_uri;
+      # return 301 $scheme://www.{{.Values.publicFqdn3}}$request_uri;
+      return 301 https://www.{{.Values.publicFqdn3}}$request_uri;
     }
 
     server {
       listen 80;
       server_name {{.Values.publicFqdn4}};
-      return 301 $scheme://www.{{.Values.publicFqdn4}}$request_uri;
+      # return 301 $scheme://www.{{.Values.publicFqdn4}}$request_uri;
+      return 301 https://www.{{.Values.publicFqdn4}}$request_uri;
     }
 
     server {

--- a/kube/boost/templates/gateway.yaml
+++ b/kube/boost/templates/gateway.yaml
@@ -84,3 +84,5 @@ spec:
     - type: RequestRedirect
       requestRedirect:
         scheme: https
+        statusCode: 301
+        hostname: {{.Values.mainFqdn}}

--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -36,6 +36,7 @@ publicFqdn: &fqdn cppal-dev.boost.cppalliance.org
 publicFqdn2: &fqdn2 cppal-dev.boost.org
 publicFqdn3: &fqdn3 cppal-dev2.boost.cppalliance.org
 publicFqdn4: &fqdn4 boost.org
+mainFqdn: www.cppal-dev.boost.org
 
 Env:
   - name: DJANGO_SETTINGS_MODULE

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -36,6 +36,7 @@ publicFqdn: &fqdn boost.cppalliance.org
 publicFqdn2: &fqdn2 boost.org
 publicFqdn3: &fqdn3 preview.boost.org
 publicFqdn4: &fqdn4 boost.io
+mainFqdn: www.boost.org
 
 Env:
   - name: DJANGO_SETTINGS_MODULE

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -36,6 +36,7 @@ publicFqdn: &fqdn stage.boost.cppalliance.org
 publicFqdn2: &fqdn2 stage.boost.org
 publicFqdn3: &fqdn3 stage2.boost.cppalliance.org
 publicFqdn4: &fqdn4 boost.io
+mainFqdn: www.stage.boost.org
 
 Env:
   - name: DJANGO_SETTINGS_MODULE


### PR DESCRIPTION
In the case of either "http" or a missing "www", redirect with 301.  (This had generally been working before, but with more iterative redirects involved.)

