### PR TITLE
Story 2383: Image reduction for Upload Post Images

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -700,3 +700,9 @@ WAGTAILMARKDOWN = {
     "extensions_settings_mode": "extend",  # optional. Possible values: "extend" or "override". Defaults to "extend".
     "tab_length": 4,  # optional. Sets the length of tabs used by python-markdown to render the output. This is the number of spaces used to replace with a tab character. Defaults to 4.
 }
+
+
+# DOWNSCALING PREFERRED VALUES
+DOWNSCALED_HEIGHT = 720  # Preferred height to downscale to
+DOWNSCALED_WIDTH = 1440  # preferred width to downscale to
+DOWNSCALE_THRESHOLD = 1 * 1024 * 1024  # threshold overwhich to downscale

--- a/config/settings.py
+++ b/config/settings.py
@@ -703,6 +703,6 @@ WAGTAILMARKDOWN = {
 
 
 # DOWNSCALING PREFERRED VALUES
-DOWNSCALED_HEIGHT = 720  # Preferred height to downscale to
-DOWNSCALED_WIDTH = 1440  # preferred width to downscale to
-DOWNSCALE_THRESHOLD = 1 * 1024 * 1024  # threshold overwhich to downscale
+DOWNSCALED_IMAGE_HEIGHT = 720  # Preferred height to downscale to
+DOWNSCALED_IMAGE_WIDTH = 1440  # preferred width to downscale to
+DOWNSCALE_IMAGE_THRESHOLD = 1 * 1024 * 1024  # threshold overwhich to downscale

--- a/news/tests/test_utils.py
+++ b/news/tests/test_utils.py
@@ -1,5 +1,4 @@
 from io import BytesIO
-from sys import getsizeof
 from PIL import Image
 
 from django.core.files.uploadedfile import UploadedFile
@@ -13,10 +12,11 @@ def test_downscale_image():
     test_image = Image.effect_noise((1920 * 2, 1080 * 2), 100)
     b_io = BytesIO()
     test_image.save(b_io, format="png")
+    b_io.seek(0)
     test_upload = UploadedFile(b_io, "test_image.png")
 
     r_upload = downsize_uploaded_image(test_upload)
 
-    assert getsizeof(test_upload.file) > settings.DOWNSCALE_THRESHOLD
-    assert getsizeof(r_upload.file) < settings.DOWNSCALE_THRESHOLD
+    assert test_upload.file.getbuffer().nbytes > settings.DOWNSCALE_IMAGE_THRESHOLD
+    assert r_upload.file.getbuffer().nbytes < settings.DOWNSCALE_IMAGE_THRESHOLD
     assert r_upload.name == "test_image.webp"

--- a/news/tests/test_utils.py
+++ b/news/tests/test_utils.py
@@ -1,0 +1,22 @@
+from io import BytesIO
+from sys import getsizeof
+from PIL import Image
+
+from django.core.files.uploadedfile import UploadedFile
+from django.conf import settings
+
+from news.utils import downsize_uploaded_image
+
+
+def test_downscale_image():
+    # Image that is far too large
+    test_image = Image.effect_noise((1920 * 2, 1080 * 2), 100)
+    b_io = BytesIO()
+    test_image.save(b_io, format="png")
+    test_upload = UploadedFile(b_io, "test_image.png")
+
+    r_upload = downsize_uploaded_image(test_upload)
+
+    assert getsizeof(test_upload.file) > settings.DOWNSCALE_THRESHOLD
+    assert getsizeof(r_upload.file) < settings.DOWNSCALE_THRESHOLD
+    assert r_upload.name == "test_image.webp"

--- a/news/tests/test_utils.py
+++ b/news/tests/test_utils.py
@@ -8,15 +8,78 @@ from news.utils import downsize_uploaded_image
 
 
 def test_downscale_image():
+    """
+    Rigorous test of basic usage of the dowscale functionality:
+
+        * Basic sanity test that we produce an image large enough to be downscaled
+        * Test that the downscaled image is smaller than our threshold
+        * Test that the image was renamed properly
+        * Test that the aspect ratio has not mutated when downscaling (portrait remains portrait as well)
+        * Test that we actually hit our preferred width/height values when downscaling
+    """
     # Image that is far too large
-    test_image = Image.effect_noise((1920 * 2, 1080 * 2), 100)
-    b_io = BytesIO()
-    test_image.save(b_io, format="png")
-    b_io.seek(0)
-    test_upload = UploadedFile(b_io, "test_image.png")
+    initial_width = 1920 * 2
+    initial_height = 1080 * 2
+    initial_aspect = initial_width / initial_height
+    test_image = Image.effect_noise((initial_width, initial_height), 100)
+    img = BytesIO()
+    test_image.save(img, format="png")
+    img.seek(0)
+    test_upload = UploadedFile(img, "test_image.png")
 
     r_upload = downsize_uploaded_image(test_upload)
 
+    # Tests to assert basic functionality of the downscale
     assert test_upload.file.getbuffer().nbytes > settings.DOWNSCALE_IMAGE_THRESHOLD
     assert r_upload.file.getbuffer().nbytes < settings.DOWNSCALE_IMAGE_THRESHOLD
     assert r_upload.name == "test_image.webp"
+
+    # Tests to assert our output hasn't mutated
+    downscale_image = Image.open(r_upload.file)
+    width, height = downscale_image.size
+    assert width / height == initial_aspect
+
+    # Assert that we actually are smaller than specified settings
+    assert width <= settings.DOWNSCALED_IMAGE_WIDTH
+    assert height <= settings.DOWNSCALED_IMAGE_HEIGHT
+
+
+def test_upscaled_edgecase():
+    """
+    Test that if an image smaller than our preferred width/height somehow makes it in,
+    it doesn't somehow end up upscaled
+    """
+    # Image that is smaller than our minimum size
+    initial_width = settings.DOWNSCALED_IMAGE_WIDTH - 1
+    initial_height = settings.DOWNSCALED_IMAGE_HEIGHT - 1
+    test_image = Image.effect_noise((initial_width, initial_height), 1)
+    img = BytesIO()
+    test_image.save(img, format="png")
+    img.seek(0)
+    test_upload = UploadedFile(img, "test_image.png")
+
+    r_upload = downsize_uploaded_image(test_upload)
+
+    # Image should not have changed, other than being turned into a webp
+    downscale_image = Image.open(r_upload.file)
+    width, height = downscale_image.size
+    assert r_upload.name == "test_image.webp"
+    assert width == initial_width
+    assert height == initial_height
+
+
+def test_name_edgecase():
+    """
+    Test that if we try to downscale an image with a name containing an extension (e.g. png_test.png)
+    that it properly strips the extension, but doesn't mutate the file name
+    """
+    initial_width = 1920
+    initial_height = 1080
+    test_image = Image.effect_noise((initial_width, initial_height), 1)
+    img = BytesIO()
+    test_image.save(img, format="png")
+    img.seek(0)
+    test_upload = UploadedFile(img, "png_test.png")
+
+    r_upload = downsize_uploaded_image(test_upload)
+    assert r_upload.name == "png_test.webp"

--- a/news/utils.py
+++ b/news/utils.py
@@ -1,8 +1,12 @@
+import math
 import requests
 import typing
 from io import BytesIO
+from PIL import Image as PImage
 
+from django.conf import settings
 from django.core.files import File
+from django.core.files.uploadedfile import UploadedFile
 from wagtail.images.models import Image
 
 if typing.TYPE_CHECKING:
@@ -37,3 +41,55 @@ def set_video_thumbnail(video: "Video"):
     )
     video.thumbnail = image
     video.save()
