### PR TITLE
Fix release note generation race condition (#2027)

### DIFF
--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -86,9 +86,10 @@ def import_release_notes(new_versions_only=True):
     if not new_versions_only:
         versions = Version.objects.exclude(name__in=["master", "develop"]).active()
 
+    logger.info(f"import_release_notes {[(v.pk,v.name) for v in versions]}")
     for version in versions:
         logger.info(f"retrieving release notes for {version.name=} {version.pk=}")
-        store_release_notes_task.delay(str(version.pk))
+        store_release_notes_task(version.pk)
     store_release_notes_in_progress_task.delay()
 
 


### PR DESCRIPTION
This PR is related to ticket #2027.

When an admin wants to update the beta release notes, they can use "import new releases" in the admin interface. This calls `import_beta_release` management command which regenerates the release notes for the beta version.

Locally this was working fine, on staging it wasn't. This seemed to be related to the beta version having been marked as deleted and a new one having been imported, but the transaction likely isn't being committed before the `store_release_notes_task` task is called in `import_release_notes`. 

Switching that to a function call rather than a queued task resolves this locally. That required changes to functions called within that to make them handle errors better.

This was difficult to reproduce so in case this doesn't resolve the issue when the code gets to staging/prod, for future reference how I reproduced this was adding a `sleep(30)` after `import_release_notes(new_versions_only=False)` in `import_most_recent_beta_release`. 

1. Resolves race condition on release note generation.
1. Update github release notes retrieval to cleanly handle missing paths 

Testing: we should just test this on staging. Pass = "import new releases" results in new release notes with "Locale" related content block for the beta release.