### PR TITLE
Redirect /libs/{library} to latest docs version (#1977)

### DIFF
--- a/libraries/views.py
+++ b/libraries/views.py
@@ -339,7 +339,10 @@ class LibraryDetail(VersionAlertMixin, BoostVersionMixin, ContributorMixin, Deta
                     version_slug=get_prioritized_version(request),
                 )
             return redirect(
-                get_documentation_url_redirect(library_version, latest=False)
+                get_documentation_url_redirect(
+                    library_version,
+                    latest=self.get_version() == Version.objects.most_recent(),
+                )
             )
         response = super().dispatch(request, *args, **kwargs)
         set_selected_boost_version(


### PR DESCRIPTION
This PR relates to ticket #1977.

Currently the code redirects to the most recent versioned library when the user has no version in their cookies. 

With this PR we now direct to the `latest` docs when no version has been set in the user's cookies.

Testing: 

1. with no version selected visit "/libs/asio" by typing it in the location bar and you will be redirected to the version of the docs with `latest` as the version segment.
2. With an older version selected visit "/libs/asio" by typing it in the location bar and you will be redirected to the docs with that version as the version segment.