### PR TITLE
fix(2327): limit horizontal layout to 3 posts

### DIFF
--- a/templates/v3/includes/_post_card.html
+++ b/templates/v3/includes/_post_card.html
@@ -27,6 +27,7 @@
   {% if items %}
     <ul class="card-group__list">
       {% for item in items %}
+        {% if layout != "horizontal" or forloop.counter0 < 3 %}
         <li class="card-group__item">
           {% if item.title or item.url or item.date or item.category or item.tag %}
             <article class="post-card">
@@ -52,6 +53,7 @@
             </article>
           {% endif %}
         </li>
+        {% endif %}
       {% endfor %}
     </ul>
   {% endif %}


### PR DESCRIPTION
# Issue: #2327

## Summary & Context
Fixes the layout issues by limiting the component to 3 posts when variant is horizontal.

- **Figma link**: https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=403-6216&t=OKjltnhdISNOB9Kx-4
- **Link to components/page:** http://localhost:8000/v3/demo/components/#post-cards-card-teal-horizontal

## Changes

- At template level, limit posts to 3 when variant is horizontal.

## ‼️ Risks & Considerations ‼️
- This is a failsafe at component level, but the actual query in the view should efficiently query the 3 to display.

## Screenshots

### Before
<img width="978" height="404" alt="image" src="https://github.com/user-attachments/assets/08c18fe6-b2c3-49ac-bd00-450b82f561d6" />

### After
<img width="1006" height="398" alt="image" src="https://github.com/user-attachments/assets/67df142b-0f5e-46eb-8b49-aaeacce64167" />



## Self-review Checklist

- [x] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings
