### PR TITLE
Bug: Fix V3 Demo Page Overflow Issue In Avatar Section

### DIFF
--- a/static/css/v3/v3-examples-section.css
+++ b/static/css/v3/v3-examples-section.css
@@ -72,7 +72,13 @@ html.dark .v3-examples-section__example-box {
   text-align: center;
 }
 
+.v3-examples-section__avatar-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 .v3-examples-section__avatar-table {
+  min-width: 36rem;
   width: 100%;
   border-collapse: collapse;
 }

--- a/templates/v3/examples/_v3_example_section.html
+++ b/templates/v3/examples/_v3_example_section.html
@@ -70,6 +70,7 @@
     <div class="v3-examples-section__block" id="{{ section_title|slugify }}">
       <h3>{{ section_title }}</h3>
       <div class="v3-examples-section__example-box">
+        <div class="v3-examples-section__avatar-scroll">
         <table class="v3-examples-section__avatar-table">
           <tbody>
             <tr>
@@ -149,6 +150,7 @@
             </tr>
           </tbody>
         </table>
+        </div>
       </div>
     </div>
   {% endwith %}


### PR DESCRIPTION
## Summary
Fix the avatar table on the V3 component demo page so it doesn't overflow on narrow viewports.
http://localhost:8000/v3/demo/components/#avatar

## Changes
- Wrap `.v3-examples-section__avatar-table` in a horizontally-scrollable container (`.v3-examples-section__avatar-scroll`)
- Set `min-width: 36rem` on the table so columns stay readable instead of collapsing, scrolling when the viewport is smaller


## ‼️ Risks & Considerations ‼️
None

## Screenshots

Before | After
-- | --
<img width="669" height="651" alt="Screenshot 2026-03-30 at 3 53 08 PM" src="https://github.com/user-attachments/assets/82c3f7b8-6903-41d0-a315-6d82e23b9dbd" /> | <img width="682" height="934" alt="Screenshot 2026-03-30 at 3 48 54 PM" src="https://github.com/user-attachments/assets/2007100d-2233-4cbc-9790-95f1ae81537e" />