### PR TITLE
Story 2305: Implement Version Dropdown On V3 Nav Bar

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -179,6 +179,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "core.context_processors.current_version",
+                "core.context_processors.selected_version",
                 "core.context_processors.active_nav_item",
                 "core.context_processors.header_context",
                 "core.context_processors.debug",

--- a/config/urls.py
+++ b/config/urls.py
@@ -101,6 +101,7 @@ from versions.views import (
     VersionDetail,
     ReportPreviewView,
     ReportPreviewGenerateView,
+    set_version,
 )
 
 djdt_urls = []
@@ -218,6 +219,7 @@ urlpatterns = (
             name="boost-development",
         ),
         # Boost versions views
+        path("set-version/", set_version, name="set-version"),
         path("releases/", VersionDetail.as_view(), name="releases-most-recent"),
         path(
             "releases/boost-in-progress/",

--- a/config/urls.py
+++ b/config/urls.py
@@ -115,7 +115,7 @@ except ModuleNotFoundError:
         "DEBUG_TOOLBAR enabled but Django Debug Toolbar not installed. Run `just build`"
     )
 
-register_converter(BoostVersionSlugConverter, "boostversionslug")
+register_converter(BoostVersionSlugConverter, BoostVersionSlugConverter.URL_TYPE_NAME)
 
 router = routers.SimpleRouter()
 

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -20,6 +20,19 @@ def _get_header_version_data(request):
     return data
 
 
+def _is_non_latest_version(url_version_slug, cookie_slug):
+    """Whether the user's active version is a specific, non-latest one.
+
+    Drives the dropdown button label: non-latest → show version number,
+    otherwise → show "Latest". URL wins over cookie.
+    """
+    if url_version_slug:
+        return url_version_slug != LATEST_RELEASE_URL_PATH_STR
+    if cookie_slug:
+        return cookie_slug != LATEST_RELEASE_URL_PATH_STR
+    return False
+
+
 def current_version(request):
     """Custom context processor that adds the current release to the context"""
     return {"current_version": _get_header_version_data(request).most_recent}
@@ -42,7 +55,7 @@ def selected_version(request):
     GET /releases/1.88.0/  (no cookie)
         selected_version               -> Version(slug="boost-1-88-0")
         selected_version_is_url_driven -> True       (URL mode: render <a>s)
-        selected_version_is_explicit   -> True       (button reads "1.88.0")
+        selected_version_is_non_latest -> True       (button reads "1.88.0")
         selected_version_label         -> "1.88.0"
         version_dropdown_options[i]    -> Version with `.href` attached,
                                           e.g. "/releases/1.89.0/"
@@ -51,7 +64,7 @@ def selected_version(request):
     GET /  (cookie boost_version="boost-1-87-0")
         selected_version               -> Version(slug="boost-1-87-0")
         selected_version_is_url_driven -> False      (cookie mode: render <form>s)
-        selected_version_is_explicit   -> True       (button reads "1.87.0")
+        selected_version_is_non_latest -> True       (button reads "1.87.0")
         selected_version_label         -> "1.87.0"
         version_dropdown_options[i]    -> Version (no `.href` needed)
         latest_href                    -> ""
@@ -59,7 +72,7 @@ def selected_version(request):
     GET /  (no cookie)
         selected_version               -> Version.objects.most_recent()
         selected_version_is_url_driven -> False
-        selected_version_is_explicit   -> False      (button reads "Latest")
+        selected_version_is_non_latest -> False      (button reads "Latest")
         selected_version_label         -> "Latest"
 
     GET /library/1.88.0/foo/  (target version "boost-1-70-0" predates "foo")
@@ -88,17 +101,8 @@ def selected_version(request):
     if version is None:
         version = header_data.most_recent
 
-    is_explicit_non_latest_url = bool(
-        url_version_slug and url_version_slug != LATEST_RELEASE_URL_PATH_STR
-    )
-    is_explicit_cookie = bool(
-        not url_version_slug
-        and cookie_slug
-        and cookie_slug != LATEST_RELEASE_URL_PATH_STR
-    )
-    is_explicit = is_explicit_non_latest_url or is_explicit_cookie
-
-    label = version.display_name if (is_explicit and version) else "Latest"
+    is_non_latest = _is_non_latest_version(url_version_slug, cookie_slug)
+    label = version.display_name if (is_non_latest and version) else "Latest"
 
     latest_href = ""
     if is_url_driven and resolver_match and resolver_match.view_name:
