### PR TITLE
Fix profile photo upload (#2242)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -504,6 +504,7 @@ if not LOCAL_DEVELOPMENT:
     MEDIA_BUCKET_NAME = env("MEDIA_BUCKET_NAME", default="changeme")
     AWS_STORAGE_BUCKET_NAME = MEDIA_BUCKET_NAME
     AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "max-age=86400"}
+    AWS_S3_USE_THREADS = False  # boto3 threads deadlock under gevent
     AWS_DEFAULT_ACL = None
     AWS_S3_ENDPOINT_URL = env(
         "AWS_S3_ENDPOINT_URL", default="https://sfo2.digitaloceanspaces.com"

--- a/core/storages.py
+++ b/core/storages.py
@@ -5,6 +5,6 @@ from storages.backends.s3boto3 import S3Boto3Storage
 
 class MediaStorage(S3Boto3Storage):
     bucket_name = settings.MEDIA_BUCKET_NAME
-    default_acl = None
+    default_acl = "public-read"
     file_overwrite = True
     custom_domain = False

--- a/core/storages.py
+++ b/core/storages.py
@@ -5,6 +5,6 @@ from storages.backends.s3boto3 import S3Boto3Storage
 
 class MediaStorage(S3Boto3Storage):
     bucket_name = settings.MEDIA_BUCKET_NAME
-    default_acl = "public-read"
+    default_acl = None
     file_overwrite = True
     custom_domain = False

--- a/templates/libraries/_library_grid_list_item.html
+++ b/templates/libraries/_library_grid_list_item.html
@@ -10,8 +10,8 @@ onclick="handleCardClick(event, '{% url 'library-detail' library_slug=library_ve
       {% include "libraries/includes/_documentation_link_icon.html" %}
     </div>
       {% for author in library.authors.all %}
-        {% if author.image %}
-          <img src="{{ author.image.url }}" class="inline float-right rounded w-[30px] ml-1" alt="{{ author.display_name }}" />
+        {% if author.profile_image %}
+          <img src="{{ author.profile_image.url }}" class="inline float-right rounded w-[30px] ml-1" alt="{{ author.display_name }}" />
         {% endif %}
       {% endfor %}
     </h3>

--- a/templates/news/detail.html
+++ b/templates/news/detail.html
@@ -55,7 +55,7 @@
         </span>
         {{ entry.title }}</h1>
       <div class="space-x-3 mt-3 flex items-center">
-        {% if entry.author.image %}
+        {% if entry.author.profile_image %}
           <span class="inline-block h-[30px] w-[30px] overflow-hidden rounded border border-gray-400 dark:border-gray-500">
             <img src="{{ entry.author.image_thumbnail.url }}" alt="{{ entry.author.display_name }}" class="h-full w-full object-cover">
           </span>

--- a/templates/news/detail.html
+++ b/templates/news/detail.html
@@ -55,15 +55,17 @@
         </span>
         {{ entry.title }}</h1>
       <div class="space-x-3 mt-3 flex items-center">
-        {% if entry.author.profile_image %}
+        {% with author_thumb=entry.author.get_thumbnail_url %}
+        {% if author_thumb %}
           <span class="inline-block h-[30px] w-[30px] overflow-hidden rounded border border-gray-400 dark:border-gray-500">
-            <img src="{{ entry.author.image_thumbnail.url }}" alt="{{ entry.author.display_name }}" class="h-full w-full object-cover">
+            <img src="{{ author_thumb }}" alt="{{ entry.author.display_name }}" class="h-full w-full object-cover">
           </span>
         {% else %}
           <span class="inline-block h-[30px] w-[30px] bg-white rounded dark:text-white dark:bg-slate border border-gray-400 dark:border-gray-500">
             <i class="text-2xl fas fa-user ml-1" title="{{ entry.author.display_name }}"></i>
           </span>
         {% endif %}
+        {% endwith %}
         {% if entry.author.display_name %}
           <div class="inline-block p-0 m-0">
             {{ entry.author.display_name }}<br />

--- a/templates/news/list.html
+++ b/templates/news/list.html
@@ -191,9 +191,9 @@
                 {% endif %}
               </div>
               <div class="pt-2 mt-4 w-1/3 text-xs text-right">
-                {% if entry.author.image %}
+                {% if entry.author.profile_image %}
                   <span class="inline-block h-[36px] w-[36px] overflow-hidden rounded-lg  ">
-                    <img src="{{ entry.author.image.url }}" alt="{{ entry.author.display_name }}" class="h-full w-full object-cover">
+                    <img src="{{ entry.author.profile_image.url }}" alt="{{ entry.author.display_name }}" class="h-full w-full object-cover">
                   </span>
                 {% else %}
                   <span class="inline-block h-[36px] w-[36px] bg-white rounded-lg dark:text-white dark:bg-slate border">

--- a/templates/users/includes/user_profile_image.html
+++ b/templates/users/includes/user_profile_image.html
@@ -1,5 +1,5 @@
-{% if user.image %}
-  <img src="{{ user.image.url }}" alt="user" class="inline -mt-1 rounded-sm cursor-pointer w-[30px]" @click="userOpen = !userOpen" />
+{% if user.profile_image %}
+  <img src="{{ user.profile_image.url }}" alt="user" class="inline -mt-1 rounded-sm cursor-pointer w-[30px]" @click="userOpen = !userOpen" />
 {% else %}
   <i class="inline mr-2 cursor-pointer fas fa-user text-charcoal dark:text-white/60" @click="userOpen = !userOpen"></i>
 {% endif %}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -88,8 +88,8 @@
                     {% endfor %}
                   {% endif %}
 
-                  {% if user.image %}
-                    <img src="{{ user.image.url }}" alt="user" class="ml-4 inline -mt-1 rounded bg-white dark:bg-slate w-[30px] mr-2" />
+                  {% if user.profile_image %}
+                    <img src="{{ user.profile_image.url }}" alt="user" class="ml-4 inline -mt-1 rounded bg-white dark:bg-slate w-[30px] mr-2" />
                   {% endif %}
 
                   {% render_field field class='text-sm text-grey-500 !border-0 file:mr-5 file:py-2 file:px-6 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-white file:text-slate hover:file:cursor-pointer hover:file:bg-orange hover:file:text-white' %}

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,6 +1,7 @@
 import os
 
 from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import UploadedFile
 from django import forms
 
 from allauth.account.forms import ResetPasswordKeyForm
@@ -136,29 +137,34 @@ class UserProfilePhotoForm(forms.ModelForm):
         return cleaned_data
 
     def save(self, commit=True):
-        # Temporarily store the old image
         old_image = self.instance.profile_image
+        old_image_name = old_image.name if old_image else None
+        new_image_data = self.cleaned_data.get("profile_image")
+        has_new_upload = isinstance(new_image_data, UploadedFile)
+
         # Save the new image
         user = super().save(commit=False)
         if not old_image:
             # reset image on image delete checked
             user.image_uploaded = False
-        elif self.cleaned_data["profile_image"] != old_image:
-            # Delete the old image file if there's a new image being uploaded
-            old_image.delete(save=False)
+        elif has_new_upload and old_image_name:
+            # Delete the old file directly from storage (not via FieldFile.delete(),
+            # which closes file handles and interferes with the pending upload)
+            old_image.storage.delete(old_image_name)
 
-        if new_image := self.cleaned_data.get("profile_image"):
-            _, file_extension = os.path.splitext(new_image.name)
-
-            # Strip the leading period from the file extension.
+        if has_new_upload:
+            _, file_extension = os.path.splitext(new_image_data.name)
             file_extension = file_extension.lstrip(".")
-
-            new_image.name = f"{user.profile_image_filename_root}.{file_extension}"
-            user.profile_image = new_image
+            new_image_data.name = f"{user.profile_image_filename_root}.{file_extension}"
+            user.profile_image = new_image_data
             user.image_uploaded = True
 
         if commit:
             user.save()
+
+        # Invalidate the cached thumbnail so ImageKit regenerates it
+        if has_new_upload:
+            user.delete_cached_thumbnail()
 
         return user
 

--- a/users/models.py
+++ b/users/models.py
@@ -264,9 +264,24 @@ class User(BaseUser):
     # elapsed.
     delete_permanently_at = models.DateTimeField(null=True, editable=False)
 
+    def delete_cached_thumbnail(self):
+        """Delete the cached ImageKit thumbnail so it regenerates on next access."""
+        if not self.profile_image:
+            return
+        try:
+            from imagekit.cachefiles.backends import CacheFileState
+
+            thumb = self.image_thumbnail
+            if thumb.name:
+                thumb.storage.delete(thumb.name)
+            thumb.cachefile_backend.set_state(thumb, CacheFileState.DOES_NOT_EXIST)
+        except (OSError, AttributeError):
+            logger.debug("Failed to invalidate thumbnail cache", exc_info=True)
+
     def save_image_from_provider(self, avatar_url):
         from django.core.files.base import ContentFile
 
+        self.delete_cached_thumbnail()
         response = requests.get(avatar_url)
         filename = f"{self.profile_image_filename_root}.png"
         self.profile_image.save(filename, ContentFile(response.content), save=True)
@@ -286,13 +301,13 @@ class User(BaseUser):
     def get_thumbnail_url(self):
         # convenience method for templates
         if self.profile_image and self.image_thumbnail:
-            with suppress(AttributeError, MissingSource):
+            with suppress(AttributeError, MissingSource, FileNotFoundError, OSError):
                 return getattr(self.image_thumbnail, "url", None)
 
     def get_hq_image_url(self):
         # convenience method for templates
         if self.hq_image and self.hq_image_render:
-            with suppress(AttributeError, MissingSource):
+            with suppress(AttributeError, MissingSource, FileNotFoundError, OSError):
                 return getattr(self.hq_image_render, "url", None)
 
     @property
@@ -324,10 +339,10 @@ class User(BaseUser):
         self.last_name = "Doe"
         self.display_name = "John Doe"
         self.email = "deleted-{}@example.com".format(uuid.uuid4())
+        self.delete_cached_thumbnail()
         image = self.profile_image
         transaction.on_commit(lambda: image.delete())
         self.profile_image = None
-        self.image_thumbnail = None
         self.delete_permanently_at = None
         self.save()
 

--- a/users/tests/test_forms.py
+++ b/users/tests/test_forms.py
@@ -202,7 +202,7 @@ def test_user_profile_photo_form_save(user):
         content_type="image/jpeg",
     )
 
