### PR TITLE
Add /users/news/version_... to release redirect (#1881)

### DIFF
--- a/kube/boost/templates/configmap-nginx.yaml
+++ b/kube/boost/templates/configmap-nginx.yaml
@@ -107,6 +107,7 @@ data:
       location = /users/faq.html { return 301 /doc/user-guide/faq.html; }
       location = /users/proposal.pdf { return 301 /doc/user-guide/boost-history.html; }
       location ~ ^/users/history/version_(\d+)_(\d+)_(\d+)\.html$ { return 301 /releases/$1.$2.$3/; }
+      location ~ ^/users/news/version_(\d+).(\d+).(\d+)/?$ { return 301 /releases/$1.$2.$3/; }
       location = /community/groups.html { return 301 /community/; }
       location = /community/policy.html { return 301 /doc/user-guide/discussion-policy.html; }
       location = /community/cpp.html { return 301 /doc/user-guide/faq.html#isocommitteemeetings; }


### PR DESCRIPTION
This is related to ticket #1881.

With this change /users/news/version_1.88.0 should now be redirected to the matching 1.88.0 release page.

Testing: as an nginx isomap change this will only work on staging and production.