### PR TITLE
CMS content code block and table styling tweaks

### DIFF
--- a/static/css/landing-style.css
+++ b/static/css/landing-style.css
@@ -29,13 +29,13 @@ h5 {font-size: 0.69rem; font-weight:700;}
 h6 {}
 ul {}
 ol {}
-code, pre {
-    font-family: monospace;
-    font-size: 0.88rem;
-    display: inline;
-    font-weight: 500;
-    color: #187645;
-}
+
+table  {font-size:.8rem; width:100%;border:2px solid #f1f1f1; border-collapse: collapse;
+  border-spacing: 0;}
+table th, table td {padding:.3rem; text-align: left; border:2px solid #f1f1f1;}
+table th {background-color:f1f1f1}
+
+.codehilite { padding: 1rem; }
 
 .section {}
 .inset {padding-left:50px}


### PR DESCRIPTION
CSS styling tweaks for tables and code highlighting in CMS-created content.

### Before:
<img width="674" height="635" alt="Screenshot 2025-12-05 at 1 57 36 PM" src="https://github.com/user-attachments/assets/e03bf302-a2a5-43cc-88c4-dc86d68a918f" />

### After:
<img width="668" height="644" alt="Screenshot 2025-12-05 at 1 58 18 PM" src="https://github.com/user-attachments/assets/4d8a6a49-c2bc-4cd6-ac3a-87477e6b0c61" />

