### PR TITLE
Updated import_ml_counts to pull data from hyperkitty db

### DIFF
--- a/.github/workflows/actions-gcp.yaml
+++ b/.github/workflows/actions-gcp.yaml
@@ -68,6 +68,7 @@ jobs:
       - name: Test with pytest
         env:
           DATABASE_URL: "postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres"
+          HYPERKITTY_DATABASE_URL: "postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/lists_production_web"
           SECRET_KEY: "for-testing-only"
           REDIS_HOST: "localhost"
           CI: "true"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Test with pytest
         env:
           DATABASE_URL: "postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres"
+          HYPERKITTY_DATABASE_URL: "postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/lists_production_web"
           SECRET_KEY: "for-testing-only"
           REDIS_HOST: "localhost"
           CI: "true"

--- a/config/settings.py
+++ b/config/settings.py
@@ -189,7 +189,10 @@ WSGI_APPLICATION = "config.wsgi.application"
 # https://docs.djangoproject.com/en/1.10/ref/settings/#databases
 
 try:
-    DATABASES = {"default": env.dj_db_url("DATABASE_URL")}
+    DATABASES = {
+        "default": env.dj_db_url("DATABASE_URL"),
+        "hyperkitty": env.dj_db_url("HYPERKITTY_DATABASE_URL"),
+    }
 except (ImproperlyConfigured, environs.EnvError):
     DATABASES = {
         "default": {
@@ -201,7 +204,17 @@ except (ImproperlyConfigured, environs.EnvError):
             "USER": env("PGUSER"),
             "CONN_MAX_AGE": 0,
             "OPTIONS": {"MAX_CONNS": env("MAX_CONNECTIONS", default=20)},
-        }
+        },
+        "hyperkitty": {
+            "ENGINE": "django_db_geventpool.backends.postgresql_psycopg2",
+            "HOST": env("PGHOST"),
+            "NAME": env("HYPERKITTY_DATABASE_NAME", default=""),
+            "PASSWORD": env("PGPASSWORD"),
+            "PORT": env.int("PGPORT", default=5432),
+            "USER": env("PGUSER"),
+            "CONN_MAX_AGE": 0,
+            "OPTIONS": {"MAX_CONNS": env("MAX_CONNECTIONS", default=20)},
+        },
     }
 
 # Password validation

--- a/env.template
+++ b/env.template
@@ -35,6 +35,7 @@ PROD_MEDIA_CONTENT_AWS_S3_ENDPOINT_URL=$STATIC_CONTENT_AWS_S3_ENDPOINT_URL
 # Mailman database settings
 HYPERKITTY_DATABASE_NAME="lists_production_web"
 DATABASE_URL="postgresql://postgres@db:5432/postgres"
+HYPERKITTY_DATABASE_URL="postgresql://postgres@db:5432/lists_production_web"
 DATABASE_TYPE="postgres"
 DATABASE_CLASS="mailman.database.postgresql.PostgreSQLDatabase"
 HYPERKITTY_API_KEY="changeme!"

--- a/mailing_list/admin.py
+++ b/mailing_list/admin.py
@@ -11,7 +11,7 @@ from django.http import HttpResponseRedirect
 from django.contrib import admin, messages
 from django.conf import settings
 
-from mailing_list.models import EmailData, SubscriptionData
+from mailing_list.models import EmailData, SubscriptionData, ListPosting
 from mailing_list.tasks import sync_mailinglist_stats
 
 logger = logging.getLogger(__name__)
@@ -112,3 +112,18 @@ class SubscriptionDataAdmin(admin.ModelAdmin):
 
         payload = {"form": SubscribesCSVForm()}
         return render(request, "admin/mailinglist_subscribe_csv_form.html", payload)
+
+
+@admin.register(ListPosting)
+class ListPostingAdmin(admin.ModelAdmin):
+    list_display = ["id", "date", "sender_id"]
+    search_fields = ["sender_id"]
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -57,3 +57,20 @@ class SubscriptionData(models.Model):
 
     class Meta:
         unique_together = ["subscription_dt", "email", "list"]
+
+
+class ListPostingManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().using("hyperkitty")
+
+
+class ListPosting(models.Model):
+    id = models.IntegerField(primary_key=True, blank=False, null=False)
+    date = models.DateTimeField(blank=False, null=False)
+    sender_id = models.CharField(blank=False, null=False)
+
+    objects = ListPostingManager()
+
+    class Meta:
+        managed = False
+        db_table = "hyperkitty_email"


### PR DESCRIPTION
This PR changes the `import_ml_counts` management command to retrieve the mailing list email metadata from hyperkitty instead of the archives urls.

Also added is a readonly admin view on the hyperkitty metadata that'd be used. 

Generated release report now looks like:

<img width="1204" height="1865" alt="mailinglist" src="https://github.com/user-attachments/assets/fcd5d6cc-4950-45f8-85dd-9f7a0efac5f4" />

Testing: run `just manage import_ml_counts` and when completed generate a release report for 1.90.0, confirm graphs are as expected.