+
+
+def downsize_uploaded_image(image: UploadedFile) -> UploadedFile:
+    """
+    Takes a given image file from an upload form, and returns a downscaled image
+    to take better use of available storage space.
+
+    Does not handle the initial size comparison to determin if the image should be downsized.
+
+    Downsizes the images using three methods:
+        1) Downscales the image to specified parameters in the settings, maintaining the aspect ratio
+        2) Converts the image to webp
+        3) Uses Pillows built in compression algorithm to do available compression during saving
+
+    Example Usage:
+
+        def clean_image(self):
+        image = self.cleaned_data.get("image", None)
+        if image and image.size > settings.DOWNSCALE_THRESHOLD:
+            return downsize_uploaded_image(image)
+        return image
+    """
+
+    with PImage.open(image) as im:
+        file_name = image.name
+        if image_format := im.format:
+            file_name = file_name.strip(image_format.lower())
+            file_name += "webp"
+
+        width, height = im.size
+        p_width, p_height = None, None  # Preferred output image width and height
+        s_width, s_height = (
+            settings.DOWNSCALED_WIDTH,
+            settings.DOWNSCALED_HEIGHT,
+        )  # Settings based prefferred width and height
+
+        # Scale the preferred width and height in a proportional manner, to not skew the image
+
+        # Scale based on the dimension that is further off from preferred dimensions
+        if width - s_width >= height - s_height:
+            p_width = s_width
+            p_height = math.floor((p_width / width) * height)
+        else:
+            p_height = s_height
+            p_width = math.floor((p_height / height) * width)
+
+        r_image = im.resize((p_width, p_height))
+
+        # Save to a BytesIO, actual file system saving will be handled by the form calling this function
+        imgstr = BytesIO()
+        r_image.save(imgstr, format="webp")
+        return UploadedFile(imgstr, name=file_name)

