### PR TITLE
Bug #2161 Follow-up: Update secondary button background

### DIFF
--- a/static/css/v3/buttons.css
+++ b/static/css/v3/buttons.css
@@ -63,6 +63,7 @@
 }
 
 .btn-secondary {
+  background: var(--color-surface-weak);
   border-color: var(--color-stroke-strong);
   color: var(--color-text-primary);
 }

--- a/static/css/v3/themes.css
+++ b/static/css/v3/themes.css
@@ -28,7 +28,7 @@ html.dark {
   /* Error Primitives (Dark theme override)
      Note: This is a special case where a primitive token needs theme-specific opacity.
      In dark theme, error-weak uses reduced opacity for better contrast. */
-  --color-error-weak: #FDF2F217;
+  --color-error-weak: #fdf2f217;
 
   /* Buttons */
   --color-button-primary: var(--color-primary-grey-800);
@@ -45,18 +45,18 @@ html.dark {
   --color-navigation-selected: var(--color-primary-grey-800);
 
   /* Stroke */
-  --color-stroke-error: #D53F3F;
+  --color-stroke-error: #d53f3f;
   --color-stroke-link-accent: var(--color-secondary-mid-blue);
-  --color-stroke-mid: #F7F7F82B;
-  --color-stroke-strong: #F7F7F836;
-  --color-stroke-weak: #F7F7F81A;
+  --color-stroke-mid: #f7f7f82b;
+  --color-stroke-strong: #f7f7f836;
+  --color-stroke-weak: #f7f7f81a;
 
   /* Surface */
-  --color-surface-brand-accent-hovered: #FFA000D9;
+  --color-surface-brand-accent-hovered: #ffa000d9;
   --color-surface-error-strong: var(--color-error-mid);
-  --color-surface-error-weak: #FDF2F217;
+  --color-surface-error-weak: #fdf2f217;
   --color-surface-mid: var(--color-primary-grey-900);
-  --color-surface-modal: #0508164D;
+  --color-surface-modal: #0508164d;
   --color-surface-page: var(--color-primary-black);
   --color-surface-strong: var(--color-primary-grey-800);
   --color-surface-weak: var(--color-primary-grey-950);
@@ -83,7 +83,7 @@ html.dark {
   /* Tag */
   --color-tag-fill: var(--color-primary-grey-900);
   --color-tag-fill-hover: var(--color-primary-grey-850);
-  --color-tag-stroke: #FFFFFF1A;
+  --color-tag-stroke: #ffffff1a;
   /* Category tag dark: single source for neutral and colored tag surfaces (no raw primitives in category-tags.css) */
   --color-tag-neutral-bg: var(--color-primary-grey-900);
   --color-tag-neutral-bg-hover: var(--color-primary-grey-800);


### PR DESCRIPTION
# Bug #2161 Follow-up

- Added a background color for **secondary** buttons. 
- Updated `--color-text-on-accent` from `var(--color-primary-white);` to `var(--color-primary-black);`

## Screenshot (Dark mode)
Before | After
-- | --
<img width="1015" height="645" alt="Screenshot 2026-03-16 at 3 07 38 PM" src="https://github.com/user-attachments/assets/30bbbaa6-1e23-4fcf-9b86-7ce826f466ec" /> | <img width="994" height="633" alt="Screenshot 2026-03-16 at 3 07 13 PM" src="https://github.com/user-attachments/assets/760cb93d-7255-4bd6-a0be-415637345acc" />
