### PR TITLE
fix: version tag pill shape & dark border

### DIFF
--- a/static/css/v3/category-tags.css
+++ b/static/css/v3/category-tags.css
@@ -46,7 +46,6 @@
 .category-tag--green:hover,
 .category-tag--green.category-tag--hover-state {
   background: var(--color-surface-strong-accent-green-hover);
-  color: var(--color-text-secondary);
 }
 
 .category-tag--yellow {
@@ -56,7 +55,6 @@
 .category-tag--yellow:hover,
 .category-tag--yellow.category-tag--hover-state {
   background: var(--color-surface-strong-accent-yellow-hover);
-  color: var(--color-text-secondary);
 }
 
 .category-tag--teal {
@@ -66,7 +64,6 @@
 .category-tag--teal:hover,
 .category-tag--teal.category-tag--hover-state {
   background: var(--color-surface-strong-accent-teal-hover);
-  color: var(--color-text-secondary);
 }
 
 .version-tag {
@@ -88,6 +85,8 @@
 
 .version-tag--hover {
   background: var(--color-tag-fill-hover);
+  color: var(--color-text-primary);
+  border-color: var(--color-stroke-strong);
 }
 
 .category-cards {
@@ -119,7 +118,7 @@ html.dark .category-tag--green,
 html.dark .category-tag--yellow,
 html.dark .category-tag--teal {
   background: var(--color-tag-colored-bg);
-  border-color: var(--color-tag-colored-border);
+  border-color: transparent;
   color: var(--color-tag-colored-text);
 }
 

--- a/static/css/v3/category-tags.css
+++ b/static/css/v3/category-tags.css
@@ -4,7 +4,7 @@
   justify-content: center;
   font-family: var(--font-sans);
   font-size: var(--font-size-xs);
-  line-height: var(--line-height-default);
+  line-height: var(--line-height-tight);
   font-weight: var(--font-weight-regular);
   border-radius: var(--border-radius-s);
   text-decoration: none;
@@ -130,6 +130,6 @@ html.dark .category-tag--green.category-tag--hover-state,
 html.dark .category-tag--yellow.category-tag--hover-state,
 html.dark .category-tag--teal.category-tag--hover-state {
   background: var(--color-tag-colored-bg-hover);
-  border-color: var(--color-tag-colored-border);
+  border-color: transparent;
   color: var(--color-tag-colored-text);
 }

--- a/static/css/v3/category-tags.css
+++ b/static/css/v3/category-tags.css
@@ -68,9 +68,10 @@
 .version-tag {
   display: inline-flex;
   align-items: center;
-  padding: var(--space-default) var(--space-default);
+  padding: var(--space-default);
   font-family: var(--font-sans);
   font-size: var(--font-size-xs);
+  line-height: var(--line-height-tight);
   color: var(--color-text-secondary);
   border: 1px solid var(--color-tag-stroke);
   border-radius: var(--border-radius-xl);

--- a/static/css/v3/category-tags.css
+++ b/static/css/v3/category-tags.css
@@ -11,7 +11,7 @@
   cursor: pointer;
   transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
   color: var(--color-text-secondary);
-  border: 1px solid var(--color-tag-stroke);
+  border: 1px solid transparent;
 }
 
 .category-tag--default {
@@ -24,6 +24,7 @@
 
 .category-tag--neutral {
   background: var(--color-tag-fill);
+  border-color: var(--color-tag-stroke);
 }
 
 .category-tag--neutral:hover,
@@ -32,9 +33,14 @@
   color: var(--color-text-secondary);
 }
 
+.category-tag--green,
+.category-tag--yellow,
+.category-tag--teal {
+  color: var(--color-text-primary);
+}
+
 .category-tag--green {
   background: var(--color-surface-strong-accent-green-default);
-  color: var(--color-text-primary);
 }
 
 .category-tag--green:hover,
@@ -45,7 +51,6 @@
 
 .category-tag--yellow {
   background: var(--color-surface-strong-accent-yellow-default);
-  color: var(--color-text-primary);
 }
 
 .category-tag--yellow:hover,
@@ -56,7 +61,6 @@
 
 .category-tag--teal {
   background: var(--color-surface-strong-accent-teal-default);
-  color: var(--color-text-primary);
 }
 
 .category-tag--teal:hover,

--- a/static/css/v3/themes.css
+++ b/static/css/v3/themes.css
@@ -79,7 +79,7 @@ html.dark {
   --color-tag-stroke: #ffffff1a;
   --color-tag-neutral-bg: var(--color-primary-grey-900);
   --color-tag-neutral-bg-hover: var(--color-primary-grey-800);
-  --color-tag-neutral-border: var(--color-primary-grey-900);
+  --color-tag-neutral-border: var(--color-tag-stroke);
   --color-tag-colored-bg: var(--color-primary-grey-800);
   --color-tag-colored-bg-hover: var(--color-primary-grey-850);
   --color-tag-colored-border: var(--color-primary-grey-800);

--- a/static/css/v3/themes.css
+++ b/static/css/v3/themes.css
@@ -81,7 +81,7 @@ html.dark {
   --color-tag-neutral-bg-hover: var(--color-primary-grey-800);
   --color-tag-neutral-border: var(--color-tag-stroke);
   --color-tag-colored-bg: var(--color-primary-grey-800);
-  --color-tag-colored-bg-hover: var(--color-primary-grey-850);
+  --color-tag-colored-bg-hover: var(--color-primary-grey-700);
   --color-tag-colored-border: var(--color-primary-grey-800);
   --color-tag-colored-text: var(--color-text-primary);
 


### PR DESCRIPTION
# Issue: #2292

## Summary & Context

Fixes version tag pill shape and dark mode border visibility for category tags to match Figma spec.

- **Figma link**: https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=455-4246&m=dev
- **Link to components/page:** http://localhost:8000/v3/demo/components/#category-tags

## Changes

- Add line-height token to version-tag for rounder pill shape
- Fix dark mode neutral tag border visibility

## ‼️ Risks & Considerations ‼️

- Low risk — only affects `.version-tag` base styles and dark mode `--color-tag-neutral-border` variable
- No changes to markup or component API

## Screenshots
<img width="2518" height="1224" alt="localhost_8000_v3_demo_components_ (20)" src="https://github.com/user-attachments/assets/e938d249-abd9-476b-bafb-331a83a5f8da" />
<img width="2518" height="1224" alt="localhost_8000_v3_demo_components_ (19)" src="https://github.com/user-attachments/assets/046106d0-8154-434c-9346-b7eb124ea37a" />


## Self-review Checklist

- [x] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings
