### PR TITLE
Bug: Fix Release Report continuing polling on success

### DIFF
--- a/libraries/admin.py
+++ b/libraries/admin.py
@@ -370,7 +370,9 @@ class ReleaseReportView(TemplateView):
                 form.cache_set("")
                 self.generate_report()
             elif content.content_html:
-                return HttpResponse(content.content_html)
+                response = HttpResponse(content.content_html)
+                response.status_code = 286
+                return response
             # If this flag is set, the page is being request via htmx and should only
             # return the task widget
             if self.request.GET.get("render_widget", None):

--- a/templates/admin/report_polling.html
+++ b/templates/admin/report_polling.html
@@ -6,7 +6,6 @@
 {% endblock %}
 
 {% block content %}
-  <div class="flex container my-4 mx-auto">The {{ report_type }} is being generated. This page will refresh periodically, please wait.</div>
   <div hx-get="{{widget_endpoint|escape}}" hx-trigger="every 2s">
     {{task_widget|safe}}
   </div>

--- a/templates/admin/task_polling_widget.html
+++ b/templates/admin/task_polling_widget.html
@@ -1,3 +1,4 @@
+<div class="flex container my-4 mx-auto">The {{ report_type }} is being generated. This page will refresh periodically, please wait.</div>
 <div class="container my-4 mx-auto">
     <table>
         <thead>


### PR DESCRIPTION
* Fix issue in which the release report would not stop polling on completion
* Also move the polling message to the widget, so that it is no longer shown once the report is complete