### PR TITLE
fix: update badges card name font size to 12px

### DIFF
--- a/static/css/v3/badges-card.css
+++ b/static/css/v3/badges-card.css
@@ -38,7 +38,7 @@
 
 .badges-card__name {
   color: var(--color-text-primary);
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-xs);
   font-weight: var(--font-weight-regular);
   line-height: var(--line-height-default);
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- Update `.badges-card__name` font size from `--font-size-small` (14px) to `--font-size-xs` (12px) to match design specs

fixes https://github.com/boostorg/website-v2/issues/2146#issuecomment-4111263472