### PR TITLE
Mailman api variables

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -379,6 +379,11 @@ else:
 
 MAILMAN_CORE_DATABASE = env("MAILMAN_CORE_DATABASE", default="unknown")
 
+# Mailman API credentials
+MAILMAN_REST_API_URL = env("MAILMAN_REST_API_URL", default="http://localhost:8001")
+MAILMAN_REST_API_USER = env("MAILMAN_REST_API_USER", default="restadmin")
+MAILMAN_REST_API_PASS = env("MAILMAN_REST_API_PASS", default="restpass")
+
 # Fastly API credentials
 FASTLY_SERVICE = env("FASTLY_SERVICE", default="empty")
 FASTLY_SERVICE2 = env("FASTLY_SERVICE2", default="empty")

--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -146,6 +146,21 @@ Env:
         key: key
   - name: MAILGUN_SENDER_DOMAIN
     value: cppal-dev.boost.cppalliance.org
+  - name: MAILMAN_REST_API_URL
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_url
+  - name: MAILMAN_REST_API_USER
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_user
+  - name: MAILMAN_REST_API_PASS
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_pass
   - name: MAILMAN_CORE_DATABASE
     valueFrom:
       secretKeyRef:

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -146,6 +146,21 @@ Env:
         key: key
   - name: MAILGUN_SENDER_DOMAIN
     value: boost.cppalliance.org
+  - name: MAILMAN_REST_API_URL
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_url
+  - name: MAILMAN_REST_API_USER
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_user
+  - name: MAILMAN_REST_API_PASS
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_pass
   - name: MAILMAN_CORE_DATABASE
     valueFrom:
       secretKeyRef:

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -146,6 +146,21 @@ Env:
         key: key
   - name: MAILGUN_SENDER_DOMAIN
     value: stage.boost.cppalliance.org
+  - name: MAILMAN_REST_API_URL
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_url
+  - name: MAILMAN_REST_API_USER
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_user
+  - name: MAILMAN_REST_API_PASS
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_pass
   - name: MAILMAN_CORE_DATABASE
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
Returns three environment variables that existed in the past and had been removed.  

MAILMAN_REST_API_URL
MAILMAN_REST_API_USER
MAILMAN_REST_API_PASS

The format of an api call would be similar to these curl command:

```
curl -u user:passwd https://lists.cppal-dev.boost.cppalliance.org/api-proxy/3.1/lists

curl -u $MAILMAN_REST_API_USER:$MAILMAN_REST_API_PASS $MAILMAN_REST_API_URL/api-proxy/3.1/lists

```

From any official mailman3 documentation, add an extra `/api-proxy/` to the path, as shown above.

@herzog0 