### PR TITLE
Remove "toc-hidden" class from original_docs.html

### DIFF
--- a/templates/original_docs.html
+++ b/templates/original_docs.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% get_current_language as LANGUAGE_CODE %}
 <!DOCTYPE html>
-<html lang="{{ LANGUAGE_CODE }}" class="toc-hidden">
+<html lang="{{ LANGUAGE_CODE }}">
   <head>
     <meta charset="utf-8">
     <link href="{% static 'css/header.css' %}">


### PR DESCRIPTION
Removes the `toc-hidden` CSS class from the HTML element in original_docs.html template. 

This class was causing the table of contents to be hidden in libraries using this template, preventing users from accessing navigation on desktop. The TOC should always be visible for better user experience.