### PR TITLE
Story: Correct button text alignment on mobile

### DIFF
--- a/static/css/v3/buttons.css
+++ b/static/css/v3/buttons.css
@@ -17,6 +17,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  text-align: center;
   gap: var(--space-default, 8px);
   font-family: var(--font-sans);
   font-size: var(--font-size-small, 14px);


### PR DESCRIPTION
Correct mobile styling of buttons, which appear left aligned when word wrap is applied: 
<img width="742" height="1280" alt="image" src="https://github.com/user-attachments/assets/e7c73004-9890-4c86-b74b-195b523c36c1" />

Corrected appearance: 
<img width="388" height="355" alt="image" src="https://github.com/user-attachments/assets/42405e1d-de40-499d-89cc-4c3883918315" />
