### PR TITLE
Tweaks to wagtail configuration

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -615,7 +615,8 @@ ALGOLIA = {
 # Required by Wagtail
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10_000
 WAGTAIL_SITE_NAME = "Boost.org"
-WAGTAILADMIN_BASE_URL = env("WAGTAILADMIN_BASE_URL", default="https://www.boost.org/")
+WAGTAILADMIN_BASE_URL = env("WAGTAILADMIN_BASE_URL", default="https://www.boost.org")
+WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS = False
 WAGTAILDOCS_EXTENSIONS = [
     "csv",
     "docx",

--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -202,7 +202,7 @@ Env:
   - name: ENABLE_DB_CACHE
     value: "true"
   - name: WAGTAILADMIN_BASE_URL
-    value: https://www.cppal-dev.boost.org/
+    value: https://www.cppal-dev.boost.org
 
 # Volumes
 Volumes:

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -202,7 +202,7 @@ Env:
   - name: ENABLE_DB_CACHE
     value: "true"
   - name: WAGTAILADMIN_BASE_URL
-    value: https://www.boost.org/
+    value: https://www.boost.org
 
 # Volumes
 Volumes:

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -202,7 +202,7 @@ Env:
   - name: ENABLE_DB_CACHE
     value: "true"
   - name: WAGTAILADMIN_BASE_URL
-    value: https://www.stage.boost.org/
+    value: https://www.stage.boost.org
 
 # Volumes
 Volumes:


### PR DESCRIPTION
1. Remove trailing slash in `WAGTAILADMIN_BASE_URL`. Noticed the extra slash in a notification email:
<img width="664" height="64" alt="Screenshot 2025-11-19 at 11 08 37 AM" src="https://github.com/user-attachments/assets/ac4e2cf6-5967-4977-9e4b-e20223177905" />

2. Turned off email notifications for superusers - only explicitly set "moderators" will get email notifications about pages awaiting moderation. [[docs](https://docs.wagtail.org/en/latest/reference/settings.html#wagtailadmin-notification-include-superusers)]