### PR TITLE
fix(2261): hardcode library intro authors bios

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -84,7 +84,6 @@ from .tasks import (
 
 from libraries.models import Library, LibraryVersion
 from libraries.utils import (
-    build_library_intro_context,
     get_commit_data_by_release_for_library,
     commit_data_to_stats_bars,
 )
@@ -1780,6 +1779,48 @@ class V3ComponentDemoView(TemplateView):
 
         context["release_contributor_data"] = context["contributor_data"][:8]
 
+        # Hardcoded for the demo page. The production library intro context is
+        # built by `libraries.utils.build_library_intro_context`; reuse it when
+        # integrating this component into the real library pages.
+        context["library_intro"] = {
+            "library_name": "Boost.Beast.",
+            "description": (
+                "Lightweight utilities that power dozens of other Boost libraries"
+            ),
+            "authors": [
+                {
+                    "name": "Vinnie Falco",
+                    "role": "Author",
+                    "avatar_url": f"{settings.STATIC_URL}img/v3/demo_page/Avatar.png",
+                    "badge_url": (
+                        f"{settings.STATIC_URL}img/v3/badges/badge-first-place.png"
+                    ),
+                    "badge": "",
+                    "bio": "Big C++ fan. Not quite kidney-donation level, but close.",
+                    "profile_url": "",
+                },
+                {
+                    "name": "Alex Wells",
+                    "role": "Contributor",
+                    "avatar_url": f"{settings.STATIC_URL}img/v3/demo_page/Avatar.png",
+                    "badge_url": "",
+                    "badge": "",
+                    "bio": "C++ enthusiast who has worked at Intel and Microsoft.",
+                    "profile_url": "",
+                },
+                {
+                    "name": "Dave Abrahams",
+                    "role": "Contributor",
+                    "avatar_url": f"{settings.STATIC_URL}img/v3/demo_page/Avatar.png",
+                    "badge_url": f"{settings.STATIC_URL}img/v3/badges/badge-bronze.png",
+                    "badge": "",
+                    "bio": "Contributor to Boost since 2009.",
+                    "profile_url": "",
+                },
+            ],
+            "cta_url": "#",
+        }
+
         latest = Version.objects.most_recent()
         if latest:
             lv = (
@@ -1788,7 +1829,6 @@ class V3ComponentDemoView(TemplateView):
                 .first()
             )
             if lv:
-                context["library_intro"] = build_library_intro_context(lv)
                 deps = lv.dependencies.order_by("name")
                 context["dependencies_card_data"] = [
                     {


### PR DESCRIPTION
# Issue: #2261 

## Summary & Context
Hardcode library intros to have authors bios available.

- **Figma link**: https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=492-4408&t=OKjltnhdISNOB9Kx-4
- **Link to components/page:** http://localhost:8000/v3/demo/components/#library-intro-card

## Changes

- Instead of adding the bio to the user model, this just plugs the test data into the demo component page.

## ‼️ Risks & Considerations ‼️
- Bio actual data source must be addressed later on.

## Screenshots

### Figma + Before
<img width="1364" height="610" alt="image" src="https://github.com/user-attachments/assets/642bffb1-fc14-4f0f-9de9-1a4931c6f59a" />


### After
<img width="1069" height="545" alt="library-intro-card" src="https://github.com/user-attachments/assets/4c80338c-2c14-4f70-b345-864455edd2cf" />


## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings
