### PR TITLE
Show news summaries instead of content on homepage

### DIFF
--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -284,9 +284,9 @@
               </h2>
 
               <p class="pt-0 pb-4 mx-auto w-full text-xs md:text-sm align-left">Posted on {{ entry.publish_at|date:"M jS, Y" }} by {{ entry.author.display_name }}</p>
-              {% if entry.content %}
+              {% if entry.summary %}
               <div class="md:ml-[40px]">
-                <span class="text-sm md:text-base text-gray-500 dark:text-white/70">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|multi_truncate_middle:30|truncatechars_html:500 }}</span>
+                <span class="text-sm md:text-base text-gray-500 dark:text-white/70">{{ entry.summary }}</span>
                 </div>
               {% endif %}
             </div>


### PR DESCRIPTION
The homepage news section was showing the raw entry content (truncated to 500 chars with various filters). This switches it to show the AI-generated summary field instead.

## Screenshots

![Homepage news summaries](https://i.imgur.com/f5Qgdfi.png)