### PR TITLE
Update report download table

### DIFF
--- a/libraries/forms.py
+++ b/libraries/forms.py
@@ -284,7 +284,7 @@ class CreateReportForm(CreateReportFullForm):
         report_configuration = self.cleaned_data["report_configuration"]
         return f"release-report-{lib_string}-{report_configuration.version}"
 
-    def get_stats(self):
+    def get_stats(self, base_uri: str = None):
         report_configuration = self.cleaned_data["report_configuration"]
         committee_members = report_configuration.financial_committee_members.all()
         # NOTE TO FUTURE DEVS: remember to account for the fact that a report
@@ -366,7 +366,7 @@ class CreateReportForm(CreateReportFullForm):
         )
 
         git_graph_data = get_git_graph_data(prior_version, version)
-        download = get_download_links(version)
+        download = get_download_links(version, base_uri)
         ### completed task handling ###
         (mailinglist_contributor_release_count, mailinglist_contributor_new_count) = (
             mailing_list_contributors_task.get()
@@ -431,7 +431,10 @@ class CreateReportForm(CreateReportFullForm):
         }
 
     def generate_context(
-        self, report_configuration: ReportConfiguration, stats_results: dict
+        self,
+        report_configuration: ReportConfiguration,
+        stats_results: dict,
+        base_uri: str = None,
     ):
         committee_members = report_configuration.financial_committee_members.all()
 
@@ -506,7 +509,7 @@ class CreateReportForm(CreateReportFullForm):
         )
 
         git_graph_data = get_git_graph_data(prior_version, version)
