### PR TITLE
Feedback PR for #2287: `Story 2269: Enable Conditional S3 Storage for development`

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,51 @@ To work with mailinglist data locally, the django application expects to be
 able to query a copy of the hyperkitty database from HYPERKITTY_DATABASE_NAME.
 Then, `just manage sync_mailinglist_stats` management command can be run.
 
+## Syncing Large Static Images
+
+Large static images and other assets are stored in S3 buckets rather than in the repository. Use the `scripts/sync-large-static-images.sh` script to manage these files.
+
+### Prerequisites
+
+- `awscli` must be installed.
+- Configure a set of credentials in your `~/.aws/credentials` file with the profile name `upload-images`:
+
+  ```ini
+  [sync-boost-images]
+  aws_access_key_id = <your_key_id>
+  aws_secret_access_key = <your_secret_key>
+  ```
+
+### Usage
+
+The script supports both uploading and downloading files.
+
+#### Uploading
+
+To upload files from your local directory (`static/static-large/`) to the default S3 bucket:
+
+```shell
+$ just up_sync_images
+```
+
+To upload to all S3 buckets:
+
+```shell
+$ just up_sync_images_all_buckets
+```
+
+*Note: The script will prompt you for the S3 destination path, defaulting to `/static/img/v3`.*
+
+#### Downloading
+
+To download missing or outdated static items from the staging bucket to your local directory:
+
+```shell
+$ just down_sync_images
+```
+
+---
+
 ## Deploying
 
 TDB

--- a/justfile
+++ b/justfile
@@ -185,7 +185,7 @@ alias shell := console
 
 # Static File Management
 @down_sync_images:
-    scripts/upload-images.sh --down-sync;
+    scripts/sync-large-static-images.sh --down-sync;
 
-@upload_images:
-    scripts/upload-images.sh --up-sync;
+@up_sync_images:
+    scripts/sync-large-static-images.sh --up-sync --all-buckets;

--- a/justfile
+++ b/justfile
@@ -184,18 +184,8 @@ alias shell := console
     docker compose run --rm web python manage.py {{ args }}
 
 # Static File Management
-@down_sync_images BUCKET='stage.boost.org.v2': ## syncs all items from specified bucket to static/static-large for local development. See scripts/upload-images.sh for required vars.
-    if ! command -v aws &>/dev/null; then \
-        echo "awscli is required. Please install it from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"; \
-        exit 1; \
-    fi
-
-    if echo {{VALID_BUCKETS}} | grep -q -w '{{BUCKET}}'; then \
-        aws s3 sync s3://{{BUCKET}}/static/  static/static-large/ --profile 'upload-images' --delete; \
-        echo "All missing or outdated static items synced."; \
-    else \
-        echo "Bucket name invalid."; \
-    fi
+@down_sync_images:
+    scripts/upload-images.sh --down-sync;
 
 @upload_images:
-    scripts/upload-images.sh;
+    scripts/upload-images.sh --up-sync;

--- a/justfile
+++ b/justfile
@@ -188,4 +188,7 @@ alias shell := console
     scripts/sync-large-static-images.sh --down-sync;
 
 @up_sync_images:
+    scripts/sync-large-static-images.sh --up-sync;
+
+@up_sync_images_all_buckets:
     scripts/sync-large-static-images.sh --up-sync --all-buckets;

