### PR TITLE
Support README.adoc as fallback for library descriptions

### DIFF
--- a/libraries/constants.py
+++ b/libraries/constants.py
@@ -346,6 +346,9 @@ SUB_LIBRARIES = {
 # List of versions for which we know docs are missing
 VERSION_DOCS_MISSING = ["boost-1.33.0"]
 
+# File paths where library description content might be stored, in priority order.
+DESCRIPTION_FILES = ["doc/library-detail.adoc", "README.md", "README.adoc"]
+
 # This constant is for library-versions missing a README
 README_MISSING = (
     "⚠️ This library has no README file or library-detail.adoc; "

--- a/libraries/constants.py
+++ b/libraries/constants.py
@@ -348,7 +348,7 @@ VERSION_DOCS_MISSING = ["boost-1.33.0"]
 
 # This constant is for library-versions missing a README
 README_MISSING = (
-    "⚠️ This library has no README.md or library-details.adoc; "
+    "⚠️ This library has no README file or library-detail.adoc; "
     "consider contributing one."
 )
 

--- a/libraries/models.py
+++ b/libraries/models.py
@@ -335,9 +335,9 @@ class Library(models.Model):
     def get_description(self, client, tag="develop"):
         """Get description from the appropriate file on GitHub.
 
-        For more recent versions, that will be `/doc/library-details.adoc`.
+        For more recent versions, that will be `/doc/library-detail.adoc`.
         For older versions, or libraries that have not adopted the adoc file,
-        that will be `/README.md`.
+        that will be `/README.md` or `/README.adoc`.
         """
         content = None
         # File paths/names where description data might be stored.

--- a/libraries/models.py
+++ b/libraries/models.py
@@ -25,7 +25,7 @@ from core.validators import image_validator, max_file_size_validator
 from libraries.managers import IssueManager
 from mailing_list.models import EmailData
 from versions.models import ReportConfiguration
-from .constants import LIBRARY_GITHUB_URL_OVERRIDES
+from .constants import DESCRIPTION_FILES, LIBRARY_GITHUB_URL_OVERRIDES
 
 from .utils import (
     generate_random_string,
@@ -340,8 +340,7 @@ class Library(models.Model):
         that will be `/README.md` or `/README.adoc`.
         """
         content = None
-        # File paths/names where description data might be stored.
-        files = ["doc/library-detail.adoc", "README.md", "README.adoc"]
+        files = DESCRIPTION_FILES
 
         # Try to get the content from the cache first
         static_content_cache = caches["static_content"]

--- a/libraries/models.py
+++ b/libraries/models.py
@@ -341,7 +341,7 @@ class Library(models.Model):
         """
         content = None
         # File paths/names where description data might be stored.
-        files = ["doc/library-detail.adoc", "README.md"]
+        files = ["doc/library-detail.adoc", "README.md", "README.adoc"]
 
         # Try to get the content from the cache first
         static_content_cache = caches["static_content"]

--- a/libraries/tests/test_models.py
+++ b/libraries/tests/test_models.py
@@ -1,7 +1,12 @@
 import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.cache import caches
 from django.db.models import Sum
 from model_bakery import baker
 
+from core.models import RenderedContent
 from libraries.models import CommitAuthor
 from mailing_list.models import EmailData
 
@@ -138,6 +143,37 @@ def test_library_version_first_boost_version_property(library):
     version_3.save()
     del library.first_boost_version
     assert library.first_boost_version == version_3
+
+
+DESCRIPTION_FILES = ["doc/library-detail.adoc", "README.md", "README.adoc"]
+
+
+@pytest.mark.parametrize(
+    "first_available, expected",
+    [(0, "<p>adoc</p>"), (1, "<p>md</p>"), (2, "<p>adoc</p>"), (None, None)],
+    ids=["library-detail.adoc", "README.md-fallback", "README.adoc-fallback", "none"],
+)
+@patch("libraries.models.process_md", return_value=("", "<p>md</p>"))
+@patch("libraries.models.write_content_to_tempfile")
+@patch("libraries.models.convert_adoc_to_html", return_value="<p>adoc</p>")
+def test_get_description_file_priority(
+    mock_adoc, mock_tempfile, mock_md, library, first_available, expected
+):
+    """Files are tried in order; the first available file wins."""
+    caches["static_content"].clear()
+    RenderedContent.objects.all().delete()
+    mock_tempfile.return_value.name = "/tmp/fake"
+
+    available = {
+        f: b"content" if first_available is not None and i >= first_available else None
+        for i, f in enumerate(DESCRIPTION_FILES)
+    }
+    client = MagicMock()
+    client.get_file_content.side_effect = (
+        lambda repo_slug, tag, file_path: available.get(file_path)
+    )
+
+    assert library.get_description(client) == expected
 
 
 def test_merge_author_deletes_author():

--- a/libraries/tests/test_models.py
+++ b/libraries/tests/test_models.py
@@ -7,6 +7,7 @@ from django.db.models import Sum
 from model_bakery import baker
 
 from core.models import RenderedContent
+from libraries.constants import DESCRIPTION_FILES
 from libraries.models import CommitAuthor
 from mailing_list.models import EmailData
 
@@ -145,9 +146,6 @@ def test_library_version_first_boost_version_property(library):
     assert library.first_boost_version == version_3
 
 
-DESCRIPTION_FILES = ["doc/library-detail.adoc", "README.md", "README.adoc"]
-
-
 @pytest.mark.parametrize(
     "first_available, expected",
     [(0, "<p>adoc</p>"), (1, "<p>md</p>"), (2, "<p>adoc</p>"), (None, None)],
@@ -157,22 +155,22 @@ DESCRIPTION_FILES = ["doc/library-detail.adoc", "README.md", "README.adoc"]
 @patch("libraries.models.write_content_to_tempfile")
 @patch("libraries.models.convert_adoc_to_html", return_value="<p>adoc</p>")
 def test_get_description_file_priority(
-    mock_adoc, mock_tempfile, mock_md, library, first_available, expected
+    _adoc, mock_tempfile, _md, library, first_available, expected
 ):
     """Files are tried in order; the first available file wins."""
     caches["static_content"].clear()
     RenderedContent.objects.all().delete()
     mock_tempfile.return_value.name = "/tmp/fake"
 
-    available = {
-        f: b"content" if first_available is not None and i >= first_available else None
-        for i, f in enumerate(DESCRIPTION_FILES)
-    }
+    available = dict.fromkeys(DESCRIPTION_FILES)
+    if first_available is not None:
+        for f in DESCRIPTION_FILES[first_available:]:
+            available[f] = b"content"
+
     client = MagicMock()
     client.get_file_content.side_effect = (
         lambda repo_slug, tag, file_path: available.get(file_path)
     )
-
     assert library.get_description(client) == expected
 
 


### PR DESCRIPTION
Fixes #2182 

Adds README.adoc as a third fallback option in Library.get_description, tried after doc/library-detail.adoc and README.md.

- Appended README.adoc to the files list in get_description
- Existing .adoc conversion logic handles it automatically
- Added parametrized test covering file priority and the no-files-found case

Locally, Boost.URL, version 1.91.0-beta1 now shows a library description from its README.adoc (note there is a pre-existing table stretching display bug):
![URL library description from README.adoc](https://i.imgur.com/bJyUcwN.png)