-    form = UserProfilePhotoForm({"profile_image": new_image}, instance=user)
+    form = UserProfilePhotoForm({}, {"profile_image": new_image}, instance=user)
     assert form.is_valid()
     updated_user = form.save()
     updated_user.refresh_from_db()


### PR DESCRIPTION
It appears that boto3's s3transfer library uses threads by default for uploads, which deadlock under gevent's monkey-patched threading. The gunicorn arbiter kills the hung worker after 30 seconds, surfacing as "upstream request timeout." This may have been an issue since the project started using S3 storage alongside gunicorn's gevent workers.

Reproduced locally by switching from `runserver` to gunicorn with gevent, confirmed the fix by setting `AWS_S3_USE_THREADS = False`.

- `AWS_S3_USE_THREADS = False` in settings, disabling boto3's threaded transfers that deadlock under gevent
- Use `isinstance(data, UploadedFile)` to detect new uploads instead of the unreliable `!=` comparison between `FieldFile` and `InMemoryUploadedFile`
- Delete old files via `storage.delete()` instead of `FieldFile.delete()`, which closes the pending upload's file handle
- Invalidate ImageKit's cached thumbnail after upload so it regenerates from the new source image
- Fix `user.image` -> `user.profile_image` in 5 templates (missed during field rename in e0fe6d61)
- Use `get_thumbnail_url` in news detail template instead of accessing `image_thumbnail.url` directly
- Broaden error suppression in `get_thumbnail_url` and `get_hq_image_url` for S3 storage errors
- Clean up `delete_account` to properly invalidate cached thumbnails

