### PR TITLE
Fix pill max height exceeding 22px when categories are too long (#2013)

### DIFF
--- a/templates/libraries/_library_categorized_list_item.html
+++ b/templates/libraries/_library_categorized_list_item.html
@@ -7,7 +7,7 @@ onclick="handleCardClick(event, '{% url 'library-detail' library_slug=library_ve
   </td>
 
   <td class="w-12 align-top pt-2.5 pr-2">
-    <span class="flex justify-center px-2 text-sm font-bold text-gray-600 rounded-full border dark:text-gray-300 bg-green/40 border-green/60 dark:bg-green/40 tabular-nums"
+    <span class="flex justify-center px-2 text-sm font-bold text-gray-600 rounded-full border dark:text-gray-300 bg-green/40 border-green/60 dark:bg-green/40 tabular-nums max-h-[22px]"
           title="{% if library_version.cpp_standard_minimum and library_version.cpp_standard_minimum != 'None' %}C++ Version {{ library_version.cpp_standard_minimum }} or Later{% else %}C++ Version 03 or Later{% endif %}">
           <span class="text-white dark:text-gray-800 tracking-wide scale-x-75 origin-left w-6 text-nowrap whitespace-nowrap">C++</span>
           {% if library_version.cpp_standard_minimum and library_version.cpp_standard_minimum != 'None' %}{{ library_version.cpp_standard_minimum }}{% else %}03{% endif %}

--- a/templates/libraries/_library_grid_list_item.html
+++ b/templates/libraries/_library_grid_list_item.html
@@ -22,7 +22,7 @@ onclick="handleCardClick(event, '{% url 'library-detail' library_slug=library_ve
   </div>
   <div class="text-sm flex py-3 bottom-3 absolute w-4/5 md:w-11/12">
     <div class="flex">
-      <span class="flex justify-center py-0 px-2 text-sm font-bold text-gray-600 rounded-full border dark:text-gray-300 bg-green/40 border-green/60 dark:bg-green/40 tabular-nums"
+      <span class="flex justify-center py-0 px-2 text-sm font-bold text-gray-600 rounded-full border dark:text-gray-300 bg-green/40 border-green/60 dark:bg-green/40 tabular-nums max-h-[22px]"
         title="C++ Version {% if library_version.cpp_standard_minimum and library_version.cpp_standard_minimum != 'None' %}{{ library_version.cpp_standard_minimum }}{% else %}03{% endif %} or Later">
         <span class="text-white dark:text-gray-800 tracking-wide scale-x-75 origin-left w-6 text-nowrap whitespace-nowrap">C++</span>
         {% if library_version.cpp_standard_minimum and library_version.cpp_standard_minimum != 'None' %}{{ library_version.cpp_standard_minimum }}{% else %}03{% endif %}


### PR DESCRIPTION
Adds a max height of 22px to C++ version pill elements to prevent height expansion
when category text wraps to multiple lines.

Affected templates:
- `_library_grid_list_item.html`
- `_library_categorized_list_item.html`

Issue: #2013

<img width="1268" height="1320" alt="fix-pill-max-height-issue-2013" src="https://github.com/user-attachments/assets/c433678a-c4a3-4deb-bacf-ea8b6c61e24c" />