--- a/news/utils.py
+++ b/news/utils.py
@@ -98,6 +98,6 @@ def downsize_uploaded_image(image: UploadedFile) -> UploadedFile:
         return UploadedFile(
             img,
             name=file_name,
-            content_type=image.content_type,
+            content_type="image/webp",
             size=img.getbuffer().nbytes,
         )

--- a/news/utils.py
+++ b/news/utils.py
@@ -3,6 +3,7 @@ import requests
 import typing
 from io import BytesIO
 from PIL import Image as PImage
+from PIL import ImageOps
 
 from django.conf import settings
 from django.core.files import File
@@ -76,9 +77,12 @@ def downsize_uploaded_image(image: UploadedFile) -> UploadedFile:
             settings.DOWNSCALED_IMAGE_HEIGHT,
         )  # Settings based preferred width and height
 
+        # Bake EXIF orientation into pixels so portrait phone photos don't end up sideways
+        im = ImageOps.exif_transpose(im)
+
         # Use the thumbnail functionality to reduce this image to our preferred width and height.
         # Maintains aspect ratio, and won't ever upscale.
-        im.thumbnail((s_width, s_height))
+        im.thumbnail((s_width, s_height), PImage.Resampling.LANCZOS)
 
         # Save to a BytesIO, actual file system saving will be handled by the form calling this function
         img = BytesIO()

--- a/news/utils.py
+++ b/news/utils.py
@@ -1,4 +1,3 @@
-import math
 import os
 import requests
 import typing
@@ -72,28 +71,18 @@ def downsize_uploaded_image(image: UploadedFile) -> UploadedFile:
             file_name = root
             file_name += ".webp"
 
-        width, height = im.size
-        p_width, p_height = None, None  # Preferred output image width and height
         s_width, s_height = (
             settings.DOWNSCALED_IMAGE_WIDTH,
             settings.DOWNSCALED_IMAGE_HEIGHT,
         )  # Settings based preferred width and height
 
