### PR TITLE
Reenable slack celery task

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -83,12 +83,11 @@ def setup_periodic_tasks(sender, **kwargs):
         app.signature("core.tasks.clear_static_content_cache"),
     )
 
-    # TODO: reenable
-    # # Fetch Slack activity. Executes daily at 3:07 AM.
-    # sender.add_periodic_task(
-    #     crontab(hour=3, minute=7),
-    #     app.signature("slack.tasks.fetch_slack_activity"),
-    # )
+    # Fetch Slack activity. Executes daily at 3:07 AM.
+    sender.add_periodic_task(
+        crontab(hour=3, minute=7),
+        app.signature("slack.tasks.fetch_slack_activity"),
+    )
 
     # delete users scheduled for deletion, arbitrarily every 61 minutes
     sender.add_periodic_task(


### PR DESCRIPTION
This PR re-enables the scheduled celery task after it was previously disabled, to allow for a manually run long running task.