### PR TITLE
chore: Update Figma link section of PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,9 +3,7 @@
 ## Summary & Context
 <!-- *1-2 sentences describing what this PR does and why* -->
 
-- **Figma links**:
-  - ML Figma:
-  - CPPA Figma:
+- **Figma link**: <!-- Add link to relevant Figma design here -->
 - **Link to components/page:** <!-- e.g. localhost:8000/news/add -->
 
 ## Changes


### PR DESCRIPTION
## Summary & Context
- Update the PR template to remove coming vs CPP Figma link fields into 1 since we're using a shared design file now. 