### PR TITLE
Add horizontal card component

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1145,6 +1145,14 @@ class V3ComponentDemoView(TemplateView):
             "secondary_button_label": "Secondary Button",
         }
 
+        context["horizontal_card_data"] = {
+            "title": "Build anything with Boost",
+            "text": "Use, modify, and distribute Boost libraries freely. No binary attribution needed.",
+            "image_url": f"{settings.STATIC_URL}img/checker.png",
+            "button_url": "#",
+            "button_label": "See license details",
+        }
+
         context["demo_cards_carousel_cards"] = [
             {
                 "title": "Get help",

--- a/static/css/v3/card.css
+++ b/static/css/v3/card.css
@@ -61,3 +61,42 @@
     border: none;
     margin: 0;
 }
+
+/* Horizontal card — text + image side by side */
+
+.horizontal-card {
+    max-width: 459px;
+}
+
+.horizontal-card__content-row {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-large, 16px);
+    align-self: stretch;
+    padding: 0 var(--space-large, 16px);
+}
+
+.horizontal-card__text {
+    flex: 1 0 0;
+    padding: 0;
+    color: var(--color-text-secondary, #585a64);
+    font-family: var(--font-sans, 'Mona Sans VF'), sans-serif;
+    font-size: var(--font-size-base, 16px);
+    font-weight: var(--font-weight-regular, 400);
+    line-height: var(--line-height-default, 1.2);
+    letter-spacing: var(--letter-spacing-tight, -0.01em);
+}
+
+.horizontal-card__image {
+    flex: 1 0 0;
+    aspect-ratio: 1 / 1;
+    border-radius: var(--border-radius-l, 8px);
+    overflow: hidden;
+}
+
+.horizontal-card__image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}

--- a/templates/v3/examples/_v3_example_section.html
+++ b/templates/v3/examples/_v3_example_section.html
@@ -272,6 +272,15 @@
     {% endwith %}
   </div>
 
+  <div class="v3-examples-section__block">
+    <h3>Horizontal Card</h3>
+    {% with horizontal_card_data as card %}
+    <div class="v3-examples-section__example-box">
+      {% include "v3/includes/_horizontal_card.html" with title=card.title text=card.text image_url=card.image_url button_url=card.button_url button_label=card.button_label %}
+    </div>
+    {% endwith %}
+  </div>
+
 <div class="v3-examples-section__block">
     <h3>Learn Card</h3>
     <div class="v3-examples-section__example-box">

--- a/templates/v3/includes/_horizontal_card.html
+++ b/templates/v3/includes/_horizontal_card.html
@@ -1,0 +1,34 @@
+{% comment %}
+  Horizontal card: title, side-by-side text + image, and CTA button.
+
+  Variables:
+    title        (string, required) — card heading
+    text         (string, required) — description text beside the image
+    image_url    (string, required) — URL of the image
+    image_alt    (string, optional) — alt text for image, defaults to ""
+    button_url   (string, optional) — CTA link destination
+    button_label (string, optional) — CTA button text
+    button_style (string, optional) — button style variant, defaults to "primary"
+
+  Usage:
+    {% include "v3/includes/_horizontal_card.html" with title="Build anything with Boost" text="Use, modify, and distribute..." image_url="/static/img/example.png" button_url="#" button_label="See license details" %}
+{% endcomment %}
+
+<div class="horizontal-card card py-large">
+  <div class="card__header">
+    <span class="card__title">{{ title }}</span>
+  </div>
+  <hr class="card__hr" />
+  <div class="horizontal-card__content-row">
+    <p class="horizontal-card__text">{{ text }}</p>
+    <div class="horizontal-card__image">
+      <img src="{{ image_url }}" alt="{{ image_alt|default:'' }}" />
+    </div>
+  </div>
+  {% if button_url and button_label %}
+    <hr class="card__hr" />
+    <div class="px-large btn-row">
+      {% include 'v3/includes/_button.html' with style=button_style url=button_url label=button_label extra_classes="btn-flex" only %}
+    </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
- New `_horizontal_card.html` template: card with title, side-by-side text + image, and optional CTA button
- Extends existing `.card` base class with `.horizontal-card` variant (scoped BEM elements)
- Added demo block to `/v3/demo/components/`