### PR TITLE
Batched deletion of rendered content (#1959)

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,11 +1,49 @@
 from django.contrib import admin
+from django.urls import path
+from django.shortcuts import redirect, render
+from django.contrib import messages
 from .models import RenderedContent, SiteSettings
+from .tasks import delete_all_rendered_content
 
 
 @admin.register(RenderedContent)
 class RenderedContentAdmin(admin.ModelAdmin):
     list_display = ("cache_key", "content_type", "modified")
     search_fields = ("cache_key",)
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "delete-all/",
+                self.admin_site.admin_view(self.delete_all_view),
+                name="core_renderedcontent_delete_all",
+            ),
+        ]
+        return custom_urls + urls
+
+    def delete_all_view(self, request):
+        if request.method == "POST":
+            delete_all_rendered_content.delay()
+            messages.success(
+                request,
+                "Mass deletion task has been queued. All rendered content "
+                "records will be deleted in batches. This may take some time.",
+            )
+            return redirect("..")
+
+        context = {
+            **self.admin_site.each_context(request),
+            "title": "Delete All Rendered Content",
+        }
+        return render(
+            request, "admin/core/renderedcontent/delete_all_confirmation.html", context
+        )
+
+    def changelist_view(self, request, extra_context=None):
+        extra_context = extra_context or {}
+        extra_context["has_delete_all"] = True
+        return super().changelist_view(request, extra_context=extra_context)
 
 
 @admin.register(SiteSettings)

--- a/core/constants.py
+++ b/core/constants.py
@@ -69,3 +69,4 @@ FULLY_MODERNIZED_LIB_VERSIONS = [
     "master/libs/redis",
     "doc/antora/url",
 ]
+RENDERED_CONTENT_BATCH_DELETE_SIZE = 10000

--- a/templates/admin/core/renderedcontent/change_list.html
+++ b/templates/admin/core/renderedcontent/change_list.html
@@ -1,0 +1,13 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+    {{ block.super }}
+    {% if has_delete_all %}
+    <li>
+        <a href="{% url 'admin:core_renderedcontent_delete_all' %}" class="deletelink">
+            {% trans "Delete All Records" %}
+        </a>
+    </li>
+    {% endif %}
+{% endblock %}

--- a/templates/admin/core/renderedcontent/delete_all_confirmation.html
+++ b/templates/admin/core/renderedcontent/delete_all_confirmation.html
@@ -1,0 +1,29 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="{% static 'admin/js/cancel.js' %}" async></script>
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-core model-renderedcontent delete-confirmation{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:core_renderedcontent_changelist' %}">{% translate 'Rendered Contents' %}</a>
+&rsaquo; {% translate 'Delete All' %}
+</div>
+{% endblock %}
+
+{% block content %}
+<p>{% translate "Are you sure you want to delete ALL rendered content records?" %}</p>
+<p><strong>{% translate "Warning:" %}</strong> {% translate "This action will queue a background task to delete all records in batches. This cannot be undone." %}</p>
+<form method="post">{% csrf_token %}
+<div>
+<input type="hidden" name="post" value="yes">
+<input type="submit" value="Yes, I'm sure">
+<a href="#" class="button cancel-link">No, take me back</a>
+</div>
+</form>
+{% endblock %}


### PR DESCRIPTION
This is related to ticket #1959.

Adds batched deletion of rendered content through the admin UI. Deletes 10,000 rows at a time to reduce locking. Will continue until all rows are deleted, including recently added ones so we may see some re-added ones but CDN caching should mitigate that to some extent. 

Testing:
in the admin UI under Rendered Content,  click on "Delete All Rendered Content" and periodically check to confirm that the number goes down until none remain. 