### PR TITLE
Bug: Correct race condition in release tasks version import

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,7 @@ pytest_plugins = [
     "news.tests.fixtures",
     "users.tests.fixtures",
     "versions.tests.fixtures",
+    "celery.contrib.pytest",
 ]
 
 
@@ -56,3 +57,8 @@ def ensure_github_token_env_variable():
     if not current_value:
         os.environ[VAR_NAME] = VAR_DEFAULT_VALUE
         print(f"Env variable '{VAR_NAME}' not set. Forced to {VAR_DEFAULT_VALUE=}.")
+
+
+@pytest.fixture(scope="session")
+def celery_config():
+    return {"broker_url": "amqp://", "result_backend": "redis://"}

--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,6 @@ pytest_plugins = [
     "news.tests.fixtures",
     "users.tests.fixtures",
     "versions.tests.fixtures",
-    "celery.contrib.pytest",
 ]
 
 

--- a/libraries/management/commands/release_tasks.py
+++ b/libraries/management/commands/release_tasks.py
@@ -64,7 +64,16 @@ class ReleaseTasksManager(ActionsManager):
         ]
 
     def import_versions(self):
-        call_command("import_versions")
+        from versions.tasks import import_versions as import_versions_task
+
+        import_versions_task.apply(
+            kwargs={
+                "delete_versions": False,
+                "new_versions_only": True,
+                "token": None,
+                "purge_after": True,
+            }
+        )
         self.latest_version = Version.objects.with_partials().most_recent()
 
     def import_library_versions(self):

--- a/libraries/management/commands/release_tasks.py
+++ b/libraries/management/commands/release_tasks.py
@@ -21,6 +21,7 @@ from libraries.tasks import update_commits, generate_release_report
 from reports.models import WebsiteStatReport
 from slack.management.commands.fetch_slack_activity import get_my_channels, locked
 from versions.models import Version, ReportConfiguration
+from versions.tasks import import_versions as import_versions_task
 
 User = get_user_model()
 
@@ -64,8 +65,6 @@ class ReleaseTasksManager(ActionsManager):
         ]
 
     def import_versions(self):
