### PR TITLE
Beta release issues fixes (#2004, #2005)

### DIFF
--- a/versions/admin.py
+++ b/versions/admin.py
@@ -19,7 +19,14 @@ class VersionFileInline(admin.StackedInline):
 
 @admin.register(models.Version)
 class VersionAdmin(admin.ModelAdmin):
-    list_display = ["name", "release_date", "active", "full_release", "beta"]
+    list_display = [
+        "name",
+        "release_date",
+        "active",
+        "full_release",
+        "beta",
+        "fully_imported",
+    ]
     list_filter = ["active", "full_release", "beta"]
     ordering = ["-release_date", "-name"]
     search_fields = ["name", "description"]

--- a/versions/releases.py
+++ b/versions/releases.py
@@ -317,13 +317,11 @@ def process_release_notes(content):
 def store_release_notes_for_version(version_pk):
     """Check S3 and then github for release notes and store them in RenderedContent."""
     # Get the version
+    # todo: convert to task, remove the task that calls this, is redundant
     try:
         version = Version.objects.get(pk=version_pk)
     except Version.DoesNotExist:
-        logger.info(
-            "store_release_notes_for_version_error_version_not_found",
-            version_pk=version_pk,
-        )
+        logger.info(f"store_release_notes version_not_found {version_pk=}")
         raise Version.DoesNotExist
 
     content, processed_content, content_type = get_release_notes_for_version(version_pk)

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -22,7 +22,7 @@ from versions.releases import (
 )
 
 
-logger = structlog.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 @app.task
@@ -87,7 +87,7 @@ def import_release_notes(new_versions_only=True):
         versions = Version.objects.exclude(name__in=["master", "develop"]).active()
 
     for version in versions:
-        logger.info(f"retrieving release notes for {version.name=}")
+        logger.info(f"retrieving release notes for {version.name=} {version.pk=}")
         store_release_notes_task.delay(str(version.pk))
     store_release_notes_in_progress_task.delay()
 
@@ -203,6 +203,7 @@ def import_most_recent_beta_release(token=None, delete_old=False):
                 logger.info(f"calling import_version with {name=} {tag=}")
                 import_version(name, tag, token=token, beta=True, full_release=False)
                 logger.info(f"completed import_version with {name=} {tag=}")
+                mark_fully_completed()
                 # new_versions_only='False' otherwise will only be full releases
                 import_release_notes(new_versions_only=False)
                 return


### PR DESCRIPTION
This PR is related to tickets #2004 and #2005.

The fix for beta version not showing up in version drop down is to have `mark_fully_completed` run on an import of the beta release, and the fix for beta release notes not being imported is to have `mark_fully_completed` run before `import_release_notes` is run.

We should make this less like an OK Go video, either by flattening it out, merging parts together, and/or maybe migrating to an Apache Airflow setup for task orchestration.

https://www.youtube.com/watch?v=GrEskQFqQE0

Testing: 

delete the beta versions, run "do it all" or "get release report data", whichever applies, then when it has completed check the beta versions are listed in the libraries page drop down.