### Steps to reproduce the error locally

1. Add S3 env vars to your .env file:
```
AWS_ACCESS_KEY_ID=<key>
AWS_SECRET_ACCESS_KEY=<secret>
MEDIA_BUCKET_NAME=stage.boost.org.media
AWS_S3_ENDPOINT_URL=https://s3.us-east-2.amazonaws.com/
AWS_S3_REGION_NAME=us-east-2
```
3. Add a temporary S3 media block to the bottom of config/settings.py :
```python
if LOCAL_DEVELOPMENT and env("MEDIA_BUCKET_NAME", default=None):
    MEDIA_BUCKET_NAME = env("MEDIA_BUCKET_NAME")
    AWS_ACCESS_KEY_ID = env("AWS_ACCESS_KEY_ID")
    AWS_SECRET_ACCESS_KEY = env("AWS_SECRET_ACCESS_KEY")
    AWS_STORAGE_BUCKET_NAME = MEDIA_BUCKET_NAME
    AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "max-age=86400"}
    AWS_DEFAULT_ACL = None
    AWS_S3_ENDPOINT_URL = env("AWS_S3_ENDPOINT_URL")
    AWS_S3_REGION_NAME = env("AWS_S3_REGION_NAME")
    STORAGES = {
        "default": {"BACKEND": "core.storages.MediaStorage"},
        "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
    }
    MEDIA_URL = f"{AWS_S3_ENDPOINT_URL}/{MEDIA_BUCKET_NAME}/"
```
5. Switch to gunicorn in `docker/compose-start.sh`:
```bash
gunicorn -c gunicorn.conf.py --log-level INFO --reload -b 0.0.0.0:$WEB_PORT config.wsgi
# $PYTHON manage.py runserver 0.0.0.0:$WEB_PORT
```
6. If you're on this branch, comment out `AWS_S3_USE_THREADS = False` in `config/settings.py` (the fix)
7. Restart docker with `just down && just up`
8. Log in and upload a profile photo at `/users/me/`. It should hang for ~30 seconds then error (locally I saw "Internal Server Error", not "upstream request timeout").