--- a/scripts/sync-large-static-images.sh
+++ b/scripts/sync-large-static-images.sh
@@ -55,7 +55,7 @@ upload_images() {
   # ─────────────────────────────────────────────
   check_source_files() {
     # Returns 0 if files exist, 1 if empty
-    if [[ -n "$(find "$SOURCE_DIR" -maxdepth 1 -mindepth 1 -type f 2>/dev/null)" ]]; then
+    if [[ -n "$(find "$SOURCE_DIR" -maxdepth 1 -mindepth 1 2>/dev/null)" ]]; then
       return 0
     else
       return 1

--- a/scripts/sync-large-static-images.sh
+++ b/scripts/sync-large-static-images.sh
@@ -7,6 +7,7 @@ DEFAULT_BUCKET="stage.boost.org.v2"
 S3_BUCKETS="boost.org.v2 boost.org-cppal-dev-v2 ${DEFAULT_BUCKET}"
 AWS_PROFILE='sync-boost-images'
 DEFAULT_DEST="/static/"
+DEST_PATH=${DEFAULT_DEST}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(dirname "$SCRIPT_DIR")/static/static-large/"
@@ -53,39 +54,6 @@ upload_images() {
   echo ""
   echo "Source files found in $SOURCE_DIR:"
   ls -1 "$SOURCE_DIR"
-
-  # ─────────────────────────────────────────────
-  # PROMPT FOR DESTINATION PATH
-  # ─────────────────────────────────────────────
-  is_valid_dest() {
-    local dest="$1"
-    # Must be exactly /static/ or start with /static/ followed by more path
-    if [[ "$dest" == "/static/" ]] || [[ "$dest" == /static/* ]]; then
-      return 0
-    else
-      return 1
-    fi
-  }
-
-  DEST_PATH=""
-  while true; do
-    echo ""
-    printf "Enter the S3 destination path [default: %s]: " "$DEFAULT_DEST"
-    read -r user_dest
-
-    # Use default if user just pressed ENTER
-    if [[ -z "$user_dest" ]]; then
-      DEST_PATH="$DEFAULT_DEST"
-    else
-      DEST_PATH="$user_dest"
-    fi
-
-    if is_valid_dest "$DEST_PATH"; then
-      break
-    else
-      echo "The upload destination should be a subfolder of /static/ (e.g. /static/img/v3).  Please try again."
-    fi
-  done
 
   echo "Destination path: $DEST_PATH"
 

--- a/scripts/sync-large-static-images.sh
+++ b/scripts/sync-large-static-images.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(dirname "$SCRIPT_DIR")/static/static-large/"
 
 # ─────────────────────────────────────────────
-# 0. PARSE COMMAND-LINE OPTIONS
+# PARSE COMMAND-LINE OPTIONS
 # ─────────────────────────────────────────────
 usage() {
   cat <<EOF
@@ -46,33 +46,16 @@ validate_dependencies() {
 upload_images() {
   local all_buckets="${1:-false}"
   # ─────────────────────────────────────────────
-  # 1. CHECK FOR AWS CLI
+  # CHECK FOR AWS CLI
   # ─────────────────────────────────────────────
   validate_dependencies
-
-  # ─────────────────────────────────────────────
-  # 3. CHECK SOURCE FOLDER
-  # ─────────────────────────────────────────────
-  check_source_files() {
-    # Returns 0 if files exist, 1 if empty
-    if [[ -n "$(find "$SOURCE_DIR" -maxdepth 1 -mindepth 1 2>/dev/null)" ]]; then
-      return 0
-    else
-      return 1
-    fi
-  }
-
-  if ! check_source_files; then
-    echo "Error: The source folder $SOURCE_DIR is empty. Please place files there before uploading."
-    exit 1
-  fi
 
   echo ""
   echo "Source files found in $SOURCE_DIR:"
   ls -1 "$SOURCE_DIR"
 
   # ─────────────────────────────────────────────
-  # 4. PROMPT FOR DESTINATION PATH
+  # PROMPT FOR DESTINATION PATH
   # ─────────────────────────────────────────────
   is_valid_dest() {
     local dest="$1"
@@ -107,7 +90,7 @@ upload_images() {
   echo "Destination path: $DEST_PATH"
 
   # ─────────────────────────────────────────────
-  # 5. UPLOAD TO BUCKETS
+  # UPLOAD TO BUCKETS
   # ─────────────────────────────────────────────
   UPLOAD_FAILED=0
 
@@ -142,7 +125,7 @@ upload_images() {
   done
 
   # ─────────────────────────────────────────────
-  # 6. POST-UPLOAD SUMMARY
+  # POST-UPLOAD SUMMARY
   # ─────────────────────────────────────────────
   echo ""
   if [[ $UPLOAD_FAILED -ne 0 ]]; then

--- a/scripts/sync-large-static-images.sh
+++ b/scripts/sync-large-static-images.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
-# upload-images.sh — Upload local images to S3 buckets
+# sync-large-static-images.sh — Upload local images to S3 buckets
 
 set -euo pipefail
 
-S3_BUCKETS="boost.org.v2 stage.boost.org.v2 boost.org-cppal-dev-v2"
+DEFAULT_BUCKET="stage.boost.org.v2"
+S3_BUCKETS="boost.org.v2 boost.org-cppal-dev-v2 ${DEFAULT_BUCKET}"
+AWS_PROFILE='upload-images'
+DEFAULT_DEST="/static/img/v3"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(dirname "$SCRIPT_DIR")/static/static-large/"
 
-DEFAULT_DEST="/static/img/v3"
 # ─────────────────────────────────────────────
 # 0. PARSE COMMAND-LINE OPTIONS
 # ─────────────────────────────────────────────
@@ -19,16 +21,16 @@ Usage: $0 [OPTION]
 Upload or download image files and other static assets to/from the website S3 buckets.
 
 Options:
-  --up-sync      Upload files from /tmp/upload-images to S3 buckets.
-  --down-sync    Download files from S3 stage bucket to local static directory.
-  --help         Display this help and exit.
+  --up-sync        Upload files from the default source dir (${SOURCE_DIR}) to S3 buckets.
+  --down-sync      Download files from S3 stage bucket to local static directory (${SOURCE_DIR}).
+  --all-buckets    When used with --up-sync, upload to all buckets instead of the default bucket.
+  --help           Display this help and exit.
 
 Configuration:
-  The source folder for upload is /tmp/upload-images.
   The default destination for upload is /static/img/v3.
   In your .aws/credentials file, add a set of credentials:
 
-  [upload-images]
+  [${AWS_PROFILE}]
   aws_access_key_id = <your_key_id>
   aws_secret_access_key = <your_secret_key>
 EOF
@@ -42,21 +44,14 @@ validate_dependencies() {
 }
 
 upload_images() {
+  local all_buckets="${1:-false}"
   # ─────────────────────────────────────────────
   # 1. CHECK FOR AWS CLI
   # ─────────────────────────────────────────────
   validate_dependencies
 
   # ─────────────────────────────────────────────
-  # 2. ENSURE SOURCE FOLDER EXISTS
-  # ─────────────────────────────────────────────
-  if [[ ! -d "$SOURCE_DIR" ]]; then
-    echo "Source folder $SOURCE_DIR does not exist. Creating it..."
-    mkdir -p "$SOURCE_DIR"
-  fi
-
-  # ─────────────────────────────────────────────
-  # 3. WAIT FOR FILES IN SOURCE FOLDER
+  # 3. CHECK SOURCE FOLDER
   # ─────────────────────────────────────────────
   check_source_files() {
     # Returns 0 if files exist, 1 if empty
@@ -67,24 +62,10 @@ upload_images() {
     fi
   }
 
-  while ! check_source_files; do
-    echo ""
-    echo "The source folder $SOURCE_DIR is empty.  Please place files there."
-    printf "Press y to continue, n to cancel: "
-    read -r choice
-    case "$choice" in
-      [yY])
-        # Re-check happens at the top of the while loop
-        ;;
-      [nN])
-        echo "Cancelled."
-        exit 0
-        ;;
-      *)
-        echo "Please enter y or n."
-        ;;
-    esac
-  done
+  if ! check_source_files; then
+    echo "Error: The source folder $SOURCE_DIR is empty. Please place files there before uploading."
+    exit 1
+  fi
 
   echo ""
   echo "Source files found in $SOURCE_DIR:"
@@ -126,11 +107,16 @@ upload_images() {
   echo "Destination path: $DEST_PATH"
 
   # ─────────────────────────────────────────────
-  # 5. UPLOAD TO EACH BUCKET
+  # 5. UPLOAD TO BUCKETS
   # ─────────────────────────────────────────────
   UPLOAD_FAILED=0
 
-  for bucket in $S3_BUCKETS; do
+  BUCKETS_TO_UPLOAD="$DEFAULT_BUCKET"
+  if [[ "$all_buckets" == "true" ]]; then
+    BUCKETS_TO_UPLOAD="$S3_BUCKETS"
+  fi
+
+  for bucket in $BUCKETS_TO_UPLOAD; do
     S3_DEST="s3://${bucket}${DEST_PATH}"
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -139,7 +125,7 @@ upload_images() {
 
     # Capture exit code; show stdout+stderr live via tee to /dev/null trick
     set +e
-    aws s3 sync --profile upload-images "$SOURCE_DIR" "$S3_DEST" 2>&1
+    aws s3 sync --profile "${AWS_PROFILE}" "$SOURCE_DIR" "$S3_DEST" 2>&1
     EXIT_CODE=$?
     set -e
 
@@ -172,29 +158,31 @@ upload_images() {
 }
 
 download_images() {
-  BUCKET='stage.boost.org.v2'
-
   validate_dependencies
 
-  if echo "${S3_BUCKETS}" | grep -q -w "${BUCKET}"; then
-      aws s3 sync "s3://${BUCKET}/static/"  "${SOURCE_DIR}" --profile 'upload-images';
+  if echo "${S3_BUCKETS}" | grep -q -w "${DEFAULT_BUCKET}"; then
+      aws s3 sync "s3://${DEFAULT_BUCKET}/static/"  "${SOURCE_DIR}" --profile "${AWS_PROFILE}";
       echo "All missing or outdated static items synced.";
   else
-      echo "Bucket name invalid.";
+      echo "Bucket name invalid: ${DEFAULT_BUCKET}";
       exit 1;
   fi
 }
 
 
 
+ALL_BUCKETS=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --help)
       usage
       exit 0
       ;;
+    --all-buckets)
+      ALL_BUCKETS=true
+      ;;
     --up-sync)
-      upload_images
+      upload_images "$ALL_BUCKETS"
       exit $?
       ;;
     --down-sync)

--- a/scripts/sync-large-static-images.sh
+++ b/scripts/sync-large-static-images.sh
@@ -28,7 +28,7 @@ Options:
   --help           Display this help and exit.
 
 Configuration:
-  The default destination for upload is /static/img/v3.
+  The default destination for upload is ${DEFAULT_DEST}.
   In your .aws/credentials file, add a set of credentials:
 
   [${AWS_PROFILE}]

--- a/scripts/sync-large-static-images.sh
+++ b/scripts/sync-large-static-images.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 DEFAULT_BUCKET="stage.boost.org.v2"
 S3_BUCKETS="boost.org.v2 boost.org-cppal-dev-v2 ${DEFAULT_BUCKET}"
 AWS_PROFILE='sync-boost-images'
-DEFAULT_DEST="/static/img/v3"
+DEFAULT_DEST="/static/"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(dirname "$SCRIPT_DIR")/static/static-large/"

--- a/scripts/sync-large-static-images.sh
+++ b/scripts/sync-large-static-images.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 DEFAULT_BUCKET="stage.boost.org.v2"
 S3_BUCKETS="boost.org.v2 boost.org-cppal-dev-v2 ${DEFAULT_BUCKET}"
-AWS_PROFILE='upload-images'
+AWS_PROFILE='sync-boost-images'
 DEFAULT_DEST="/static/img/v3"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/upload-images.sh
+++ b/scripts/upload-images.sh
@@ -3,19 +3,208 @@
 
 set -euo pipefail
 
+S3_BUCKETS="boost.org.v2 stage.boost.org.v2 boost.org-cppal-dev-v2"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$(dirname "$SCRIPT_DIR")/static/static-large/"
+
+DEFAULT_DEST="/static/img/v3"
 # ─────────────────────────────────────────────
 # 0. PARSE COMMAND-LINE OPTIONS
 # ─────────────────────────────────────────────
 usage() {
-  cat <<'EOF'
-This script is used to upload image files and other static assets to the website S3 buckets.
-The source folder is /tmp/upload-images and the destination folder may be selected during the
-process (default is /static/img/v3). In your .aws/credentials file, add a set of credentials
-[upload-images]
-aws_access_key_id =
-aws_secret_access_key =
+  cat <<EOF
+Usage: $0 [OPTION]
+
+Upload or download image files and other static assets to/from the website S3 buckets.
+
+Options:
+  --up-sync      Upload files from /tmp/upload-images to S3 buckets.
+  --down-sync    Download files from S3 stage bucket to local static directory.
+  --help         Display this help and exit.
+
+Configuration:
+  The source folder for upload is /tmp/upload-images.
+  The default destination for upload is /static/img/v3.
+  In your .aws/credentials file, add a set of credentials:
+
+  [upload-images]
+  aws_access_key_id = <your_key_id>
+  aws_secret_access_key = <your_secret_key>
 EOF
 }
+
+validate_dependencies() {
+  if ! command -v aws &>/dev/null; then
+    echo "awscli is required. Please install it from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+    exit 1
+  fi
+}
+
+upload_images() {
+  # ─────────────────────────────────────────────
+  # 1. CHECK FOR AWS CLI
+  # ─────────────────────────────────────────────
+  validate_dependencies
+
+  # ─────────────────────────────────────────────
+  # 2. ENSURE SOURCE FOLDER EXISTS
+  # ─────────────────────────────────────────────
+  if [[ ! -d "$SOURCE_DIR" ]]; then
+    echo "Source folder $SOURCE_DIR does not exist. Creating it..."
+    mkdir -p "$SOURCE_DIR"
+  fi
+
+  # ─────────────────────────────────────────────
+  # 3. WAIT FOR FILES IN SOURCE FOLDER
+  # ─────────────────────────────────────────────
+  check_source_files() {
+    # Returns 0 if files exist, 1 if empty
+    if [[ -n "$(find "$SOURCE_DIR" -maxdepth 1 -mindepth 1 -type f 2>/dev/null)" ]]; then
+      return 0
+    else
+      return 1
+    fi
+  }
+
+  while ! check_source_files; do
+    echo ""
+    echo "The source folder $SOURCE_DIR is empty.  Please place files there."
+    printf "Press y to continue, n to cancel: "
+    read -r choice
+    case "$choice" in
+      [yY])
+        # Re-check happens at the top of the while loop
+        ;;
+      [nN])
+        echo "Cancelled."
+        exit 0
+        ;;
+      *)
+        echo "Please enter y or n."
+        ;;
+    esac
+  done
+
+  echo ""
+  echo "Source files found in $SOURCE_DIR:"
+  ls -1 "$SOURCE_DIR"
+
+  # ─────────────────────────────────────────────
+  # 4. PROMPT FOR DESTINATION PATH
+  # ─────────────────────────────────────────────
+  is_valid_dest() {
+    local dest="$1"
+    # Must be exactly /static/ or start with /static/ followed by more path
+    if [[ "$dest" == "/static/" ]] || [[ "$dest" == /static/* ]]; then
+      return 0
+    else
+      return 1
+    fi
+  }
+
+  DEST_PATH=""
+  while true; do
+    echo ""
+    printf "Enter the S3 destination path [default: %s]: " "$DEFAULT_DEST"
+    read -r user_dest
+
+    # Use default if user just pressed ENTER
+    if [[ -z "$user_dest" ]]; then
+      DEST_PATH="$DEFAULT_DEST"
+    else
+      DEST_PATH="$user_dest"
+    fi
+
+    if is_valid_dest "$DEST_PATH"; then
+      break
+    else
+      echo "The upload destination should be a subfolder of /static/ (e.g. /static/img/v3).  Please try again."
+    fi
+  done
+
+  echo "Destination path: $DEST_PATH"
+
+  # ─────────────────────────────────────────────
+  # 5. UPLOAD TO EACH BUCKET
+  # ─────────────────────────────────────────────
+  UPLOAD_FAILED=0
+
+  for bucket in $S3_BUCKETS; do
+    S3_DEST="s3://${bucket}${DEST_PATH}"
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "Uploading to: $S3_DEST"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    # Capture exit code; show stdout+stderr live via tee to /dev/null trick
+    set +e
+    aws s3 sync --profile upload-images "$SOURCE_DIR" "$S3_DEST" 2>&1
+    EXIT_CODE=$?
+    set -e
+
+    if [[ $EXIT_CODE -ne 0 ]]; then
+      echo ""
+      echo "The upload failed for bucket: $bucket (exit code $EXIT_CODE)"
+      echo "  Source:      $SOURCE_DIR"
+      echo "  Destination: $S3_DEST"
+      UPLOAD_FAILED=1
+    else
+      echo ""
+      echo "✓ Upload succeeded for bucket: $bucket"
+    fi
+  done
+
+  # ─────────────────────────────────────────────
+  # 6. POST-UPLOAD SUMMARY
+  # ─────────────────────────────────────────────
+  echo ""
+  if [[ $UPLOAD_FAILED -ne 0 ]]; then
+    echo "One or more uploads failed. Please review the output above for details."
+    echo "  Source folder:   $SOURCE_DIR"
+    echo "  Destination:     $DEST_PATH"
+    echo "  Buckets:         $S3_BUCKETS"
+    exit 1
+  fi
+
+  # ─────────────────────────────────────────────
+  # 7. OFFER TO DELETE LOCAL TMP FILES
+  # ─────────────────────────────────────────────
+  echo "The files uploaded successfully."
+  echo ""
+  printf "We recommend deleting the local files in %s to clear them out for next time.  Delete local tmp files? [Y/n]: " "$SOURCE_DIR"
+  read -r del_choice
+
+  case "${del_choice:-Y}" in
+    [nN])
+      echo "Skipping deletion. Local files remain in $SOURCE_DIR."
+      ;;
+    *)
+      echo "Deleting files in $SOURCE_DIR..."
+      find "$SOURCE_DIR" -maxdepth 1 -mindepth 1 -type f -delete
+      echo "Local files deleted."
+      ;;
+  esac
+
+  echo ""
+  echo "Done."
+}
+
+download_images() {
+  BUCKET='stage.boost.org.v2'
+
+  validate_dependencies
+
+  if echo "${S3_BUCKETS}" | grep -q -w "${BUCKET}"; then
+      aws s3 sync "s3://${BUCKET}/static/"  "${SOURCE_DIR}" --profile 'upload-images';
+      echo "All missing or outdated static items synced.";
+  else
+      echo "Bucket name invalid.";
+      exit 1;
+  fi
+}
+
+
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -23,169 +212,19 @@ while [[ $# -gt 0 ]]; do
       usage
       exit 0
       ;;
+    --up-sync)
+      upload_images
+      exit $?
+      ;;
+    --down-sync)
+      download_images
+      exit $?
+      ;;
     *)
       echo "Unknown option: $1"
-      echo "Usage: $0 [--help]"
+      usage
       exit 1
       ;;
   esac
   shift
 done
-
-# ─────────────────────────────────────────────
-# 1. CHECK FOR AWS CLI
-# ─────────────────────────────────────────────
-if ! command -v aws &>/dev/null; then
-  echo "awscli is required. Please install it from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
-  exit 1
-fi
-
-# ─────────────────────────────────────────────
-# 2. CONFIGURATION
-# ─────────────────────────────────────────────
-S3_BUCKETS="boost.org.v2 stage.boost.org.v2 boost.org-cppal-dev-v2"
-SOURCE_DIR="/tmp/upload-images"
-DEFAULT_DEST="/static/img/v3"
-
-# ─────────────────────────────────────────────
-# 3. ENSURE SOURCE FOLDER EXISTS
-# ─────────────────────────────────────────────
-if [[ ! -d "$SOURCE_DIR" ]]; then
-  echo "Source folder $SOURCE_DIR does not exist. Creating it..."
-  mkdir -p "$SOURCE_DIR"
-fi
-
-# ─────────────────────────────────────────────
-# 4. WAIT FOR FILES IN SOURCE FOLDER
-# ─────────────────────────────────────────────
-check_source_files() {
-  # Returns 0 if files exist, 1 if empty
-  if [[ -n "$(find "$SOURCE_DIR" -maxdepth 1 -mindepth 1 -type f 2>/dev/null)" ]]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-while ! check_source_files; do
-  echo ""
-  echo "The source folder $SOURCE_DIR is empty.  Please place files there."
-  printf "Press y to continue, n to cancel: "
-  read -r choice
-  case "$choice" in
-    [yY])
-      # Re-check happens at the top of the while loop
-      ;;
-    [nN])
-      echo "Cancelled."
-      exit 0
-      ;;
-    *)
-      echo "Please enter y or n."
-      ;;
-  esac
-done
-
-echo ""
-echo "Source files found in $SOURCE_DIR:"
-ls -1 "$SOURCE_DIR"
-
-# ─────────────────────────────────────────────
-# 5. PROMPT FOR DESTINATION PATH
-# ─────────────────────────────────────────────
-is_valid_dest() {
-  local dest="$1"
-  # Must be exactly /static/ or start with /static/ followed by more path
-  if [[ "$dest" == "/static/" ]] || [[ "$dest" == /static/* ]]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-DEST_PATH=""
-while true; do
-  echo ""
-  printf "Enter the S3 destination path [default: %s]: " "$DEFAULT_DEST"
-  read -r user_dest
-
-  # Use default if user just pressed ENTER
-  if [[ -z "$user_dest" ]]; then
-    DEST_PATH="$DEFAULT_DEST"
-  else
-    DEST_PATH="$user_dest"
-  fi
-
-  if is_valid_dest "$DEST_PATH"; then
-    break
-  else
-    echo "The upload destination should be a subfolder of /static/ (e.g. /static/img/v3).  Please try again."
-  fi
-done
-
-echo "Destination path: $DEST_PATH"
-
-# ─────────────────────────────────────────────
-# 6. UPLOAD TO EACH BUCKET
-# ─────────────────────────────────────────────
-UPLOAD_FAILED=0
-
-for bucket in $S3_BUCKETS; do
-  S3_DEST="s3://${bucket}${DEST_PATH}"
-  echo ""
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "Uploading to: $S3_DEST"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-
-  # Capture exit code; show stdout+stderr live via tee to /dev/null trick
-  set +e
-  aws s3 cp --recursive --profile upload-images "$SOURCE_DIR" "$S3_DEST" 2>&1
-  EXIT_CODE=$?
-  set -e
-
-  if [[ $EXIT_CODE -ne 0 ]]; then
-    echo ""
-    echo "The upload failed for bucket: $bucket (exit code $EXIT_CODE)"
-    echo "  Source:      $SOURCE_DIR"
-    echo "  Destination: $S3_DEST"
-    UPLOAD_FAILED=1
-  else
-    echo ""
-    echo "✓ Upload succeeded for bucket: $bucket"
-  fi
-done
-
-# ─────────────────────────────────────────────
-# 7. POST-UPLOAD SUMMARY
-# ─────────────────────────────────────────────
-echo ""
-if [[ $UPLOAD_FAILED -ne 0 ]]; then
-  echo "One or more uploads failed. Please review the output above for details."
-  echo "  Source folder:   $SOURCE_DIR"
-  echo "  Destination:     $DEST_PATH"
-  echo "  Buckets:         $S3_BUCKETS"
-  exit 1
-fi
-
-# ─────────────────────────────────────────────
-# 8. OFFER TO DELETE LOCAL TMP FILES
-# ─────────────────────────────────────────────
-echo "The files uploaded successfully."
-echo ""
-printf "We recommend deleting the local files in %s to clear them out for next time.  Delete local tmp files? [Y/n]: " "$SOURCE_DIR"
-read -r del_choice
-
-case "${del_choice:-Y}" in
-  [nN])
-    echo "Skipping deletion. Local files remain in $SOURCE_DIR."
-    ;;
-  *)
-    echo "Deleting files in $SOURCE_DIR..."
-    find "$SOURCE_DIR" -maxdepth 1 -mindepth 1 -type f -delete
-    echo "Local files deleted."
-    ;;
-esac
-
-echo ""
-echo "Done."
-exit 0

--- a/scripts/upload-images.sh
+++ b/scripts/upload-images.sh
@@ -167,25 +167,6 @@ upload_images() {
     exit 1
   fi
 
-  # ─────────────────────────────────────────────
-  # 7. OFFER TO DELETE LOCAL TMP FILES
-  # ─────────────────────────────────────────────
-  echo "The files uploaded successfully."
-  echo ""
-  printf "We recommend deleting the local files in %s to clear them out for next time.  Delete local tmp files? [Y/n]: " "$SOURCE_DIR"
-  read -r del_choice
-
-  case "${del_choice:-Y}" in
-    [nN])
-      echo "Skipping deletion. Local files remain in $SOURCE_DIR."
-      ;;
-    *)
-      echo "Deleting files in $SOURCE_DIR..."
-      find "$SOURCE_DIR" -maxdepth 1 -mindepth 1 -type f -delete
-      echo "Local files deleted."
-      ;;
-  esac
-
   echo ""
   echo "Done."
 }


### PR DESCRIPTION
⚠️ Base branch is `jc/conditional-image-storage`

# Feedback for PR #2287 
## Issue: 2269

## Changes

- Renamed the original `upload-images.sh` script to `sync-large-static-images.sh`;
- Encapsulated the behavior of the uploads images into a function in the sync script;
- Changed the behavior of the upload function to "up sync", using the same strategy to down sync, i.e., it won't copy all files from SOURCE_DIR to aws every time, it'll just sync the `static-large/` folder upwards too, which is totally safe as it won't delete anything in the remote buckets;
  - Therefore I removed the section that offers to delete the source dir after upload;
- Added the "down-sync" capabilities to the script;
- Defaults to uploading to the `staging` bucket rather than all of them;
- Changed/added the commands in `justfile`:
  - `down_sync_images`; → now calls the new script
  - `up_sync_images`; → defaults to uploading to staging bucket only;
  - `up_sync_images_all_buckets`: → uploads to all buckets
- Changed the AWS profile from `upload-images` to `sync-boost-images` for better comprehension (we may have credentials for multiple projects in our local machines);
- Added documentation in the readme file;