### PR TITLE
Change boto3 retrieval error from exception to warning (#1956)

### DIFF
--- a/core/boostrenderer.py
+++ b/core/boostrenderer.py
@@ -157,14 +157,10 @@ def get_file_data(client, bucket_name, s3_key):
         response = client.get_object(Bucket=bucket_name, Key=s3_key.lstrip("/"))
         return extract_file_data(response, s3_key)
     except ClientError as e:
-        # Log the exception but ignore it otherwise, since it's not necessarily an error
-        logger.exception(
-            "get_content_from_s3_error",
-            s3_key=s3_key,
-            error=str(e),
-            function_name="get_content_from_s3",
-        )
-    return
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            logger.warning(f"NoSuchKey {s3_key=}")
+        else:
+            logger.exception(f"get_content_from_s3_client_error {s3_key=}, {str(e)=}")
 
 
 def get_s3_client():


### PR DESCRIPTION
These aren't necessarily errors that require action, so I've changed this log to a warning. If we want we can have some sort of metric based alerting in the future should any issues arise. Either way we will have a log of any s3 file misses in the meantime.

Error goes from what was in the original ticket to what is in the screenshot below.

<img width="1908" height="330" alt="nosuchkey_error" src="https://github.com/user-attachments/assets/689ddc24-9310-4882-a342-6d2f0588497c" />


Testing: attempt to load paths like those provided in the original ticket, e.g. "/doc/libs/1_89_0/libs/math/doc/sf_and_dist/html/math_toolkit/utils/next_float/float_distance.html" and logs should no longer show an exception but show the warning instead.