### PR TITLE
Add block to direct docs path access  (#2012)

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -11,6 +11,7 @@ SLACK_URL = "https://cpplang.slack.com"
 STATIC_CONTENT_EARLY_EXIT_PATH_PREFIXES = ("releases/",)
 # possible library versions are: boost_1_53_0_beta1, 1_82_0, 1_55_0b1
 BOOST_LIB_PATH_RE = re.compile(r"^(boost_){0,1}([0-9_]*[0-9]+[^/]*)/(.*)")
+BOOST_VERSION_REGEX = r"(boost_){0,1}([0-9_]*[0-9]+[^/]*)"
 NO_PROCESS_LIBS = [
     # Do nothing with these - just render contents directly
     "libs/filesystem",


### PR DESCRIPTION
This is related to ticket #2012.

Adds a filter to return a 404 should an attempt be made to access the docs directly on s3 via static content serving.

Testing: before switching to the branch the URLs as documented in the original ticket should work locally. You'll need to load the full correct path first so it's in the cache. After switching to this branch a 404 should be returned for the URL we don't want. Check that all other static content, e.g. images etc. continue to work.