-        # Scale the preferred width and height in a proportional manner, to not skew the image
-
-        # Scale based on the dimension that is further off from preferred dimensions
-        if width - s_width >= height - s_height:
-            p_width = s_width
-            p_height = math.floor((p_width / width) * height)
-        else:
-            p_height = s_height
-            p_width = math.floor((p_height / height) * width)
-
-        r_image = im.resize((p_width, p_height))
+        # Use the thumbnail functionality to reduce this image to our preferred width and height.
+        # Maintains aspect ratio, and won't ever upscale.
+        im.thumbnail((s_width, s_height))
 
         # Save to a BytesIO, actual file system saving will be handled by the form calling this function
         img = BytesIO()
-        r_image.save(img, format="webp")
+        im.save(img, format="webp")
         img.seek(0)
         return UploadedFile(
             img,

--- a/news/utils.py
+++ b/news/utils.py
@@ -1,4 +1,5 @@
 import math
+import os
 import requests
 import typing
 from io import BytesIO
@@ -48,34 +49,35 @@ def downsize_uploaded_image(image: UploadedFile) -> UploadedFile:
     Takes a given image file from an upload form, and returns a downscaled image
     to take better use of available storage space.
 
-    Does not handle the initial size comparison to determin if the image should be downsized.
+    Does not handle the initial size comparison to determine if the image should be downsized.
 
     Downsizes the images using three methods:
         1) Downscales the image to specified parameters in the settings, maintaining the aspect ratio
         2) Converts the image to webp
-        3) Uses Pillows built in compression algorithm to do available compression during saving
+        3) Uses Pillow's built in compression algorithm to do available compression during saving
 
     Example Usage:
 
         def clean_image(self):
-        image = self.cleaned_data.get("image", None)
-        if image and image.size > settings.DOWNSCALE_THRESHOLD:
-            return downsize_uploaded_image(image)
-        return image
+            image = self.cleaned_data.get("image", None)
+            if image and image.size > settings.DOWNSCALE_IMAGE_THRESHOLD:
+                return downsize_uploaded_image(image)
+            return image
     """
 
     with PImage.open(image) as im:
         file_name = image.name
-        if image_format := im.format:
-            file_name = file_name.strip(image_format.lower())
-            file_name += "webp"
+        root, ext = os.path.splitext(file_name)
+        if root:
+            file_name = root
+            file_name += ".webp"
 
         width, height = im.size
         p_width, p_height = None, None  # Preferred output image width and height
         s_width, s_height = (
-            settings.DOWNSCALED_WIDTH,
-            settings.DOWNSCALED_HEIGHT,
-        )  # Settings based prefferred width and height
+            settings.DOWNSCALED_IMAGE_WIDTH,
+            settings.DOWNSCALED_IMAGE_HEIGHT,
+        )  # Settings based preferred width and height
 
         # Scale the preferred width and height in a proportional manner, to not skew the image
 
@@ -90,6 +92,12 @@ def downsize_uploaded_image(image: UploadedFile) -> UploadedFile:
         r_image = im.resize((p_width, p_height))
 
         # Save to a BytesIO, actual file system saving will be handled by the form calling this function
-        imgstr = BytesIO()
-        r_image.save(imgstr, format="webp")
-        return UploadedFile(imgstr, name=file_name)
+        img = BytesIO()
+        r_image.save(img, format="webp")
+        img.seek(0)
+        return UploadedFile(
+            img,
+            name=file_name,
+            content_type=image.content_type,
+            size=img.getbuffer().nbytes,
+        )


### PR DESCRIPTION
# Issue: #2383 

## Summary & Context
<!-- *1-2 sentences describing what this PR does and why* -->
Adds a helper function to allow for downscaling of uploaded images if they are over the size threshold.

## Changes

- Adds `downsize_uploaded_image` to `news/utils.py`, which accepts an uploaded image, downscales it, and returns it for consumption
- Adds three values to settings values which control this downsizing: DOWNSCALED_HEIGHT, DOWNSCALED_WIDTH, DOWNSCALE_THRESHOLD 
- Adds a test to ensure that the downscaling is reaching our established thresholds.


## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [x] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket
