### PR TITLE
Fix issue with events no longer showing on homepage (#1990)

### DIFF
--- a/core/calendar.py
+++ b/core/calendar.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 from django.conf import settings
 import requests
 from collections import defaultdict
@@ -21,7 +21,9 @@ def get_calendar(min_time=None, single_events=True, order_by="startTime"):
     """
     if not min_time:
         # 'Z' indicates UTC time
-        min_time = datetime.datetime.now(datetime.timezone.utc).isoformat() + "Z"
+        # we replace +00:00 with Z because google no longer seems to be fully rfc3339
+        # compliant for this parameter, even with a valid format ending with +00:00
+        min_time = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     url = f"https://www.googleapis.com/calendar/v3/calendars/{settings.BOOST_CALENDAR}/events?key={settings.CALENDAR_API_KEY}&timeMin={min_time}&singleEvents={single_events}&orderBy={order_by}"
 
     headers = {"Accept": "application/json"}


### PR DESCRIPTION
This relates to ticket #1990.

Seems like google has changed their claimed support for rfc3339 on this field, this works around their changes.

While the original was not compliant (had a trailing Z when it shouldn't) it presumably worked up to now, but now, even with an rfc3339 `+00:00` without the trailing 'Z', it no longer works and only supports `Z` at the end.