@@ -111,7 +115,7 @@ def selected_version(request):
     return {
         "selected_version": version,
         "selected_version_is_url_driven": is_url_driven,
-        "selected_version_is_explicit": is_explicit,
+        "selected_version_is_non_latest": is_non_latest,
         "selected_version_label": label,
         "version_dropdown_options": options,
         "latest_href": latest_href,

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -6,7 +6,13 @@ from django.urls import NoReverseMatch, reverse
 
 from libraries.constants import LATEST_RELEASE_URL_PATH_STR
 from libraries.utils import get_version_from_cookie
+from versions.converters import BoostVersionSlugConverter
 from versions.models import Version
+
+
+_BOOST_VERSION_SLUG_ROUTE_TOKEN = (
+    f"<{BoostVersionSlugConverter.URL_TYPE_NAME}:version_slug>"
+)
 
 
 def _get_header_version_data(request):
@@ -83,7 +89,9 @@ def selected_version(request):
     """
     url_version_slug = None
     resolver_match = getattr(request, "resolver_match", None)
-    if resolver_match:
+    if resolver_match and _BOOST_VERSION_SLUG_ROUTE_TOKEN in (
+        resolver_match.route or ""
+    ):
         url_version_slug = resolver_match.kwargs.get("version_slug")
 
     is_url_driven = bool(url_version_slug)

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -9,9 +9,20 @@ from libraries.utils import get_version_from_cookie
 from versions.models import Version
 
 
+def _get_header_version_data(request):
+    """Per-request shared accessor so `current_version` and `selected_version`
+    share one DB fetch within a single request."""
+    cached = getattr(request, "_header_version_data", None)
+    if cached is not None:
+        return cached
+    data = Version.objects.get_header_dropdown_data()
+    request._header_version_data = data
+    return data
+
+
 def current_version(request):
     """Custom context processor that adds the current release to the context"""
-    return {"current_version": Version.objects.most_recent()}
+    return {"current_version": _get_header_version_data(request).most_recent}
 
 
 def selected_version(request):
@@ -65,12 +76,17 @@ def selected_version(request):
     is_url_driven = bool(url_version_slug)
     cookie_slug = get_version_from_cookie(request)
 
+    header_data = _get_header_version_data(request)
+    options = list(header_data.options)
+
     resolved_slug = url_version_slug or cookie_slug
     version = None
     if resolved_slug and resolved_slug != LATEST_RELEASE_URL_PATH_STR:
-        version = Version.objects.filter(slug=resolved_slug).first()
+        version = next((v for v in options if v.slug == resolved_slug), None)
+        if version is None:
+            version = Version.objects.filter(slug=resolved_slug).first()
     if version is None:
-        version = Version.objects.most_recent()
+        version = header_data.most_recent
 
     is_explicit_non_latest_url = bool(
         url_version_slug and url_version_slug != LATEST_RELEASE_URL_PATH_STR
@@ -83,9 +99,6 @@ def selected_version(request):
     is_explicit = is_explicit_non_latest_url or is_explicit_cookie
 
     label = version.display_name if (is_explicit and version) else "Latest"
-
-    # Materialize: _annotate_option_hrefs mutates each option with a `.href`.
-    options = list(Version.objects.get_dropdown_versions())
 
     latest_href = ""
     if is_url_driven and resolver_match and resolver_match.view_name:

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -2,14 +2,146 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 from django.conf import settings
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 
+from libraries.constants import LATEST_RELEASE_URL_PATH_STR
+from libraries.utils import get_version_from_cookie
 from versions.models import Version
 
 
 def current_version(request):
     """Custom context processor that adds the current release to the context"""
     return {"current_version": Version.objects.most_recent()}
+
+
+def selected_version(request):
+    """User's active Boost version + data to render the navbar version dropdown.
+
+    Resolution priority for `selected_version`:
+    1. URL `version_slug` kwarg (on `/releases/`, `/libraries/`, `/library/` routes)
+    2. `boost_version` cookie
+    3. Most recent release (fallback)
+
+    When the version comes from the URL, the dropdown renders anchor links that
+    swap the version segment of the current path — shareable. Otherwise it
+    renders POST forms that write the cookie without navigating.
+
+    Examples
+    --------
+    GET /releases/1.88.0/  (no cookie)
+        selected_version               -> Version(slug="boost-1-88-0")
+        selected_version_is_url_driven -> True       (URL mode: render <a>s)
+        selected_version_is_explicit   -> True       (button reads "1.88.0")
+        selected_version_label         -> "1.88.0"
+        version_dropdown_options[i]    -> Version with `.href` attached,
+                                          e.g. "/releases/1.89.0/"
+        latest_href                    -> "/releases/latest/"
+
+    GET /  (cookie boost_version="boost-1-87-0")
+        selected_version               -> Version(slug="boost-1-87-0")
+        selected_version_is_url_driven -> False      (cookie mode: render <form>s)
+        selected_version_is_explicit   -> True       (button reads "1.87.0")
+        selected_version_label         -> "1.87.0"
+        version_dropdown_options[i]    -> Version (no `.href` needed)
+        latest_href                    -> ""
+
+    GET /  (no cookie)
+        selected_version               -> Version.objects.most_recent()
+        selected_version_is_url_driven -> False
+        selected_version_is_explicit   -> False      (button reads "Latest")
+        selected_version_label         -> "Latest"
+
+    GET /library/1.88.0/foo/  (target version "boost-1-70-0" predates "foo")
+        version_dropdown_options[…].href for that version
+                                       -> "/library/1.70.0/foo/"
+                                          (plain version swap; target view
+                                          renders the missing-version state)
+    """
+    url_version_slug = None
+    resolver_match = getattr(request, "resolver_match", None)
+    if resolver_match:
+        url_version_slug = resolver_match.kwargs.get("version_slug")
+
+    is_url_driven = bool(url_version_slug)
+    cookie_slug = get_version_from_cookie(request)
+
+    resolved_slug = url_version_slug or cookie_slug
+    version = None
+    if resolved_slug and resolved_slug != LATEST_RELEASE_URL_PATH_STR:
+        version = Version.objects.filter(slug=resolved_slug).first()
+    if version is None:
+        version = Version.objects.most_recent()
+
+    is_explicit_non_latest_url = bool(
+        url_version_slug and url_version_slug != LATEST_RELEASE_URL_PATH_STR
+    )
+    is_explicit_cookie = bool(
+        not url_version_slug
+        and cookie_slug
+        and cookie_slug != LATEST_RELEASE_URL_PATH_STR
+    )
+    is_explicit = is_explicit_non_latest_url or is_explicit_cookie
+
+    label = version.display_name if (is_explicit and version) else "Latest"
+
+    # Materialize: _annotate_option_hrefs mutates each option with a `.href`.
+    options = list(Version.objects.get_dropdown_versions())
+
+    latest_href = ""
+    if is_url_driven and resolver_match and resolver_match.view_name:
+        latest_href = _annotate_option_hrefs(
+            view_name=resolver_match.view_name,
+            url_kwargs=dict(resolver_match.kwargs),
+            options=options,
+        )
+
+    return {
+        "selected_version": version,
+        "selected_version_is_url_driven": is_url_driven,
+        "selected_version_is_explicit": is_explicit,
+        "selected_version_label": label,
+        "version_dropdown_options": options,
+        "latest_href": latest_href,
+    }
+
+
+def _annotate_option_hrefs(*, view_name, url_kwargs, options):
+    """Attach `.href` to each option for the current page; return the latest's.
+
+    The swap is a plain `reverse()` with the option's version substituted in —
+    on a library detail page at `/library/1.88.0/foo/`, picking 1.70.0 yields
+    `/library/1.70.0/foo/` even if that library didn't exist in 1.70.0. The
+    target view is responsible for rendering the empty / "not available" state.
+
+    Examples
+    --------
+    Current URL /releases/1.88.0/
+        view_name  = "release-detail"
+        url_kwargs = {"version_slug": "boost-1-88-0"}
+        → each option gets .href = "/releases/<that version>/"
+        → returns "/releases/latest/"
+
+    Current URL /libraries/1.88.0/grid/containers/
+        view_name  = "libraries-list"
+        url_kwargs = {"version_slug": "boost-1-88-0",
+                      "library_view_str": "grid",
+                      "category_slug": "containers"}
+        → each option gets .href = "/libraries/<that version>/grid/containers/"
+        → returns "/libraries/latest/grid/containers/"
+    """
+    for v in options:
+        try:
+            v.href = reverse(view_name, kwargs={**url_kwargs, "version_slug": v.slug})
+        except NoReverseMatch:
+            v.href = ""
+
+    try:
+        return reverse(
+            view_name,
+            kwargs={**url_kwargs, "version_slug": LATEST_RELEASE_URL_PATH_STR},
+        )
+    except NoReverseMatch:
+        return ""
 
 
 class NavItem(StrEnum):

--- a/core/tests/test_context_processors.py
+++ b/core/tests/test_context_processors.py
@@ -1,7 +1,16 @@
+from types import SimpleNamespace
+
 import pytest
 from django.test import RequestFactory
+from django.urls import ResolverMatch
 
-from core.context_processors import current_version, active_nav_item
+from core.context_processors import (
+    active_nav_item,
+    current_version,
+    selected_version,
+)
+from libraries.constants import SELECTED_BOOST_VERSION_COOKIE_NAME
+from versions.managers import HeaderVersionData
 
 
 def test_current_version_context(
@@ -42,3 +51,99 @@ def test_active_nav_item(path, expected_nav_item):
     request = RequestFactory().get(path)
     context = active_nav_item(request)
     assert context["active_nav_item"] == expected_nav_item
+
+
+def _stub_header_data(request):
+    most_recent = SimpleNamespace(slug="boost-1-88-0", display_name="1.88.0")
+    older = SimpleNamespace(slug="boost-1-87-0", display_name="1.87.0")
+    request._header_version_data = HeaderVersionData(
+        options=[most_recent, older],
+        most_recent=most_recent,
+        most_recent_beta=None,
+    )
+    return most_recent, older
+
+
+def _attach_resolver(request, *, route, kwargs, view_name=""):
+    request.resolver_match = ResolverMatch(
+        func=lambda r: None,
+        args=(),
+        kwargs=kwargs,
+        url_name=view_name or None,
+        route=route,
+    )
+
+
+def test_selected_version_url_driven_for_boost_route(rf):
+    request = rf.get("/releases/1.88.0/")
+    most_recent, older = _stub_header_data(request)
+    _attach_resolver(
+        request,
+        route="releases/<boostversionslug:version_slug>/",
+        kwargs={"version_slug": "boost-1-88-0"},
+        view_name="release-detail",
+    )
+    ctx = selected_version(request)
+    assert ctx["selected_version_is_url_driven"] is True
+    assert ctx["selected_version_is_non_latest"] is True
+    assert ctx["selected_version_label"] == "1.88.0"
+    assert ctx["selected_version"] is most_recent
+    assert ctx["latest_href"] == "/releases/latest/"
+    assert most_recent.href == "/releases/1.88.0/"
+    assert older.href == "/releases/1.87.0/"
+
+
+def test_selected_version_url_driven_with_latest_slug(rf):
+    """`/releases/latest/` is URL-driven but the label should still read
+    'Latest' and the version should fall back to most_recent."""
+    request = rf.get("/releases/latest/")
+    most_recent, _ = _stub_header_data(request)
+    _attach_resolver(
+        request,
+        route="releases/<boostversionslug:version_slug>/",
+        kwargs={"version_slug": "latest"},
+        view_name="release-detail",
+    )
+    ctx = selected_version(request)
+    assert ctx["selected_version_is_url_driven"] is True
+    assert ctx["selected_version_is_non_latest"] is False
+    assert ctx["selected_version_label"] == "Latest"
+    assert ctx["selected_version"] is most_recent
+
+
+def test_selected_version_cookie_driven(rf):
+    """Cookie mode: no URL slug, cookie picks the version, dropdown renders
+    POST forms (no `latest_href`, no per-option `.href`)."""
+    request = rf.get("/")
+    request.COOKIES[SELECTED_BOOST_VERSION_COOKIE_NAME] = "boost-1-87-0"
+    _, older = _stub_header_data(request)
+    ctx = selected_version(request)
+    assert ctx["selected_version_is_url_driven"] is False
+    assert ctx["selected_version_is_non_latest"] is True
+    assert ctx["selected_version_label"] == "1.87.0"
+    assert ctx["selected_version"] is older
+    assert ctx["latest_href"] == ""
+
+
+def test_selected_version_ignores_foreign_route_with_same_kwarg(rf):
+    """A route declaring `version_slug` via a different converter must NOT be
+    treated as URL-driven — the guard against silent coupling."""
+    request = rf.get("/elsewhere/anything/")
+    _stub_header_data(request)
+    _attach_resolver(
+        request,
+        route="elsewhere/<str:version_slug>/",
+        kwargs={"version_slug": "anything"},
+        view_name="some-other-view",
+    )
+    ctx = selected_version(request)
+    assert ctx["selected_version_is_url_driven"] is False
+    assert ctx["selected_version_label"] == "Latest"
+
+
+def test_selected_version_no_resolver_match(rf):
+    request = rf.get("/")
+    _stub_header_data(request)
+    ctx = selected_version(request)
+    assert ctx["selected_version_is_url_driven"] is False
+    assert ctx["selected_version_label"] == "Latest"

--- a/news/tests/test_views.py
+++ b/news/tests/test_views.py
@@ -419,7 +419,7 @@ def test_news_create_get(tp, regular_user, url_name, form_class):
         # assertGoodView expects a resolved URL
         # see https://github.com/revsys/django-test-plus/issues/202
         url = tp.reverse(url_name)
-        tp.assertGoodView(url, test_query_count=4, verbose=True)
+        tp.assertGoodView(url, test_query_count=5, verbose=True)
 
     form = tp.get_context("form")
     assert isinstance(form, form_class)

--- a/static/css/v3/header.css
+++ b/static/css/v3/header.css
@@ -313,6 +313,8 @@ html.dark .header__icon--theme-moon {
 }
 
 .header__version-dropdown {
+  --dropdown-item-height: 40px;
+
   display: none;
   position: absolute;
   top: calc(100% + var(--space-s));
@@ -320,38 +322,57 @@ html.dark .header__icon--theme-moon {
   flex-direction: column;
   width: max-content;
   min-width: 100%;
-  max-height: 60vh;
+  max-height: calc(var(--dropdown-item-height) * 7); /* Show up to 7 items, then scroll */
   overflow-y: auto;
-  padding: var(--space-default) var(--space-medium);
-  gap: var(--space-s);
   border-radius: var(--header-radius);
-  border: 1px solid var(--color-stroke-mid);
+  border: 1px solid var(--color-stroke-weak);
   background: var(--color-surface-weak);
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-icon-primary) var(--color-surface-strong);
   z-index: 1000;
 }
 
-.header__version-dropdown .header__nav-link {
-  padding: 0 var(--space-s);
+.header__version-dropdown .header__version-option {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
   width: 100%;
-}
-
-/* Forms wrap individual options; `display: contents` lets the inner button
-   inherit the dropdown's flex layout directly. */
-.header__version-form {
-  display: contents;
-}
-
-.header__version-dropdown button.header__nav-link {
+  height: var(--dropdown-item-height);
+  padding: 0 var(--space-large);
   border: none;
+  border-radius: 0;
   background: transparent;
-  font: inherit;
-  color: inherit;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-small);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text-secondary);
   text-align: left;
+  text-decoration: none;
   cursor: pointer;
+  transition: background-color 0.1s ease, color 0.1s ease;
+}
+
+.header__version-dropdown .header__version-option + .header__version-option {
+  border-top: 1px solid var(--color-stroke-subtle);
+}
+
+.header__version-dropdown .header__version-option:hover,
+.header__version-dropdown .header__version-option:focus {
+  background-color: var(--color-surface-mid);
+  color: var(--color-text-link-accent);
+  outline: none;
+}
+
+.header__version-dropdown .header__version-option:focus-visible {
+  outline: 2px solid var(--color-text-link-accent);
+  outline-offset: -2px;
 }
 
 .header__version-option[aria-current="true"] {
-  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-medium);
+  text-decoration: underline;
 }
 
 /* ── User menu & avatar ────────────────────────── */

--- a/static/css/v3/header.css
+++ b/static/css/v3/header.css
@@ -26,7 +26,7 @@
 
 .header__nav--desktop,
 .header__search-bar,
-.header__utilities-latest,
+.header__version-trigger,
 .header__icon-btn,
 .header__menu-btn,
 .header__drawer-nav,
@@ -198,7 +198,7 @@
   gap: var(--space-s);
 }
 
-.header__utilities-latest:hover,
+.header__version-trigger:hover,
 .header__nav-btn:hover,
 .header__icon-btn:hover,
 .header__user-trigger:hover {
@@ -210,20 +210,6 @@
 .header__icon-btn:active {
   background: var(--color-surface-mid);
   border-color: var(--color-stroke-weak);
-}
-
-.header__utilities-latest {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: var(--space-s);
-  padding: 0 var(--space-large);
-}
-
-.header__utilities-latest .header__icon--chevron {
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
 }
 
 .header__nav-btn {
@@ -282,6 +268,90 @@ html.dark .header__icon--theme-sun {
 
 html.dark .header__icon--theme-moon {
   display: none;
+}
+
+/* ── Version menu ──────────────────────────────── */
+
+.header__version-menu {
+  position: relative;
+}
+
+.header__version-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.header__version-toggle:checked ~ .header__version-dropdown {
+  display: flex;
+}
+
+.header__version-toggle:checked ~ .header__version-trigger {
+  border-color: var(--color-stroke-mid);
+  background: var(--color-surface-mid);
+}
+
+.header__version-toggle:focus-visible ~ .header__version-trigger {
+  outline: 2px solid var(--color-stroke-link-accent);
+}
+
+.header__version-trigger {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--space-s);
+  padding: 0 var(--space-large);
+  cursor: pointer;
+}
+
+.header__version-trigger .header__icon--chevron {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.header__version-dropdown {
+  display: none;
+  position: absolute;
+  top: calc(100% + var(--space-s));
+  right: 0;
+  flex-direction: column;
+  width: max-content;
+  min-width: 100%;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: var(--space-default) var(--space-medium);
+  gap: var(--space-s);
+  border-radius: var(--header-radius);
+  border: 1px solid var(--color-stroke-mid);
+  background: var(--color-surface-weak);
+  z-index: 1000;
+}
+
+.header__version-dropdown .header__nav-link {
+  padding: 0 var(--space-s);
+  width: 100%;
+}
+
+/* Forms wrap individual options; `display: contents` lets the inner button
+   inherit the dropdown's flex layout directly. */
+.header__version-form {
+  display: contents;
+}
+
+.header__version-dropdown button.header__nav-link {
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.header__version-option[aria-current="true"] {
+  font-weight: var(--font-weight-bold);
 }
 
 /* ── User menu & avatar ────────────────────────── */

--- a/static/css/v3/header.css
+++ b/static/css/v3/header.css
@@ -310,6 +310,11 @@ html.dark .header__icon--theme-moon {
   width: 16px;
   height: 16px;
   flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.header__version-toggle:checked ~ .header__version-trigger .header__icon--chevron {
+  transform: rotate(180deg);
 }
 
 .header__version-dropdown {
@@ -322,14 +327,20 @@ html.dark .header__icon--theme-moon {
   flex-direction: column;
   width: max-content;
   min-width: 100%;
-  max-height: calc(var(--dropdown-item-height) * 7); /* Show up to 7 items, then scroll */
-  overflow-y: auto;
   border-radius: var(--header-radius);
   border: 1px solid var(--color-stroke-weak);
   background: var(--color-surface-weak);
+  overflow: hidden;
+  z-index: 1000;
+}
+
+.header__version-dropdown-scroll {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(var(--dropdown-item-height) * 7); /* Show up to 7 items, then scroll */
+  overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--color-icon-primary) var(--color-surface-strong);
-  z-index: 1000;
 }
 
 .header__version-dropdown .header__version-option {
@@ -339,7 +350,7 @@ html.dark .header__icon--theme-moon {
   width: 100%;
   height: var(--dropdown-item-height);
   padding: 0 var(--space-large);
-  border: none;
+  border-bottom: 1px solid var(--color-stroke-mid);
   border-radius: 0;
   background: transparent;
   font-family: var(--font-sans);
@@ -351,6 +362,10 @@ html.dark .header__icon--theme-moon {
   text-decoration: none;
   cursor: pointer;
   transition: background-color 0.1s ease, color 0.1s ease;
+}
+
+.header__version-dropdown .header__version-option:last-child {
+  border-bottom: none;
 }
 
 .header__version-dropdown .header__version-option + .header__version-option {

--- a/templates/v3/examples/_v3_example_section.html
+++ b/templates/v3/examples/_v3_example_section.html
@@ -792,7 +792,7 @@
     <div class="v3-examples-section__block header" id="{{ section_title|slugify }}">
       <h3>{{ section_title }}</h3>
       <div class="v3-examples-section__example-box">
-        {% include "v3/includes/header/_header_utilities.html" with releases_url=releases_url only %}
+        {% include "v3/includes/header/_header_utilities.html" with avatar_id="demo-desktop-user-menu" version_menu_id="demo-desktop-version-menu" %}
       </div>
     </div>
   {% endwith %}
@@ -802,7 +802,7 @@
       <h3>{{ section_title }}</h3>
       <div class="v3-examples-section__example-box">
         <div class="header__drawer" style="display: flex; position: static;">
-          {% include "v3/includes/header/_header_utilities.html" with releases_url=releases_url only %}
+          {% include "v3/includes/header/_header_utilities.html" with avatar_id="demo-mobile-user-menu" version_menu_id="demo-mobile-version-menu" %}
         </div>
       </div>
     </div>

--- a/templates/v3/includes/_header_v3.html
+++ b/templates/v3/includes/_header_v3.html
@@ -3,16 +3,16 @@
   Header (v3) — site-wide header with desktop nav, mobile drawer, search, and user menu.
 
   Context Variables:
-    current_version          (object, required)              — current Boost release
+    current_version          (object, required)              — current Boost release (from context processor)
+    selected_version_label   (string, required)              — button label for version dropdown (from context processor)
     active_nav_item          (string, required)              — active nav key: "libraries"|"learn"|"news"|"community"|"releases"|"home"
     nav_links                (list[NavLink], required)       — header navigation links
-    releases_url             (string, required)              — resolved URL for releases page
     disable_theme_switcher   (bool, optional, default false) — hides the light/dark toggle
     request                  (HttpRequest, required)         — Django request object (for auth state)
 
   Note: Subcomponents inherit the full parent context. Specifically:
     _header_nav_link.html    uses: url, label, nav_id, is_unread, active_nav_item
-    _header_utilities.html   uses: releases_url, disable_theme_switcher, request, avatar_id
+    _header_utilities.html   uses: disable_theme_switcher, request, avatar_id, version_menu_id
 
   Usage:
     {% include "v3/includes/_header_v3.html" %}
@@ -60,7 +60,7 @@
             {% include "v3/includes/header/_header_nav_link.html" with url=item.url label=item.label nav_id=item.nav_id is_unread=item.is_unread %}
           {% endfor %}
         </nav>
-        {% include "v3/includes/header/_header_utilities.html" with avatar_id="mobile-user-menu" %}
+        {% include "v3/includes/header/_header_utilities.html" with avatar_id="mobile-user-menu" version_menu_id="mobile-version-menu" %}
       </div>
     </div>
 
@@ -79,10 +79,9 @@
     </button>
     <span class="header__search-kbd" aria-hidden="true">CTRL+K</span>
     </search>
-
     {% comment %} Desktop & tablet utilities (hidden on mobile) {% endcomment %}
     <div class="header__right">
-      {% include "v3/includes/header/_header_utilities.html" with avatar_id="desktop-user-menu" %}
+      {% include "v3/includes/header/_header_utilities.html" with avatar_id="desktop-user-menu" version_menu_id="desktop-version-menu" %}
     </div>
   </div>
 </header>
@@ -96,12 +95,20 @@
 (function () {
   'use strict';
 
-  var TOGGLE_SELECTOR = '.header__user-toggle, .header__menu-toggle';
+  var TOGGLE_SELECTOR = '.header__user-toggle, .header__menu-toggle, .header__version-toggle';
 
   function dismissOpenMenus(target) {
     var openUserToggles = document.querySelectorAll('.header__user-toggle:checked');
     openUserToggles.forEach(function (toggle) {
       var menu = toggle.closest('.header__user-menu');
+      if (menu && !menu.contains(target)) {
+        toggle.checked = false;
+      }
+    });
+
+    var openVersionToggles = document.querySelectorAll('.header__version-toggle:checked');
+    openVersionToggles.forEach(function (toggle) {
+      var menu = toggle.closest('.header__version-menu');
       if (menu && !menu.contains(target)) {
         toggle.checked = false;
       }
@@ -131,6 +138,53 @@
       e.preventDefault();
       toggle.checked = !toggle.checked;
     }
+  });
+
+  /**
+   * Progressive enhancement for the cookie-mode version dropdown: send the
+   * POST via fetch and update the UI in place, avoiding a full page reload.
+   * Falls back to a normal form submit on any error.
+   */
+  document.addEventListener('submit', function (e) {
+    var form = e.target;
+    if (!form.matches || !form.matches('.header__version-form')) return;
+    e.preventDefault();
+
+    var formData = new FormData(form);
+    var submitBtn = form.querySelector('button[type="submit"]');
+    var newLabel = submitBtn ? submitBtn.textContent.trim() : '';
+    var selectedValue = formData.get('version');
+
+    fetch(form.action, {
+      method: 'POST',
+      body: formData,
+      credentials: 'same-origin',
+      redirect: 'manual'
+    }).then(function (response) {
+      if (!(response.type === 'opaqueredirect' || response.ok)) {
+        form.submit();
+        return;
+      }
+      document.querySelectorAll('.header__version-menu').forEach(function (menu) {
+        var label = menu.querySelector('.header__version-label');
+        if (label) label.textContent = newLabel;
+
+        menu.querySelectorAll('.header__version-option').forEach(function (opt) {
+          var optForm = opt.closest('.header__version-form');
+          var optInput = optForm && optForm.querySelector('input[name="version"]');
+          if (optInput && optInput.value === selectedValue) {
+            opt.setAttribute('aria-current', 'true');
+          } else {
+            opt.removeAttribute('aria-current');
+          }
+        });
+
+        var toggle = menu.querySelector('.header__version-toggle');
+        if (toggle) toggle.checked = false;
+      });
+    }).catch(function () {
+      form.submit();
+    });
   });
 })();
 </script>

--- a/templates/v3/includes/_header_v3.html
+++ b/templates/v3/includes/_header_v3.html
@@ -148,12 +148,17 @@
   document.addEventListener('submit', function (e) {
     var form = e.target;
     if (!form.matches || !form.matches('.header__version-form')) return;
+
+    // The clicked option button carries name="version" value="<slug>".
+    // FormData(form) doesn't include the submitter's name/value, so append it.
+    var submitter = e.submitter;
+    if (!submitter || submitter.name !== 'version') return;
     e.preventDefault();
 
+    var selectedValue = submitter.value;
+    var newLabel = submitter.textContent.trim();
     var formData = new FormData(form);
-    var submitBtn = form.querySelector('button[type="submit"]');
-    var newLabel = submitBtn ? submitBtn.textContent.trim() : '';
-    var selectedValue = formData.get('version');
+    formData.set('version', selectedValue);
 
     fetch(form.action, {
       method: 'POST',
@@ -170,9 +175,7 @@
         if (label) label.textContent = newLabel;
 
         menu.querySelectorAll('.header__version-option').forEach(function (opt) {
-          var optForm = opt.closest('.header__version-form');
-          var optInput = optForm && optForm.querySelector('input[name="version"]');
-          if (optInput && optInput.value === selectedValue) {
+          if (opt.value === selectedValue) {
             opt.setAttribute('aria-current', 'true');
           } else {
             opt.removeAttribute('aria-current');

--- a/templates/v3/includes/header/_header_utilities.html
+++ b/templates/v3/includes/header/_header_utilities.html
@@ -1,23 +1,18 @@
 {% load account socialaccount %}
 {% comment %}
-  Header Utilities — Latest link, theme toggle, and auth.
+  Header Utilities — Version dropdown, theme toggle, and auth.
   Shared between desktop and mobile drawer.
   Visual differences are handled by CSS based on parent context (.header__right vs .header__drawer).
 
   Context Variables:
-    releases_url            (string, required)              — resolved URL for releases page
     disable_theme_switcher  (bool, optional, default false) — hides the theme toggle
     request                 (HttpRequest, required)         — Django request object (for auth state)
     avatar_id               (string, required)              — unique ID prefix for avatar component, e.g. "desktop-user-menu"
+    version_menu_id         (string, required)              — unique ID prefix for version menu, e.g. "desktop-version-menu"
 {% endcomment %}
 <div class="header__utilities">
-  {% comment %} Latest Dropdown {% endcomment %}
-  <a href="{{ releases_url }}" class="header__utilities-latest">
-    Latest
-    <span class="icon-brand-accent">
-      {% include "includes/icon.html" with icon_name="chevron-down" icon_class="header__icon header__icon--chevron" icon_size=16 %}
-    </span>
-  </a>
+  {% comment %} Version Dropdown {% endcomment %}
+  {% include "v3/includes/header/_header_version_dropdown.html" with version_menu_id=version_menu_id %}
 
   {% comment %} Theme Toggle {% endcomment %}
   {% if not disable_theme_switcher %}

--- a/templates/v3/includes/header/_header_version_dropdown.html
+++ b/templates/v3/includes/header/_header_version_dropdown.html
@@ -26,52 +26,52 @@
          class="header__version-toggle"
          aria-label="Select Boost version"
          aria-controls="{{ version_menu_id }}-dropdown">
-  <label for="{{ version_menu_id }}-toggle" class="header__version-trigger" aria-hidden="true">
+  <label for="{{ version_menu_id }}-toggle"
+         class="header__version-trigger"
+         aria-hidden="true">
     <span class="header__version-label">{{ selected_version_label }}</span>
     <span class="icon-brand-accent">
       {% include "includes/icon.html" with icon_name="chevron-down" icon_class="header__icon header__icon--chevron" icon_size=16 %}
     </span>
   </label>
-  <div id="{{ version_menu_id }}-dropdown" role="group" class="header__version-dropdown">
+  <div id="{{ version_menu_id }}-dropdown"
+       role="group"
+       class="header__version-dropdown">
     {% if selected_version_is_url_driven %}
       {% if latest_href %}
         <a href="{{ latest_href }}"
-           class="header__nav-link header__version-option"
-           {% if not selected_version_is_non_latest %}aria-current="true"{% endif %}>
-          Latest
-        </a>
+           class="header__version-option"
+           {% if not selected_version_is_non_latest %}aria-current="true"{% endif %}>Latest</a>
       {% endif %}
       {% for v in version_dropdown_options %}
         {% if v.href %}
           <a href="{{ v.href }}"
-             class="header__nav-link header__version-option"
-             {% if selected_version and v.slug == selected_version.slug %}aria-current="true"{% endif %}>
+             class="header__version-option"
+             {% if selected_version_is_non_latest and selected_version and v.slug == selected_version.slug %}aria-current="true"{% endif %}>
             {{ v.display_name }}
           </a>
         {% endif %}
       {% endfor %}
-
     {% else %}
-      <form method="post" action="{% url 'set-version' %}" class="header__version-form">
+      <form method="post"
+            action="{% url 'set-version' %}"
+            class="header__version-form">
         {% csrf_token %}
-        <input type="hidden" name="version" value="latest">
         <button type="submit"
-                class="header__nav-link header__version-option"
-                {% if not selected_version_is_non_latest %}aria-current="true"{% endif %}>
-          Latest
-        </button>
-      </form>
-      {% for v in version_dropdown_options %}
-        <form method="post" action="{% url 'set-version' %}" class="header__version-form">
-          {% csrf_token %}
-          <input type="hidden" name="version" value="{{ v.slug }}">
+                name="version"
+                value="latest"
+                class="header__version-option"
+                {% if not selected_version_is_non_latest %}aria-current="true"{% endif %}>Latest</button>
+        {% for v in version_dropdown_options %}
           <button type="submit"
-                  class="header__nav-link header__version-option"
-                  {% if selected_version and v.slug == selected_version.slug %}aria-current="true"{% endif %}>
+                  name="version"
+                  value="{{ v.slug }}"
+                  class="header__version-option"
+                  {% if selected_version_is_non_latest and selected_version and v.slug == selected_version.slug %}aria-current="true"{% endif %}>
             {{ v.display_name }}
           </button>
-        </form>
-      {% endfor %}
+        {% endfor %}
+      </form>
     {% endif %}
   </div>
 </div>

--- a/templates/v3/includes/header/_header_version_dropdown.html
+++ b/templates/v3/includes/header/_header_version_dropdown.html
@@ -1,0 +1,77 @@
+{% comment %}
+  Header Version Dropdown — always-visible Boost version selector.
+
+  On version-aware pages (/releases/, /libraries/, /library/), the options are
+  <a> links that swap the version segment of the current URL and trigger navigation.
+
+  Elsewhere, the options are POST forms that write the cookie via
+  `set-version` and redirect back — no visible navigation.
+
+  The dropdown is a CSS-only toggle via hidden checkbox; works with JS disabled.
+
+  Variables:
+    version_menu_id  (string, required) — unique ID prefix, e.g. "desktop-version-menu"
+
+  Context Variables (from `core.context_processors.selected_version`):
+    selected_version                 (Version)  — resolved active version
+    selected_version_is_url_driven   (bool)     — true on version-aware pages (/releases/, /libraries/, /library/)
+    selected_version_is_explicit     (bool)     — drives whether the button label shows a version number or "Latest"
+    selected_version_label           (str)      — pre-resolved button label
+    version_dropdown_options         (list[Version]) — each has `.href` when URL-driven
+    latest_href                      (str)      — URL for the "Latest" option when URL-driven
+{% endcomment %}
+<div class="header__version-menu">
+  <input type="checkbox"
+         id="{{ version_menu_id }}-toggle"
+         class="header__version-toggle"
+         aria-label="Select Boost version"
+         aria-controls="{{ version_menu_id }}-dropdown">
+  <label for="{{ version_menu_id }}-toggle" class="header__version-trigger" aria-hidden="true">
+    <span class="header__version-label">{{ selected_version_label }}</span>
+    <span class="icon-brand-accent">
+      {% include "includes/icon.html" with icon_name="chevron-down" icon_class="header__icon header__icon--chevron" icon_size=16 %}
+    </span>
+  </label>
+  <div id="{{ version_menu_id }}-dropdown" role="group" class="header__version-dropdown">
+    {% if selected_version_is_url_driven %}
+      {% if latest_href %}
+        <a href="{{ latest_href }}"
+           class="header__nav-link header__version-option"
+           {% if not selected_version_is_explicit %}aria-current="true"{% endif %}>
+          Latest
+        </a>
+      {% endif %}
+      {% for v in version_dropdown_options %}
+        {% if v.href %}
+          <a href="{{ v.href }}"
+             class="header__nav-link header__version-option"
+             {% if selected_version and v.slug == selected_version.slug %}aria-current="true"{% endif %}>
+            {{ v.display_name }}
+          </a>
+        {% endif %}
+      {% endfor %}
+
+    {% else %}
+      <form method="post" action="{% url 'set-version' %}" class="header__version-form">
+        {% csrf_token %}
+        <input type="hidden" name="version" value="latest">
+        <button type="submit"
+                class="header__nav-link header__version-option"
+                {% if not selected_version_is_explicit %}aria-current="true"{% endif %}>
+          Latest
+        </button>
+      </form>
+      {% for v in version_dropdown_options %}
+        <form method="post" action="{% url 'set-version' %}" class="header__version-form">
+          {% csrf_token %}
+          <input type="hidden" name="version" value="{{ v.slug }}">
+          <button type="submit"
+                  class="header__nav-link header__version-option"
+                  {% if selected_version and v.slug == selected_version.slug %}aria-current="true"{% endif %}>
+            {{ v.display_name }}
+          </button>
+        </form>
+      {% endfor %}
+    {% endif %}
+  </div>
+</div>

--- a/templates/v3/includes/header/_header_version_dropdown.html
+++ b/templates/v3/includes/header/_header_version_dropdown.html
@@ -37,41 +37,43 @@
   <div id="{{ version_menu_id }}-dropdown"
        role="group"
        class="header__version-dropdown">
-    {% if selected_version_is_url_driven %}
-      {% if latest_href %}
-        <a href="{{ latest_href }}"
-           class="header__version-option"
-           {% if not selected_version_is_non_latest %}aria-current="true"{% endif %}>Latest</a>
-      {% endif %}
-      {% for v in version_dropdown_options %}
-        {% if v.href %}
-          <a href="{{ v.href }}"
+    <div class="header__version-dropdown-scroll">
+      {% if selected_version_is_url_driven %}
+        {% if latest_href %}
+          <a href="{{ latest_href }}"
              class="header__version-option"
-             {% if selected_version_is_non_latest and selected_version and v.slug == selected_version.slug %}aria-current="true"{% endif %}>
-            {{ v.display_name }}
-          </a>
+             {% if not selected_version_is_non_latest %}aria-current="true"{% endif %}>Latest</a>
         {% endif %}
-      {% endfor %}
-    {% else %}
-      <form method="post"
-            action="{% url 'set-version' %}"
-            class="header__version-form">
-        {% csrf_token %}
-        <button type="submit"
-                name="version"
-                value="latest"
-                class="header__version-option"
-                {% if not selected_version_is_non_latest %}aria-current="true"{% endif %}>Latest</button>
         {% for v in version_dropdown_options %}
+          {% if v.href %}
+            <a href="{{ v.href }}"
+               class="header__version-option"
+               {% if selected_version_is_non_latest and selected_version and v.slug == selected_version.slug %}aria-current="true"{% endif %}>
+              {{ v.display_name }}
+            </a>
+          {% endif %}
+        {% endfor %}
+      {% else %}
+        <form method="post"
+              action="{% url 'set-version' %}"
+              class="header__version-form">
+          {% csrf_token %}
           <button type="submit"
                   name="version"
-                  value="{{ v.slug }}"
+                  value="latest"
                   class="header__version-option"
-                  {% if selected_version_is_non_latest and selected_version and v.slug == selected_version.slug %}aria-current="true"{% endif %}>
-            {{ v.display_name }}
-          </button>
-        {% endfor %}
-      </form>
-    {% endif %}
+                  {% if not selected_version_is_non_latest %}aria-current="true"{% endif %}>Latest</button>
+          {% for v in version_dropdown_options %}
+            <button type="submit"
+                    name="version"
+                    value="{{ v.slug }}"
+                    class="header__version-option"
+                    {% if selected_version_is_non_latest and selected_version and v.slug == selected_version.slug %}aria-current="true"{% endif %}>
+              {{ v.display_name }}
+            </button>
+          {% endfor %}
+        </form>
+      {% endif %}
+    </div>
   </div>
 </div>

--- a/templates/v3/includes/header/_header_version_dropdown.html
+++ b/templates/v3/includes/header/_header_version_dropdown.html
@@ -15,7 +15,7 @@
   Context Variables (from `core.context_processors.selected_version`):
     selected_version                 (Version)  — resolved active version
     selected_version_is_url_driven   (bool)     — true on version-aware pages (/releases/, /libraries/, /library/)
-    selected_version_is_explicit     (bool)     — drives whether the button label shows a version number or "Latest"
+    selected_version_is_non_latest   (bool)     — drives whether the button label shows a version number or "Latest"
     selected_version_label           (str)      — pre-resolved button label
     version_dropdown_options         (list[Version]) — each has `.href` when URL-driven
     latest_href                      (str)      — URL for the "Latest" option when URL-driven
@@ -37,7 +37,7 @@
       {% if latest_href %}
         <a href="{{ latest_href }}"
            class="header__nav-link header__version-option"
-           {% if not selected_version_is_explicit %}aria-current="true"{% endif %}>
+           {% if not selected_version_is_non_latest %}aria-current="true"{% endif %}>
           Latest
         </a>
       {% endif %}
@@ -57,7 +57,7 @@
         <input type="hidden" name="version" value="latest">
         <button type="submit"
                 class="header__nav-link header__version-option"
-                {% if not selected_version_is_explicit %}aria-current="true"{% endif %}>
+                {% if not selected_version_is_non_latest %}aria-current="true"{% endif %}>
           Latest
         </button>
       </form>

--- a/versions/converters.py
+++ b/versions/converters.py
@@ -24,6 +24,7 @@ def to_url(value):
 
 
 class BoostVersionSlugConverter:
+    URL_TYPE_NAME = "boostversionslug"
     regex = r"[a-zA-Z0-9\-\.]+"
 
     def to_python(self, value):

--- a/versions/managers.py
+++ b/versions/managers.py
@@ -1,3 +1,5 @@
+from typing import NamedTuple
+
 from django.db import models
 from django.db.models import Func, Value, Count, Q
 from django.db.models.functions import Replace
@@ -7,6 +9,14 @@ from libraries.constants import (
     MASTER_RELEASE_URL_PATH_STR,
     DEVELOP_RELEASE_URL_PATH_STR,
 )
+
+
+class HeaderVersionData(NamedTuple):
+    """Consolidated data needed to render the navbar version dropdown."""
+
+    options: list
+    most_recent: "Version | None"  # noqa: F821
+    most_recent_beta: "Version | None"  # noqa: F821
 
 
 class VersionQuerySet(models.QuerySet):
@@ -165,6 +175,49 @@ class VersionManager(models.Manager):
             )
 
         return queryset.order_by(order_by)
+
+    def get_header_dropdown_data(self) -> HeaderVersionData:
+        """Single-query fetch for the navbar version dropdown.
+
+        Replaces the 3-4 queries from calling `most_recent()`,
+        `most_recent_beta()`, and `get_dropdown_versions()` separately. Dropdown
+        list matches `get_dropdown_versions()` for the header's use case only —
+        no develop/master, no library filtering.
+        """
+        name_exclusions = [
+            "head",
+            MASTER_RELEASE_URL_PATH_STR,
+            DEVELOP_RELEASE_URL_PATH_STR,
+        ]
+        versions = list(
+            self.active()
+            .filter(Q(full_release=True) | Q(beta=True))
+            .exclude(name__in=name_exclusions)
+            .defer("data")
+            .order_by("-name")
+        )
+
+        most_recent = next((v for v in versions if not v.beta and v.full_release), None)
+        most_recent_beta = next((v for v in versions if v.beta), None)
+
+        include_beta = (
+            most_recent_beta is not None
+            and most_recent is not None
+            and most_recent_beta.cleaned_version_parts
+            > most_recent.cleaned_version_parts
+        )
+        if include_beta:
+            options = [
+                v for v in versions if not v.beta or v.name == most_recent_beta.name
+            ]
+        else:
+            options = [v for v in versions if not v.beta]
+
+        return HeaderVersionData(
+            options=options,
+            most_recent=most_recent,
+            most_recent_beta=most_recent_beta,
+        )
 
 
 class VersionFileQuerySet(models.QuerySet):

--- a/versions/views.py
+++ b/versions/views.py
@@ -5,13 +5,15 @@ from itertools import groupby
 from operator import attrgetter
 
 from django.db.models import Q, Count
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 from django.views import View
+from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, TemplateView, ListView
 from django.shortcuts import redirect, get_object_or_404
 from django.contrib import messages
 from django.conf import settings
 from django.utils.decorators import method_decorator
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.csrf import csrf_exempt
 
 from core.models import RenderedContent
@@ -28,6 +30,29 @@ from versions.exceptions import BoostImportedDataException
 from versions.models import Review, Version
 
 logger = structlog.get_logger()
+
+
+@require_POST
+def set_version(request):
+    """Writes the selected version cookie, then redirects back to the referring page.
+
+    Used by the navbar version dropdown on pages that are not version-aware
+    (i.e. everything except `/releases/`, `/libraries/`, `/library/`). Validation
+    and cookie semantics are delegated to `set_selected_boost_version`.
+    """
+    version_slug = request.POST.get("version", "")
+    referer = request.headers.get("referer", "")
+    if referer and url_has_allowed_host_and_scheme(
+        url=referer,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        next_url = referer
+    else:
+        next_url = "/"
+    response = HttpResponseRedirect(next_url, status=303)
+    set_selected_boost_version(version_slug, response)
+    return response
 
 
 @method_decorator(csrf_exempt, name="dispatch")


### PR DESCRIPTION
# Issue: #2354 

⚠️ This work is a branch off from https://github.com/boostorg/website-v2/pull/2305 
## Summary & Context
 
Adds a version dropdown to the V3 header that lets users switch the active Boost version. The dropdown is **dual-mode**: on version-aware routes (`/releases/`, `/libraries/`, `/library/`) each option is a pre-computed link to the same page at that version (shareable URLs); everywhere else, options POST to `set-version/` to set the `boost_version` cookie and redirect back via the referer.
 
- **Figma link**: There's no Figma design for this version dropdown – it's a mixed of styling between the [form input dropdown](https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=495-4872&m=dev) and [avatar menu](https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=267-3633&m=dev). 
- **Link to components/page**: 
  -  Example of version-unaware page: http://localhost:8000/
  - Version-aware pages (i.e updating the dropdown affects the content)
      1. http://localhost:8000/libraries/latest/categorized/
      2. http://localhost:8000/releases/latest/
      3. http://localhost:8000/library/latest/algorithm/

## Notable Changes

Front End:
- Add `_header_version_dropdown.html` partial, replacing the hardcoded "Latest" link
- Improve progressive enhancement in `_header_v3.html`: fetch-based JS form submission avoids a reload in cookie mode; falls back to normal submit on error.

Back End:
- Add `set_version` view (`versions/views.py`) and `/set-version/` route (`config/urls.py`) — validates referer against the host, writes the `boost_version` cookie, redirects back
- Add `Version.objects.get_header_dropdown_data()` (`versions/managers.py`) returning a `HeaderVersionData` NamedTuple — consolidates `most_recent`, `most_recent_beta`, and dropdown options into a single deferred query; includes beta only if newer than the latest stable
- Add `selected_version` context processor (`core/context_processors.py`) resolving the active version by priority: URL `version_slug` kwarg → `boost_version` cookie → most recent release; emits `selected_version`, `selected_version_is_url_driven`, `selected_version_is_non_latest`, `selected_version_label`, `version_dropdown_options`, `latest_href`
- Refactor `current_version` and `selected_version` to share a request-scoped cache (`request._header_version_data`) — one DB hit per request regardless of include count
- Refactor: extract `_annotate_option_hrefs()` helper that substitutes each option's slug into the current URL via `reverse()` for version-swapped links
- Added tests for the version control with URL + cookies. 


## Risks & Considerations
 
- **Referer validation**: `set_version` only accepts referers matching the request host and falls back to `/`. 
- **Cookie vs URL precedence**: On version-aware pages the URL always wins over the cookie (if cookie is stale then it'll also be updated)
- **Query consolidation**: `get_header_dropdown_data()` replaces 3–4 call sites that used `most_recent()` / `most_recent_beta()` / `get_dropdown_versions()`. The request-scoped cache relies on the same `request` object being passed. 
  - ❗️The issue of the extra calls were flagged in the CI test fail in this original commit / implementation: https://github.com/boostorg/website-v2/pull/2349/commits/caa8615572548b17142031874cef5e6ae94babc4 
- **No-JS behavior**: Cookie-mode submission works without JS (native form POST + redirect). URL-mode is plain `<a>` tags. The CSS-only toggle means the menu opens without JS too; only outside-click close requires JS.

## Screenshots
 
Desktop Light Mode | Desktop Dark Mode | Mobile
-- | -- | --
<img width="529" height="358" alt="Screenshot 2026-04-22 at 12 52 26 PM" src="https://github.com/user-attachments/assets/c78f38c7-c8d6-4d1e-8f00-6d40e5890cf6" /> | <img width="527" height="368" alt="Screenshot 2026-04-22 at 12 52 37 PM" src="https://github.com/user-attachments/assets/dce07e78-7b5b-4559-8805-267a4d5cb753" /> | <img width="661" height="938" alt="Screenshot 2026-04-22 at 12 53 04 PM" src="https://github.com/user-attachments/assets/30f1f5ba-b09f-4f9f-9b90-eed65d4b8512" />

 
## Self-review Checklist
- [x] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, `aria-current`, focus states)
- [x] Design tokens used for colors, spacing, typography
- [x] Tested without JavaScript (cookie-mode form submit + URL-mode links both work)
- [x] No console errors or warnings- [ ] 