### PR TITLE
Automated unverified user removal (#1802)

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -108,6 +108,12 @@ def setup_periodic_tasks(sender, **kwargs):
         app.signature("users.tasks.refresh_users_github_photos"),
     )
 
+    # Remove unverified users. Executes daily at 2:15 AM.
+    sender.add_periodic_task(
+        crontab(hour=2, minute=15),
+        app.signature("users.tasks.remove_unverified_users"),
+    )
+
     # Clean up old sandbox documents. Executes weekly on Sundays at 2:00 AM.
     sender.add_periodic_task(
         crontab(day_of_week="sun", hour=2, minute=0),

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,6 +16,7 @@
   - [`update_library_version_dependencies`](#update_library_version_dependencies)
   - [`release_tasks`](#release_tasks)
   - [`refresh_users_github_photos`](#refresh_users_github_photos)
+  - [`remove_unverified_users`](#remove_unverified_users)
   - [`clear_slack_activity`](#clear_slack_activity)
 
 ## `boost_setup`
@@ -357,6 +358,33 @@ Preview which users would be updated:
 
 - Calls the `refresh_users_github_photos()` Celery task which queues photo updates for all users with GitHub usernames
 - With `--dry-run`, displays information about which users would be updated without making any changes
+
+## `remove_unverified_users`
+
+**Purpose**: Remove unverified users that are candidates for deletion. This command queues a Celery task that deletes user accounts with unverified email addresses that have been registered for more than 14 days (since November 21, 2025). This helps maintain database hygiene by cleaning up abandoned user registrations.
+
+**Example**
+
+```bash
+./manage.py remove_unverified_users
+```
+
+**Options**
+
+This command takes no options.
+
+**Process**
+
+- Queues a Celery task (`users.tasks.remove_unverified_users`) for execution
+- The task finds users who:
+  - Have claimed accounts (`claimed=True`)
+  - Have unverified email addresses (`emailaddress__verified=False`)
+  - Joined on or after November 21, 2025
+  - Joined more than 14 days before the current date
+- Deletes each matching user account
+- Logs the deletion process for auditing purposes
+
+**Note**: This command is also executed automatically via a Celery periodic task that runs daily at 2:15 AM.
 
 ## `clear_slack_activity`
 

--- a/users/constants.py
+++ b/users/constants.py
@@ -1,1 +1,6 @@
+from django.utils import timezone
+
 LOGIN_METHOD_SESSION_FIELD_NAME = "boost_login_method"
+
+UNVERIFIED_CLEANUP_DAYS = 14
+UNVERIFIED_CLEANUP_BEGIN = timezone.datetime(2025, 11, 21, 0, 0, 0)

--- a/users/management/commands/remove_unverified_users.py
+++ b/users/management/commands/remove_unverified_users.py
@@ -1,0 +1,15 @@
+import djclick as click
+
+from users.tasks import remove_unverified_users
+
+
+@click.command()
+def command():
+    """Remove unverified users that are candidates for deletion."""
+    click.echo("Starting remove_unverified_users task...")
+
+    try:
+        result = remove_unverified_users.delay()
+        click.secho(f"Task queued with ID: {result.id}", fg="green")
+    except Exception as e:
+        click.secho(f"Error: {e}", fg="red")

--- a/users/tests/test_tasks.py
+++ b/users/tests/test_tasks.py
@@ -1,6 +1,54 @@
 import pytest
+from datetime import timedelta
+from unittest.mock import patch
 
-from ..tasks import UserMissingGithubUsername, update_user_github_photo
+from model_bakery import baker
+from allauth.account.models import EmailAddress
+
+from ..tasks import (
+    UserMissingGithubUsername,
+    update_user_github_photo,
+    remove_unverified_users,
+)
+from ..constants import UNVERIFIED_CLEANUP_DAYS, UNVERIFIED_CLEANUP_BEGIN
+
+
+@pytest.fixture
+def mock_current_time():
+    """Current time set well after cleanup begin + grace period."""
+    return UNVERIFIED_CLEANUP_BEGIN + timedelta(days=30)
+
+
+@pytest.fixture
+def mocked_now(mock_current_time):
+    """Mock timezone.now() to return mock_current_time automatically."""
+    with patch("users.tasks.timezone.now") as mock_now:
+        mock_now.return_value = mock_current_time
+        yield mock_now
+
+
+@pytest.fixture
+def old_date_after_cleanup_begin(mock_current_time):
+    """Date just after cleanup begin, old enough to be deleted."""
+    return UNVERIFIED_CLEANUP_BEGIN + timedelta(days=1)
+
+
+@pytest.fixture
+def old_date_before_cleanup_begin():
+    """Date before cleanup begin - users from this date should not be deleted."""
+    return UNVERIFIED_CLEANUP_BEGIN - timedelta(days=1)
+
+
+@pytest.fixture
+def recent_date(mock_current_time):
+    """Recent date - users from this date should not be deleted due to age."""
+    return mock_current_time - timedelta(days=UNVERIFIED_CLEANUP_DAYS - 1)
+
+
+@pytest.fixture
+def old_date(mock_current_time):
+    """Old date - users from this date should be deleted if they meet other criteria."""
+    return mock_current_time - timedelta(days=UNVERIFIED_CLEANUP_DAYS + 1)
 
 
 def test_update_user_github_photo_user_not_found(db):
@@ -13,3 +61,228 @@ def test_update_user_github_photo_no_gh_username(user):
     user.save()
     with pytest.raises(UserMissingGithubUsername):
         update_user_github_photo(user.pk)
+
+
+@pytest.mark.django_db
+def test_removes_unverified_users_older_than_cleanup_days(
+    mocked_now, old_date_after_cleanup_begin
+):
+    """Test that unverified users older than UNVERIFIED_CLEANUP_DAYS are removed."""
+    # Create a user that should be deleted (unverified, old enough, after cleanup begin date)
+    user_to_delete = baker.make(
+        "users.User",
+        email="old_unverified@example.com",
+        claimed=True,
+        date_joined=old_date_after_cleanup_begin,
+    )
+    # Create unverified email address for this user
+    EmailAddress.objects.create(
+        user=user_to_delete, email=user_to_delete.email, verified=False, primary=True
+    )
+
+    remove_unverified_users()
+    from users.models import User
+
+    assert not User.objects.filter(id=user_to_delete.id).exists()
+
+
+@pytest.mark.django_db
+def test_keeps_unverified_users_newer_than_cleanup_days(mocked_now, recent_date):
+    """Test that unverified users newer than UNVERIFIED_CLEANUP_DAYS are kept."""
+    # Create a user that should NOT be deleted (unverified but too new)
+    user_to_keep = baker.make(
+        "users.User",
+        email="recent_unverified@example.com",
+        claimed=True,
+        date_joined=recent_date,
+    )
+    # Create unverified email address for this user
+    EmailAddress.objects.create(
+        user=user_to_keep, email=user_to_keep.email, verified=False, primary=True
+    )
+
+    remove_unverified_users()
+    from users.models import User
+
+    assert User.objects.filter(id=user_to_keep.id).exists()
+
+
+@pytest.mark.django_db
+def test_keeps_verified_users(mocked_now, old_date):
+    """Test that verified users are not deleted regardless of age."""
+    # Create an old user with verified email
+    verified_user = baker.make(
+        "users.User",
+        email="verified@example.com",
+        claimed=True,
+        date_joined=old_date,
+    )
+    # Create verified email address for this user
+    EmailAddress.objects.create(
+        user=verified_user, email=verified_user.email, verified=True, primary=True
+    )
+
+    remove_unverified_users()
+    from users.models import User
+
+    assert User.objects.filter(id=verified_user.id).exists()
+
+
+@pytest.mark.django_db
+def test_keeps_unclaimed_users(mocked_now, old_date):
+    """Test that unclaimed users are not deleted."""
+    # Create an old unclaimed user with unverified email
+    unclaimed_user = baker.make(
+        "users.User",
+        email="unclaimed@example.com",
+        claimed=False,
+        date_joined=old_date,
+    )
+    # Create unverified email address for this user
+    EmailAddress.objects.create(
+        user=unclaimed_user, email=unclaimed_user.email, verified=False, primary=True
+    )
+
+    remove_unverified_users()
+    from users.models import User
+
+    assert User.objects.filter(id=unclaimed_user.id).exists()
+
+
+@pytest.mark.django_db
+def test_keeps_users_joined_before_cleanup_begin_date(old_date_before_cleanup_begin):
+    """Test that users who joined before UNVERIFIED_CLEANUP_BEGIN are not deleted."""
+    # Create an old user who joined before the cleanup begin date
+    old_user = baker.make(
+        "users.User",
+        email="before_cleanup@example.com",
+        claimed=True,
+        date_joined=old_date_before_cleanup_begin,
+    )
+    # Create unverified email address for this user
+    EmailAddress.objects.create(
+        user=old_user, email=old_user.email, verified=False, primary=True
+    )
+
+    remove_unverified_users()
+    from users.models import User
+
+    assert User.objects.filter(id=old_user.id).exists()
+
+
+@pytest.mark.django_db
+def test_handles_multiple_users(mocked_now, old_date_after_cleanup_begin, recent_date):
+    """Test that the task handles multiple users correctly."""
+    from users.models import User
+
+    # User to delete: old, claimed, unverified, after cleanup begin
+    user_to_delete1 = baker.make(
+        "users.User",
+        email="delete1@example.com",
+        claimed=True,
+        date_joined=old_date_after_cleanup_begin,
+    )
+    EmailAddress.objects.create(
+        user=user_to_delete1, email=user_to_delete1.email, verified=False, primary=True
+    )
+
+    # Another user to delete
+    user_to_delete2 = baker.make(
+        "users.User",
+        email="delete2@example.com",
+        claimed=True,
+        date_joined=old_date_after_cleanup_begin,
+    )
+    EmailAddress.objects.create(
+        user=user_to_delete2, email=user_to_delete2.email, verified=False, primary=True
+    )
+
+    # User to keep: too recent
+    user_to_keep1 = baker.make(
+        "users.User",
+        email="keep1@example.com",
+        claimed=True,
+        date_joined=recent_date,
+    )
+    EmailAddress.objects.create(
+        user=user_to_keep1, email=user_to_keep1.email, verified=False, primary=True
+    )
+
+    # User to keep: verified
+    user_to_keep2 = baker.make(
+        "users.User",
+        email="keep2@example.com",
+        claimed=True,
+        date_joined=old_date_after_cleanup_begin,
+    )
+    EmailAddress.objects.create(
+        user=user_to_keep2, email=user_to_keep2.email, verified=True, primary=True
+    )
+
+    initial_count = User.objects.count()
+    remove_unverified_users()
+    assert not User.objects.filter(id=user_to_delete1.id).exists()
+    assert not User.objects.filter(id=user_to_delete2.id).exists()
+    assert User.objects.filter(id=user_to_keep1.id).exists()
+    assert User.objects.filter(id=user_to_keep2.id).exists()
+    assert User.objects.count() == initial_count - 2
+
+
+@pytest.mark.django_db
+def test_handles_no_users_to_delete(mocked_now, recent_date):
+    """Test that the task handles the case where no users need to be deleted."""
+    from users.models import User
+
+    # Create a user that should NOT be deleted (recent)
+    test_user = baker.make(
+        "users.User",
+        email="recent@example.com",
+        claimed=True,
+        date_joined=recent_date,
+    )
+    EmailAddress.objects.create(
+        user=test_user, email=test_user.email, verified=False, primary=True
+    )
+
+    initial_count = User.objects.count()
+    remove_unverified_users()
+    assert User.objects.count() == initial_count
+    assert User.objects.filter(id=test_user.id).exists()
+
+
+@pytest.mark.django_db
+@patch("users.tasks.logger")
+def test_remove_unverified_users_logging(
+    mock_logger, mocked_now, old_date_after_cleanup_begin
+):
+    """Test that the task logs appropriately."""
+    # Create a user to delete
+    user_to_delete = baker.make(
+        "users.User",
+        email="logging_test@example.com",
+        claimed=True,
+        date_joined=old_date_after_cleanup_begin,
+    )
+    EmailAddress.objects.create(
+        user=user_to_delete, email=user_to_delete.email, verified=False, primary=True
+    )
+
+    remove_unverified_users()
+    mock_logger.info.assert_any_call("Starting remove_unverified_users task")
+    mock_logger.info.assert_any_call("Found 1 unverified users for deletion")
+    mock_logger.info.assert_any_call("Successfully processed 1 unverified users")
+
+
+@patch("users.tasks.logger")
+def test_remove_unverified_users_exception_handling(mock_logger):
+    """Test that exceptions are properly caught and logged."""
+    # Mock User.objects.filter to raise an exception
+    with patch("users.tasks.User.objects.filter") as mock_filter:
+        mock_filter.side_effect = Exception("Test exception")
+
+        # Run the task - should not raise the exception
+        remove_unverified_users()
+        # Verify exception was logged
+        mock_logger.exception.assert_called_once_with(
+            "Error occurred processing unverified users for removal: Test exception"
+        )


### PR DESCRIPTION
This PR relates to ticket #1802.

Adds automated removal of unverified users after 14 days (#1802)

Starting with accounts created on or after the 21st of November 2025, users who create an account and don't verify it within 14 days will have the accounts removed.

Testing:
1. Add a new user, do not verify them as the email states.
2. Update the values for `UNVERIFIED_CLEANUP_DAYS` and `UNVERIFIED_CLEANUP_BEGIN` in `users/constants.py` to test as you see fit. Changes will require a restart of the celery worker with `docker compose restart celery-worker` in the code directory.
3. Test that verified users aren't deleted.