-        from versions.tasks import import_versions as import_versions_task
-
         import_versions_task.apply(
             kwargs={
                 "delete_versions": False,

--- a/libraries/management/commands/release_tasks.py
+++ b/libraries/management/commands/release_tasks.py
@@ -83,6 +83,12 @@ class ReleaseTasksManager(ActionsManager):
         self.handled_commits = update_commits(min_version=self.latest_version.name)
 
     def update_website_statistics(self):
+        if not self.latest_version.release_date:
+            self.latest_version = (
+                Version.objects.with_partials()
+                .filter(release_date__isnull=False)
+                .most_recent()
+            )
         report, _ = WebsiteStatReport.objects.get_or_create(version=self.latest_version)
         report.populate_from_api()
 

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -56,6 +56,7 @@ def _import_missing_versions(
     tags = client.get_tags()
 
     r_tags = []
+    base_url = "https://github.com/boostorg/boost/releases/tag/"
     for tag in tags:
         name = tag["name"]
 
@@ -69,7 +70,6 @@ def _import_missing_versions(
         else:
             data = {}
 
-        base_url = "https://github.com/boostorg/boost/releases/tag/"
         Version.objects.with_partials().update_or_create(
             name=name,
             defaults={

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -25,6 +25,65 @@ from versions.releases import (
 logger = structlog.get_logger()
 
 
+def _import_missing_versions(
+    delete_versions=False, new_versions_only=False, token=None
+):
+    """
+    Imports missing Boost releases from github and updates the local database.
+
+    Retrieves the boost release tags from the main github repo, excluding beta releases and release candidates.
+
+    It then creates or updates a Version instance for each tag, then returns those tags for additional task processing.
+
+    Args:
+        delete_versions (bool): If True, deletes all existing Version instances before
+            importing.
+        new_versions_only (bool): If True, only imports versions that do not already
+            exist in the database.
+        token (str): Github API token, if you need to use something other than the
+            setting.
+    """
+
+    if delete_versions:
+        Version.objects.with_partials().all().delete()
+        logger.info("import_versions_deleted_all_versions")
+
+    # delete any versions that were only partially imported so they are re-imported
+    Version.objects.with_partials().filter(fully_imported=False).delete()
+
+    # Get all Boost tags from Github
+    client = GithubAPIClient(token=token)
+    tags = client.get_tags()
+
+    r_tags = []
+    for tag in tags:
+        name = tag["name"]
+
+        if skip_tag(name, new_versions_only):
+            continue
+
+        logger.info(f"import_versions importing version {name=}")
+        # Save the response we got from Github, if present
+        if tag:
+            data = obj2dict(tag)
+        else:
+            data = {}
+
+        base_url = ("https://github.com/boostorg/boost/releases/tag/",)
+        Version.objects.with_partials().update_or_create(
+            name=name,
+            defaults={
+                "github_url": f"{base_url}{name}",
+                "beta": False,
+                "full_release": True,
+                "data": data,
+            },
+        )
+        r_tags.append(tag)
+
+    return r_tags
+
+
 @app.task
 def import_versions(
     delete_versions=False, new_versions_only=False, token=None, purge_after=True
@@ -46,25 +105,16 @@ def import_versions(
         purge_after (bool): If True, call purge_fastly_release_cache after the version
             imports are finished.
     """
-    if delete_versions:
-        Version.objects.with_partials().all().delete()
-        logger.info("import_versions_deleted_all_versions")
 
-    # delete any versions that were only partially imported so they are re-imported
-    Version.objects.with_partials().filter(fully_imported=False).delete()
-
-    # Get all Boost tags from Github
-    client = GithubAPIClient(token=token)
-    tags = client.get_tags()
+    tags = _import_missing_versions(
+        delete_versions=delete_versions,
+        new_versions_only=new_versions_only,
+        token=token,
+    )
 
     import_version_task_group = []
     for tag in tags:
         name = tag["name"]
-
-        if skip_tag(name, new_versions_only):
-            continue
-
-        logger.info(f"import_versions importing version {name=}")
         import_version_task_group.append(import_version.s(name, tag=tag, token=token))
 
     if import_version_task_group:

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -69,7 +69,7 @@ def _import_missing_versions(
         else:
             data = {}
 
-        base_url = ("https://github.com/boostorg/boost/releases/tag/",)
+        base_url = "https://github.com/boostorg/boost/releases/tag/"
         Version.objects.with_partials().update_or_create(
             name=name,
             defaults={

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -25,6 +25,32 @@ from versions.releases import (
 logger = structlog.get_logger()
 
 
+def _upsert_version_from_tag(
+    tag,
+    base_url,
+    beta=False,
+    full_release=True,
+):
+    name = tag["name"]
+
+    # Save the response we got from Github, if present
+    if tag:
+        data = obj2dict(tag)
+    else:
+        data = {}
+
+    version, created = Version.objects.with_partials().update_or_create(
+        name=name,
+        defaults={
+            "github_url": f"{base_url}{name}",
+            "beta": beta,
+            "full_release": full_release,
+            "data": data,
+        },
+    )
+    return version, created
+
+
 def _import_missing_versions(
     delete_versions=False, new_versions_only=False, token=None
 ):
@@ -64,21 +90,7 @@ def _import_missing_versions(
             continue
 
         logger.info(f"import_versions importing version {name=}")
-        # Save the response we got from Github, if present
-        if tag:
-            data = obj2dict(tag)
-        else:
-            data = {}
-
-        Version.objects.with_partials().update_or_create(
-            name=name,
-            defaults={
-                "github_url": f"{base_url}{name}",
-                "beta": False,
-                "full_release": True,
-                "data": data,
-            },
-        )
+        _upsert_version_from_tag(tag, base_url)
         r_tags.append(tag)
 
     return r_tags
@@ -115,7 +127,9 @@ def import_versions(
     import_version_task_group = []
     for tag in tags:
         name = tag["name"]
-        import_version_task_group.append(import_version.s(name, tag=tag, token=token))
+        import_version_task_group.append(
+            import_version.s(name, tag=tag, token=token, perform_upsert=False)
+        )
 
     if import_version_task_group:
         task_group = group(*import_version_task_group)
@@ -173,6 +187,7 @@ def import_version(
     full_release=True,
     base_url="https://github.com/boostorg/boost/releases/tag/",
     get_release_date=True,
+    perform_upsert=True,
 ):
     """Imports a single Boost version from Github and updates the local
     database. Also runs import_release_downloads and import_library_versions
@@ -180,22 +195,13 @@ def import_version(
 
     base_url: Most base_url values will be for tags, but we do save some
     Version objects that are branches and not tags (mainly master and develop).
+
+    perform_upsert: in most contexts, this should save the version, but in the import
+    versions workflow we don't want to double save the versions so set this flag to false
     """
     # Save the response we got from Github, if present
-    if tag:
-        data = obj2dict(tag)
-    else:
-        data = {}
-
-    version, created = Version.objects.with_partials().update_or_create(
-        name=name,
-        defaults={
-            "github_url": f"{base_url}{name}",
-            "beta": beta,
-            "full_release": full_release,
-            "data": data,
-        },
-    )
+    if perform_upsert:
+        version, created = _upsert_version_from_tag(tag, base_url, beta, full_release)
 
     logger.info(f"import_versions_version {created=} {name=} {version.pk} ")
 

--- a/versions/tests/test_tasks.py
+++ b/versions/tests/test_tasks.py
@@ -1,8 +1,11 @@
 from datetime import datetime
 from unittest.mock import MagicMock, patch
+from versions.models import Version
 from versions.tasks import get_release_date_for_version, skip_tag
+from libraries.management.commands.release_tasks import ReleaseTasksManager
 
 import pytest
+import time
 
 
 @pytest.fixture
@@ -51,8 +54,37 @@ def test_skip_tag(version):
     assert skip_tag("sample") is False
 
 
-def test_import_version_race_condition(version):
+@pytest.mark.celery(CELERY_TASK_ALWAYS_EAGER=True)
+@pytest.mark.django_db
+@patch("versions.tasks.import_version.run")
+@patch("versions.tasks.import_release_notes.run")
+@patch("versions.tasks.mark_fully_completed.run")
+@patch("versions.tasks.GithubAPIClient.get_tags")
+def test_import_version_race_condition(tag_mock: MagicMock, *args):
     """
     Test that when run synchronously the get_versions task does all deletion and creation
     of versions before returning
     """
+    tag_mock.return_value = [{"name": "boost-1.91.0", "data": {}}]
+    # This object is not competely imported, so should be deleted during import
+    v, _ = Version.objects.with_partials().update_or_create(
+        name="boost-1.91.0",
+        defaults={
+            "github_url": "",
+            "beta": False,
+            "full_release": True,
+            "data": {},
+        },
+    )
+    rm = ReleaseTasksManager("", "")
+    # Ensure that a newly created manager has no latest version
+    assert rm.latest_version is None
+    rm.import_versions()
+    rm_latest_version = rm.latest_version
+    # Ensure that we have a latest version
+    assert rm.latest_version is not None
+    # Ensure that that latest version is not our previously created version
+    assert rm.latest_version != v
+    time.sleep(1)
+    # Make sure the version doesn't change mid task run
+    assert rm.latest_version == rm_latest_version

--- a/versions/tests/test_tasks.py
+++ b/versions/tests/test_tasks.py
@@ -49,3 +49,10 @@ def test_skip_tag(version):
 
     # Assert a random tag name is not skipped
     assert skip_tag("sample") is False
+
+
+def test_import_version_race_condition(version):
+    """
+    Test that when run synchronously the get_versions task does all deletion and creation
+    of versions before returning
+    """

--- a/versions/tests/test_tasks.py
+++ b/versions/tests/test_tasks.py
@@ -5,7 +5,6 @@ from versions.tasks import get_release_date_for_version, skip_tag
 from libraries.management.commands.release_tasks import ReleaseTasksManager
 
 import pytest
-import time
 
 
 @pytest.fixture
@@ -54,7 +53,6 @@ def test_skip_tag(version):
     assert skip_tag("sample") is False
 
 
-@pytest.mark.celery(CELERY_TASK_ALWAYS_EAGER=True)
 @pytest.mark.django_db
 @patch("versions.tasks.import_version.run")
 @patch("versions.tasks.import_release_notes.run")
@@ -80,11 +78,7 @@ def test_import_version_race_condition(tag_mock: MagicMock, *args):
     # Ensure that a newly created manager has no latest version
     assert rm.latest_version is None
     rm.import_versions()
-    rm_latest_version = rm.latest_version
     # Ensure that we have a latest version
     assert rm.latest_version is not None
     # Ensure that that latest version is not our previously created version
     assert rm.latest_version != v
-    time.sleep(1)
-    # Make sure the version doesn't change mid task run
-    assert rm.latest_version == rm_latest_version


### PR DESCRIPTION
## Summary & Context
<!-- *1-2 sentences describing what this PR does and why* -->
Corrects a long standing bug in the release tasks import version process caused by a race condition.

Bug summary as follows:
- During the `import_versions` task of the `ReleaseTaskManager`, the action would first call the `import_versions` management command, and then grab the most recent Version
- The management command runs asynchronously, removing any incompletely imported versions and re importing them.
- This leads to two bugs: There is no guarantee that the most recent version grabbed is actually the most recent (since others are still importing) and the reported bug, which occurs when the most recent version is incompletely imported. Since this version is deleted during the import, when the TaskManager later references it it breaks and fails.

## Changes

- Moves deletion of Versions into its own helper function that is run first in the import process.
- Runs the import_versions task synchronously rather than as a command, to make sure all version creation/deletion has occurred before we grab the version.
- All parallelizable steps are still in parallel.

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*

