### PR TITLE
PDF download timeouts changes (#1972)

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -235,6 +235,7 @@ class ContentNotFoundException(Exception):
 class BaseStaticContentTemplateView(TemplateView):
     template_name = "adoc_content.html"
     allowed_db_save_types = {"text/asciidoc"}
+    html_content_types = {"text/html", "text/html; charset=utf-8"}
 
     def get(self, request, *args, **kwargs):
         """Return static content that originates in S3.
@@ -573,7 +574,8 @@ class DocLibsTemplateView(BaseStaticContentTemplateView):
             logger.info(f"get_content_from_s3_view_no_valid_object {content_path=}")
             raise ContentNotFoundException("Content not found")
 
-        result["redirect"] = get_meta_redirect_from_html(result["content"])
+        if result["content_type"] in self.html_content_types:
+            result["redirect"] = get_meta_redirect_from_html(result["content"])
 
         return result
 


### PR DESCRIPTION
This PR is related to ticket #1972.

Previously the code would try to parse the data for redirects, this PR adds checks for the content type before that step.

While initially investigating this the direct s3 download was taking up most of the time and the times were longer. 

Trying to reproduce the issue locally for this summary I was seeing PDF downloads take 16.4 seconds. After this change it takes 6.5 seconds. I expect both times would be longer on the servers which in the past have seemed to be slower than my local machine, which could be why the server was timing out on the extrapolated 16.4 seconds.

It's not clear that this will be enough to resolve this issue or the s3 download times may still cause problems, but we should try this as a first step.

Testing: check locally and then on stage that docs and the linked PDFs load as expected.