### PR TITLE
Fixed master/develop paths breaking docs page loading (#2008)

### DIFF
--- a/libraries/mixins.py
+++ b/libraries/mixins.py
@@ -48,6 +48,8 @@ class VersionAlertMixin:
             path_slug = current_version_kwargs.get("content_path").split("/")[0]
             if path_slug == LATEST_RELEASE_URL_PATH_STR:
                 context["selected_version"] = Version.objects.most_recent()
+            elif path_slug in ("master", "develop"):
+                context["selected_version"] = Version.objects.get(slug=path_slug)
             else:
                 version_slug = f"boost-{path_slug.replace('_', '-')}"
                 context["selected_version"] = Version.objects.get(slug=version_slug)


### PR DESCRIPTION
Related to ticket #2008.

One fix in the previous PR to correct the message not having a `selected_version` in it didn't account for `master` and `develop`. That's resolved in this PR.