-        download = get_download_links(version)
+        download = get_download_links(version, base_uri)
 
         return {
             "committee_members": committee_members,
@@ -554,7 +557,7 @@ class CreateReportForm(CreateReportFullForm):
     def render_with_stats(self, stats_results, base_uri=None):
         """Render HTML with pre-computed stats results"""
         context = self.generate_context(
-            self.cleaned_data["report_configuration"], stats_results
+            self.cleaned_data["report_configuration"], stats_results, base_uri
         )
         if base_uri:
             context["base_uri"] = base_uri

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -276,7 +276,10 @@ def generate_release_report(user_id, params, base_uri=None, stats_results=None):
         return None
 
     if stats_results:
-        html = form.render_with_stats(stats_results, base_uri=base_uri)
+        html = form.render_with_stats(
+            stats_results,
+            base_uri=base_uri,
+        )
     else:
         html = form.cache_html(base_uri=base_uri)
 

--- a/reports/generation.py
+++ b/reports/generation.py
@@ -627,7 +627,7 @@ def get_download_links(version: Version, base_uri: str = None):
 
     # Some Version of Boost have no windows binaries, so we can return
     win_bin_d = r_dict.get(OperatingSystems.WINDOWS_BIN, None)
-    if not win_bin_d or len(win_bin_d) < 1:
+    if not bool(win_bin_d):
         return r_dict
 
     # Attempt to match version name, in shape of Boost version - msvc - msvc version - bit.exe
@@ -661,8 +661,14 @@ def get_download_links(version: Version, base_uri: str = None):
     # Remove dupes and sort
     msvc_versions = list(set(msvc_versions))
     msvc_versions.sort(key=itemgetter(0, 1))
-    selected_version = msvc_versions[-1]
 
+    # If we somehow didn't generate anyversions, return to avoid an error
+    # This might occure if all versions are "all" versions, or if the regex fails
+    # in the future
+    if not bool(msvc_versions):
+        return r_dict
+
+    selected_version = msvc_versions[-1]
     updated_win_dls += version_files.get(selected_version, [])
 
     # If we have passed a base_uri, use it to create a link to the release detail page

--- a/reports/generation.py
+++ b/reports/generation.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 import random
+import re
 from dataclasses import dataclass, field
 from datetime import timedelta, date
 from functools import cached_property
@@ -13,6 +14,7 @@ import psycopg2
 from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.db.models import OuterRef, Q, F, Case, When, Value, Sum, Count
+from django.urls import reverse
 from matplotlib import pyplot as plt
 from wordcloud import WordCloud, STOPWORDS
 from algoliasearch.analytics.client import AnalyticsClientSync
@@ -613,13 +615,63 @@ def get_issues_counts(prior_version: Version, version: Version):
 
 
 def get_download_links(version: Version):
-    return {
+    from versions.models import OperatingSystems
+
+    r_dict = {
         k: list(v)
         for k, v in groupby(
-            version.downloads.all().order_by("operating_system"),
+            version.downloads.all().order_by("operating_system", "display_name"),
             key=attrgetter("operating_system"),
         )
     }
+    win_bin_d = r_dict[OperatingSystems.WINDOWS_BIN]
+    # Attempt to match version name, in shape of Boost version - msvc - msvc version - bit.exe
+    # e.g. boost_1_91_0_b1-msvc-14.5-64.exe
+    # and return major and minor msvc version
+
+    v_reg = re.compile(
+        "[^-]*-msvc-(?P<major_version>[\d]*).(?P<minor_version>[\d]*)-[\d.\w]"
+    )
+    major_vers = []
+    minor_vers = []
+    updated_win_dls = []
+    for dl in win_bin_d:
+        match = v_reg.match(dl.display_name)
+        if not match:
+            # If our regex does not match, we have found an "all" file, so add it to the list
+            updated_win_dls.append(dl)
+            win_bin_d.remove(dl)
+            continue
+        major_vers.append(match.groupdict().get("major_version"))
+        minor_vers.append(match.groupdict().get("minor_version"))
+
+    # Remove dupes and sort
+    major_vers = list(set(major_vers))
+    minor_vers = list(set(minor_vers))
+    major_vers.sort()
+    minor_vers.sort()
+
+    m_ver = major_vers[-1]
+    mi_ver = minor_vers[-1]
+
+    pref_reg = re.compile(f"[^-]*-msvc-{m_ver}.{mi_ver}-[\d.\w]")
+
+    for dl in win_bin_d:
+        match = pref_reg.match(dl.display_name)
+        if not match:
+            continue
+        else:
+            updated_win_dls.append(dl)
+
+    updated_win_dls.append(
+        {
+            "display_name": "To see other windows versions, click here",
+            "url": f"{settings.ALLOWED_HOSTS[0]}{reverse("release-detail", kwargs={"version_slug":version.slug})}",
+        }
+    )
+
+    r_dict[OperatingSystems.WINDOWS_BIN] = updated_win_dls
+    return r_dict
 
 
 def get_mailinglist_msg_counts(version: Version) -> tuple[int, int]:

--- a/reports/generation.py
+++ b/reports/generation.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta, date
 from functools import cached_property
 from itertools import chain, groupby
-from operator import attrgetter
+from operator import attrgetter, itemgetter
 
 import psycopg2
 from django.conf import settings
@@ -614,7 +614,7 @@ def get_issues_counts(prior_version: Version, version: Version):
     return opened_issues_count, closed_issues_count
 
 
-def get_download_links(version: Version):
+def get_download_links(version: Version, base_uri: str = None):
     from versions.models import OperatingSystems
 
     r_dict = {
@@ -624,51 +624,55 @@ def get_download_links(version: Version):
             key=attrgetter("operating_system"),
         )
     }
-    win_bin_d = r_dict[OperatingSystems.WINDOWS_BIN]
+
+    # Some Version of Boost have no windows binaries, so we can return
+    win_bin_d = r_dict.get(OperatingSystems.WINDOWS_BIN, None)
+    if not win_bin_d or len(win_bin_d) < 1:
+        return r_dict
+
     # Attempt to match version name, in shape of Boost version - msvc - msvc version - bit.exe
     # e.g. boost_1_91_0_b1-msvc-14.5-64.exe
     # and return major and minor msvc version
 
     v_reg = re.compile(
-        "[^-]*-msvc-(?P<major_version>[\d]*).(?P<minor_version>[\d]*)-[\d.\w]"
+        r"^[^-]*-msvc-(?P<major_version>[\d]+)\.(?P<minor_version>[\d]+)-[\d.\w]+$"
     )
-    major_vers = []
-    minor_vers = []
+
     updated_win_dls = []
+    msvc_versions = []
+    version_files = {}
+
+    # Iterate over our files, group them by major and minor msvc version
     for dl in win_bin_d:
         match = v_reg.match(dl.display_name)
         if not match:
             # If our regex does not match, we have found an "all" file, so add it to the list
             updated_win_dls.append(dl)
-            win_bin_d.remove(dl)
             continue
-        major_vers.append(match.groupdict().get("major_version"))
-        minor_vers.append(match.groupdict().get("minor_version"))
+        msvc_version = (
+            int(match.groupdict().get("major_version")),
+            int(match.groupdict().get("minor_version")),
+        )
+        msvc_versions.append(msvc_version)
+        if msvc_version not in version_files:
+            version_files[msvc_version] = []
+        version_files[msvc_version].append(dl)
 
     # Remove dupes and sort
-    major_vers = list(set(major_vers))
-    minor_vers = list(set(minor_vers))
-    major_vers.sort()
-    minor_vers.sort()
+    msvc_versions = list(set(msvc_versions))
+    msvc_versions.sort(key=itemgetter(0, 1))
+    selected_version = msvc_versions[-1]
 
-    m_ver = major_vers[-1]
-    mi_ver = minor_vers[-1]
+    updated_win_dls += version_files.get(selected_version, [])
 
-    pref_reg = re.compile(f"[^-]*-msvc-{m_ver}.{mi_ver}-[\d.\w]")
-
-    for dl in win_bin_d:
-        match = pref_reg.match(dl.display_name)
-        if not match:
-            continue
-        else:
-            updated_win_dls.append(dl)
-
-    updated_win_dls.append(
-        {
-            "display_name": "To see other windows versions, click here",
-            "url": f"{settings.ALLOWED_HOSTS[0]}{reverse("release-detail", kwargs={"version_slug":version.slug})}",
-        }
-    )
+    # If we have passed a base_uri, use it to create a link to the release detail page
+    if base_uri:
+        updated_win_dls.append(
+            {
+                "display_name": "To see other windows versions, click here",
+                "url": f"{base_uri}{reverse("release-detail", kwargs={"version_slug":version.slug})}",
+            }
+        )
 
     r_dict[OperatingSystems.WINDOWS_BIN] = updated_win_dls
     return r_dict


### PR DESCRIPTION
## Summary & Context
Updates the display of binary downloads on the release report to account for an ever growing number of windows downloads. Prevents overflowing the first page by only showing the newest version of msvc and then adding a see all link.

## Changes

- While getting windows download links, uses a regex to split out all major/minor versions of mvsc
- Kicks out all download links that are not either for an "all" version or for the latest version
- Appends a download link which goes to the downloads page of the site

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*

* The download link uses some sketchy logic involving the ALLOWED_HOSTS to avoid passing the request in strange ways. This may not be the best solution

## Screenshots

<!-- Before | After
-- | -- -->

<img width="596" height="727" alt="image" src="https://github.com/user-attachments/assets/6eae0a3d-964e-440c-8c57-60fdea5ff4b7" />

<img width="487" height="338" alt="image" src="https://github.com/user-attachments/assets/3ab03619-7493-49cb-b957-47a43c599502" />

