### PR TITLE
Adjust development branches libraries warning to specify the branch (#1979)

### DIFF
--- a/templates/libraries/includes/version_alert.html
+++ b/templates/libraries/includes/version_alert.html
@@ -10,7 +10,7 @@
         {% elif selected_version.full_release %}
           This is an older version of Boost and was released in {{ selected_version.release_date|date:"Y"}}.
         {% else %}
-          This version of Boost is under active development.
+          This version of Boost is under active development. You are currently in the {{ selected_version.display_name }} branch.
         {% endif %}
       The <a href="{{ version_alert_url }}">current version</a> is {{ current_version.display_name }}.
       {% endif %}


### PR DESCRIPTION
Adds master and develop to the version warning notification.

<img width="1943" height="678" alt="develop_branch" src="https://github.com/user-attachments/assets/e73d74ee-abd2-45c2-b69a-318c15ab8fea" />
<img width="1921" height="478" alt="master_branch" src="https://github.com/user-attachments/assets/d220a052-3249-4ba8-842b-fb8fc2692058" />
