### PR TITLE
Account for develop/master branch paths in docs version alert regex (#1984)

### DIFF
--- a/libraries/mixins.py
+++ b/libraries/mixins.py
@@ -42,7 +42,7 @@ class VersionAlertMixin:
             current_version_kwargs.update(
                 {
                     "content_path": re.sub(
-                        r"([_0-9]+)/(\S+)",
+                        r"([_0-9]+|master|develop)/(\S+)",
                         rf"{LATEST_RELEASE_URL_PATH_STR}/\2",
                         current_version_kwargs.get("content_path"),
                     )

--- a/versions/models.py
+++ b/versions/models.py
@@ -326,5 +326,8 @@ def docs_path_to_boost_name(content_path):
     Convert a documentation content path to the Boost version name.
     e.g. "1_79_0/doc/html/accumulators.html" to "boost-1.79.0"
     """
-    result = re.sub(r"^([_0-9]+)(/\S+)", r"boost-\1", content_path)
+    if content_path.startswith("develop") or content_path.startswith("master"):
+        result = content_path.split("/")[0]
+    else:
+        result = re.sub(r"^([_0-9]+)(/\S+)", r"boost-\1", content_path)
     return result.replace("_", ".")


### PR DESCRIPTION
This relates to issue #1984.

Change fixes the "current version" link for `develop` and `master` branches not being updated.