### PR TITLE
Fix icon/text alignment in account connections card

### DIFF
--- a/static/css/v3/account-connections.css
+++ b/static/css/v3/account-connections.css
@@ -33,7 +33,7 @@
 
 .account-connections__platform {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: var(--space-default, 8px);
   flex-shrink: 0;
 }


### PR DESCRIPTION
Fixes baseline alignment between the platform icons and platform name text in the account connections card.

Addresses QA comment on #2152.

![account-connections](https://i.imgur.com/vc3k8wn.png)