### PR TITLE
fix: update badges card CTA button to primary style (#2146)

### DIFF
--- a/templates/v3/includes/_badges_card.html
+++ b/templates/v3/includes/_badges_card.html
@@ -52,7 +52,7 @@
     {% if cta_url %}
     <div class="btn-row">
       {% with default_cta="Explore available badges and how to earn them" %}
-      {% include "v3/includes/_button.html" with url=cta_url label=cta_label|default:default_cta style="secondary-grey" extra_classes="btn-flex" %}
+      {% include "v3/includes/_button.html" with url=cta_url label=cta_label|default:default_cta style="primary" extra_classes="btn-flex" %}
       {% endwith %}
     </div>
     {% endif %}


### PR DESCRIPTION
Changes badges card CTA button from `secondary-grey` to `primary` style, applying the `--color-primary-grey-200` background. Fixes [#2146](https://github.com/boostorg/website-v2/issues/2146#issuecomment-4092136024).

**Fixed Preview**
<img width="2480" height="650" alt="image" src="https://github.com/user-attachments/assets/ea254cc3-0eaf-4e24-82a7-ba940b798a23" />
