### PR TITLE
Fix: Hide the header in the iframe on documentation page

### DIFF
--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -176,7 +176,10 @@ def modernize_legacy_page(
     """Modernize a legacy Boost documentation page."""
     HIDE_TAGS_BASE = []
     if not show_navbar:
+        # Legacy navbar
         HIDE_TAGS_BASE.append(("div", {"class": "header-menu-bar topnavbar"})),
+        # V3 navbar
+        HIDE_TAGS_BASE.append(("header", {"class": "header"}))
 
     if soup.html is None:
         # Not an HTML file we care about

--- a/templates/v3/includes/_header_v3.html
+++ b/templates/v3/includes/_header_v3.html
@@ -16,6 +16,10 @@
 
   Usage:
     {% include "v3/includes/_header_v3.html" %}
+
+  Note: This header is also rendered inside the iframe on the doc page and is
+  hidden there by core/htmlhelper.py. If you change the .header class name,
+  update the matching HIDE_TAGS_BASE entry in core/htmlhelper.py.
 {% endcomment %}
 <header class="header">
   <div class="header__inner">


### PR DESCRIPTION
## Summary & Context
Bug: V3 documentation pages was displaying a duplicate site header inside the iframe. `htmlhelper.modernize_legacy_page `was only hiding the old `.header-menu-bar.topnavbar` element, leaving the new `<header class="header">` visible. This PR extends `modernize_legacy_page` to also hide `<header class="header">` so the iframe renders cleanly.

- **Link to page**: http://localhost:8000/doc/contributor-guide/

## Changes
- Fix duplicate header in the doc-page iframe by adding `<header class="header">` to `HIDE_TAGS_BASE` in `core/htmlhelper.py` alongside the existing legacy navbar entry
- Add a note in `_header_v3.html` flagging that the header is rendered inside the doc iframe and that any change to the `.header` class name must be mirrored in `core/htmlhelper.py`


## Risks & Considerations
- The hide rule matches on the literal class string `"header"`. Renaming or extending the root header class would silently re-introduce the duplicate navbar – the new template comment is intended to bring attention to this matter.

## Screenshots
| Before | After |
|--------|-------|
| <img width="1446" height="1051" alt="image" src="https://github.com/user-attachments/assets/9589e20c-3d3c-425e-9e14-0eec6b2ecbd9" /> | <img width="1920" height="1080" alt="Screenshot 2026-05-06 at 10 46 54 AM" src="https://github.com/user-attachments/assets/ebb7b224-eb59-4b36-9a98-4e6c38a6b187" /> |


## Screenshots

<!-- Before | After
-- | -- -->

<!-- Desktop Light Mode | Desktop Dark Mode | Mobile
-- | -- | -- -->


## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings
