### PR TITLE
Story #2435: Webpage Integration: Posts Ranking Algorithm

### DIFF
--- a/ak/views.py
+++ b/ak/views.py
@@ -141,19 +141,19 @@ class HomepageView(V3Mixin, ContributorMixin, TemplateView):
         tag_display = {"blogpost": "Blog"}
         popular_entries = (
             Entry.objects.ranked()
-            .filter(deleted_at__isnull=True)
+            .filter(deleted_at__isnull=True, published=True)
             .select_related("author")[:5]
         )
         ctx["posts_from_the_boost_community"] = {
             "heading": "Posts from the Boost Community",
             "primary_cta_label": "View all posts",
-            "primary_cta_url": self.request.build_absolute_uri(reverse("news")),
+            "primary_cta_url": reverse("news"),
             "variant": "card",
             "theme": "teal",
             "items": [
                 {
                     "title": entry.title,
-                    "url": self.request.build_absolute_uri(entry.get_absolute_url()),
+                    "url": entry.get_absolute_url(),
                     "date": entry.publish_at,
                     "category": (
                         tag_display.get(str(entry.tag).lower(), entry.tag.capitalize())
@@ -161,12 +161,7 @@ class HomepageView(V3Mixin, ContributorMixin, TemplateView):
                         else ""
                     ),
                     "tag": "",
-                    "author": {
-                        "name": entry.author.display_name
-                        or entry.author.get_full_name(),
-                        "avatar_url": entry.author.get_avatar_url(),
-                        "role": "",
-                    },
+                    "author": entry.author.to_v3_profile_dict(""),
                 }
                 for entry in popular_entries
             ],

--- a/ak/views.py
+++ b/ak/views.py
@@ -4,6 +4,7 @@ from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse
 from django.shortcuts import render
+from django.urls import reverse
 from django.views import View
 from django.views.generic import TemplateView
 
@@ -137,13 +138,38 @@ class HomepageView(V3Mixin, ContributorMixin, TemplateView):
             "primary_button_url": "www.example.com",
             "primary_button_label": "Explore Our History",
         }
+        tag_display = {"blogpost": "Blog"}
+        popular_entries = (
+            Entry.objects.ranked()
+            .filter(deleted_at__isnull=True)
+            .select_related("author")[:5]
+        )
         ctx["posts_from_the_boost_community"] = {
             "heading": "Posts from the Boost Community",
             "primary_cta_label": "View all posts",
-            "primary_cta_url": "#",
+            "primary_cta_url": self.request.build_absolute_uri(reverse("news")),
             "variant": "card",
             "theme": "teal",
-            "items": SharedResources.demo_posts[:5],
+            "items": [
+                {
+                    "title": entry.title,
+                    "url": self.request.build_absolute_uri(entry.get_absolute_url()),
+                    "date": entry.publish_at,
+                    "category": (
+                        tag_display.get(str(entry.tag).lower(), entry.tag.capitalize())
+                        if entry.tag
+                        else ""
+                    ),
+                    "tag": "",
+                    "author": {
+                        "name": entry.author.display_name
+                        or entry.author.get_full_name(),
+                        "avatar_url": entry.author.get_avatar_url(),
+                        "role": "",
+                    },
+                }
+                for entry in popular_entries
+            ],
         }
         ctx["join_developers_building_the_future_of_cpp"] = {
             "items": SharedResources.demo_join_community_links[:5]

--- a/ak/views.py
+++ b/ak/views.py
@@ -161,7 +161,7 @@ class HomepageView(V3Mixin, ContributorMixin, TemplateView):
                         else ""
                     ),
                     "tag": "",
-                    "author": entry.author.to_v3_profile_dict(""),
+                    "author": entry.author.to_v3_profile_dict(),
                 }
                 for entry in popular_entries
             ],

--- a/config/celery.py
+++ b/config/celery.py
@@ -118,3 +118,9 @@ def setup_periodic_tasks(sender, **kwargs):
         crontab(day_of_week="sun", hour=2, minute=0),
         app.signature("asciidoctor_sandbox.tasks.cleanup_old_sandbox_documents"),
     )
+
+    # Sync per-post page views from Plausible. Executes daily at 6:00 AM.
+    sender.add_periodic_task(
+        crontab(hour=6, minute=0),
+        app.signature("news.tasks.sync_post_views_from_plausible"),
+    )

--- a/config/settings.py
+++ b/config/settings.py
@@ -627,6 +627,7 @@ RELEASE_NOTES_IN_PROGRESS_CACHE_KEY = "release-notes-in-progress"
 BOOST_CALENDAR = "5rorfm42nvmpt77ac0vult9iig@group.calendar.google.com"
 CALENDAR_API_KEY = env("CALENDAR_API_KEY", default="changeme")
 PLAUSIBLE_STATS_KEY = env("PLAUSIBLE_STATS_KEY", default="changeme")
+POSTS_RANKING_GRAVITY = env.float("POSTS_RANKING_GRAVITY", default=2.0)
 EVENTS_CACHE_KEY = "homepage_events"
 EVENTS_CACHE_TIMEOUT = 300  # 5 min
 

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -94,3 +94,16 @@ This project uses environment variables to configure certain aspects of the appl
 - For **local development**, set this in your `.env` file. Note: docker compose only loads `env_file` at container creation, so after adding the variable run `docker compose up -d --force-recreate web celery-worker celery-beat` to pick it up.
 - In **deployed environments**, set as a kube secret in `kube/boost/values.yaml` (or the environment-specific yaml file).
 - Without this variable set, OpenRouter responds with `401 No cookie auth credentials found` and Celery retries the task up to 3 times before giving up.
+
+### `PLAUSIBLE_STATS_KEY`
+
+- API key for the Plausible Analytics API, used to sync per-post page view counts into `Entry.page_views`.
+- For **local development**, obtain a valid value from the Boost team.
+- In **deployed environments**, the valid value is set in the environment-specific secrets.
+- If not set (or set to `changeme`), the sync task is silently skipped.
+
+### `POSTS_RANKING_GRAVITY`
+
+- Controls the decay rate of the posts ranking algorithm (`score = views / (age_hours + 2) ^ gravity`).
+- Higher values cause recent posts to decay faster and drop in ranking sooner.
+- Defaults to `2.0` if not set.

--- a/env.template
+++ b/env.template
@@ -51,6 +51,8 @@ CELERY_BROKER=redis://redis:6379/0
 CELERY_BACKEND=redis://redis:6379/0
 
 CALENDAR_API_KEY=changeme
+PLAUSIBLE_STATS_KEY=changeme
+POSTS_RANKING_GRAVITY=2.0
 
 # terraform vars for google cloud oauth credential creation for local dev use
 TF_VAR_google_cloud_email=

--- a/justfile
+++ b/justfile
@@ -182,6 +182,9 @@ alias shell := console
 @manage +args:
     docker compose run --rm web python manage.py {{ args }}
 
+@sync_post_views *args:  ## sync per-post page view counts from Plausible (pass --dry-run to preview)
+    docker compose run --rm web python manage.py sync_post_views {{ args }}
+
 # Static File Management
 @down_sync_images:
     scripts/sync-large-static-images.sh --down-sync;

--- a/news/management/commands/sync_post_views.py
+++ b/news/management/commands/sync_post_views.py
@@ -14,13 +14,16 @@ from news.models import Entry
 def command(dry_run):
     """Sync per-post page view counts from Plausible into Entry.page_views."""
 
-    slug_views = fetch_post_views()
+    try:
+        slug_views = fetch_post_views()
+    except (requests.HTTPError, ValueError) as e:
+        raise click.ClickException(str(e)) from e
 
     if not slug_views:
         click.echo("No matching post URLs returned by Plausible.")
         return
 
-    entries = Entry.objects.filter(slug__in=slug_views.keys())
+    entries = list(Entry.objects.filter(slug__in=slug_views.keys()))
     matched = {e.slug: e for e in entries}
 
     if dry_run:
@@ -29,9 +32,5 @@ def command(dry_run):
             click.echo(f"  {slug}: {entry.page_views} -> {slug_views[slug]}")
         return
 
-    try:
-        updated = update_page_views(slug_views)
-    except requests.HTTPError as e:
-        raise click.ClickException(str(e)) from e
-
+    updated = update_page_views(slug_views, entries=entries)
     click.echo(f"Updated page_views for {updated} entries.")

--- a/news/management/commands/sync_post_views.py
+++ b/news/management/commands/sync_post_views.py
@@ -1,14 +1,8 @@
 import djclick as click
 import requests
-import structlog
-from django.conf import settings
 
+from news.plausible import fetch_post_views, update_page_views
 from news.models import Entry
-from reports.constants import WEB_ANALYTICS_API_URL_V2, WEB_ANALYTICS_DOMAIN
-
-logger = structlog.get_logger()
-
-NEWS_ENTRY_PREFIX = "/news/entry/"
 
 
 @click.command()
@@ -20,44 +14,7 @@ NEWS_ENTRY_PREFIX = "/news/entry/"
 def command(dry_run):
     """Sync per-post page view counts from Plausible into Entry.page_views."""
 
-    if not settings.PLAUSIBLE_STATS_KEY or settings.PLAUSIBLE_STATS_KEY == "changeme":
-        click.echo("PLAUSIBLE_STATS_KEY is not configured, skipping.")
-        return
-
-    payload = {
-        "site_id": WEB_ANALYTICS_DOMAIN,
-        "metrics": ["pageviews"],
-        "dimensions": ["event:page"],
-        "filters": [["contains", "event:page", [NEWS_ENTRY_PREFIX]]],
-        "date_range": "all",
-    }
-    headers = {
-        "Content-Type": "application/json; charset=utf-8",
-        "Authorization": f"Bearer {settings.PLAUSIBLE_STATS_KEY}",
-    }
-
-    response = requests.post(
-        url=WEB_ANALYTICS_API_URL_V2, json=payload, headers=headers
-    )
-    if not response.ok:
-        raise click.ClickException(
-            f"Plausible API error {response.status_code}: {response.text}"
-        )
-    data = response.json()
-
-    if not data or "results" not in data:
-        raise ValueError(f"Unexpected Plausible API response: {data}")
-
-    # Build slug → view_count mapping from API results
-    slug_views: dict[str, int] = {}
-    for result in data["results"]:
-        path = result["dimensions"][0]
-        if not path.startswith(NEWS_ENTRY_PREFIX):
-            continue
-        # Strip prefix and trailing slash to get the slug
-        slug = path[len(NEWS_ENTRY_PREFIX) :].rstrip("/")
-        if slug:
-            slug_views[slug] = int(result["metrics"][0])
+    slug_views = fetch_post_views()
 
     if not slug_views:
         click.echo("No matching post URLs returned by Plausible.")
@@ -65,19 +22,16 @@ def command(dry_run):
 
     entries = Entry.objects.filter(slug__in=slug_views.keys())
     matched = {e.slug: e for e in entries}
-    unmatched = set(slug_views) - set(matched)
-
-    if unmatched:
-        logger.warning("sync_post_views.unmatched_slugs", slugs=sorted(unmatched))
 
     if dry_run:
         click.echo(f"Would update {len(matched)} entries (dry run):")
         for slug, entry in matched.items():
-            click.echo(f"  {slug}: {entry.page_views} → {slug_views[slug]}")
+            click.echo(f"  {slug}: {entry.page_views} -> {slug_views[slug]}")
         return
 
-    for entry in matched.values():
-        entry.page_views = slug_views[entry.slug]
+    try:
+        updated = update_page_views(slug_views)
+    except requests.HTTPError as e:
+        raise click.ClickException(str(e)) from e
 
-    Entry.objects.bulk_update(matched.values(), ["page_views"])
-    click.echo(f"Updated page_views for {len(matched)} entries.")
+    click.echo(f"Updated page_views for {updated} entries.")

--- a/news/management/commands/sync_post_views.py
+++ b/news/management/commands/sync_post_views.py
@@ -29,7 +29,7 @@ def command(dry_run):
         "metrics": ["pageviews"],
         "dimensions": ["event:page"],
         "filters": [["contains", "event:page", [NEWS_ENTRY_PREFIX]]],
-        "date_range": "all_time",
+        "date_range": "all",
     }
     headers = {
         "Content-Type": "application/json; charset=utf-8",
@@ -39,7 +39,10 @@ def command(dry_run):
     response = requests.post(
         url=WEB_ANALYTICS_API_URL_V2, json=payload, headers=headers
     )
-    response.raise_for_status()
+    if not response.ok:
+        raise click.ClickException(
+            f"Plausible API error {response.status_code}: {response.text}"
+        )
     data = response.json()
 
     if not data or "results" not in data:

--- a/news/management/commands/sync_post_views.py
+++ b/news/management/commands/sync_post_views.py
@@ -1,0 +1,80 @@
+import djclick as click
+import requests
+import structlog
+from django.conf import settings
+
+from news.models import Entry
+from reports.constants import WEB_ANALYTICS_API_URL_V2, WEB_ANALYTICS_DOMAIN
+
+logger = structlog.get_logger()
+
+NEWS_ENTRY_PREFIX = "/news/entry/"
+
+
+@click.command()
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be updated without writing to the database",
+)
+def command(dry_run):
+    """Sync per-post page view counts from Plausible into Entry.page_views."""
+
+    if not settings.PLAUSIBLE_STATS_KEY or settings.PLAUSIBLE_STATS_KEY == "changeme":
+        click.echo("PLAUSIBLE_STATS_KEY is not configured, skipping.")
+        return
+
+    payload = {
+        "site_id": WEB_ANALYTICS_DOMAIN,
+        "metrics": ["pageviews"],
+        "dimensions": ["event:page"],
+        "filters": [["contains", "event:page", [NEWS_ENTRY_PREFIX]]],
+        "date_range": "all_time",
+    }
+    headers = {
+        "Content-Type": "application/json; charset=utf-8",
+        "Authorization": f"Bearer {settings.PLAUSIBLE_STATS_KEY}",
+    }
+
+    response = requests.post(
+        url=WEB_ANALYTICS_API_URL_V2, json=payload, headers=headers
+    )
+    response.raise_for_status()
+    data = response.json()
+
+    if not data or "results" not in data:
+        raise ValueError(f"Unexpected Plausible API response: {data}")
+
+    # Build slug → view_count mapping from API results
+    slug_views: dict[str, int] = {}
+    for result in data["results"]:
+        path = result["dimensions"][0]
+        if not path.startswith(NEWS_ENTRY_PREFIX):
+            continue
+        # Strip prefix and trailing slash to get the slug
+        slug = path[len(NEWS_ENTRY_PREFIX) :].rstrip("/")
+        if slug:
+            slug_views[slug] = int(result["metrics"][0])
+
+    if not slug_views:
+        click.echo("No matching post URLs returned by Plausible.")
+        return
+
+    entries = Entry.objects.filter(slug__in=slug_views.keys())
+    matched = {e.slug: e for e in entries}
+    unmatched = set(slug_views) - set(matched)
+
+    if unmatched:
+        logger.warning("sync_post_views.unmatched_slugs", slugs=sorted(unmatched))
+
+    if dry_run:
+        click.echo(f"Would update {len(matched)} entries (dry run):")
+        for slug, entry in matched.items():
+            click.echo(f"  {slug}: {entry.page_views} → {slug_views[slug]}")
+        return
+
+    for entry in matched.values():
+        entry.page_views = slug_views[entry.slug]
+
+    Entry.objects.bulk_update(matched.values(), ["page_views"])
+    click.echo(f"Updated page_views for {len(matched)} entries.")

--- a/news/migrations/0014_entry_page_views.py
+++ b/news/migrations/0014_entry_page_views.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("news", "0013_video_thumbnail"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="entry",
+            name="page_views",
+            field=models.PositiveIntegerField(default=0),
+        ),
+    ]

--- a/news/models.py
+++ b/news/models.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 
 from structlog import get_logger
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
-from django.db.models import Case, Value, When
+from django.db.models import Case, ExpressionWrapper, FloatField, F, Func, Value, When
+from django.db.models.functions import Greatest, Now, Power
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.text import slugify
@@ -24,6 +26,12 @@ from .tasks import set_thumbnail_for_video_entry
 
 User = get_user_model()
 logger = get_logger(__name__)
+
+
+class ExtractEpoch(Func):
+    function = "EXTRACT"
+    template = "%(function)s(EPOCH FROM %(expressions)s)"
+    output_field = FloatField()
 
 
 class EntryManager(models.Manager):
@@ -54,6 +62,20 @@ class EntryManager(models.Manager):
 
     def published(self):
         return self.get_queryset().filter(published=True)
+
+    def ranked(self):
+        gravity = float(getattr(settings, "POSTS_RANKING_GRAVITY", 2.0))
+        age_in_hours = ExpressionWrapper(
+            Greatest(ExtractEpoch(Now() - F("publish_at")), Value(0.0)) / Value(3600.0),
+            output_field=FloatField(),
+        )
+        score = ExpressionWrapper(
+            F("page_views") / Power(age_in_hours + Value(2.0), Value(gravity)),
+            output_field=FloatField(),
+        )
+        return (
+            self.get_queryset().annotate(ranking_score=score).order_by("-ranking_score")
+        )
 
 
 class Entry(models.Model):
@@ -102,6 +124,7 @@ class Entry(models.Model):
         blank=True,
         related_name="deleted_entries",
     )
+    page_views = models.PositiveIntegerField(default=0)
 
     objects = EntryManager()
 

--- a/news/plausible.py
+++ b/news/plausible.py
@@ -1,0 +1,80 @@
+import requests
+import structlog
+from django.conf import settings
+
+from news.models import Entry
+from reports.constants import WEB_ANALYTICS_API_URL_V2, WEB_ANALYTICS_DOMAIN
+
+logger = structlog.get_logger(__name__)
+
+NEWS_ENTRY_PREFIX = "/news/entry/"
+
+
+def fetch_post_views() -> dict[str, int]:
+    """Return a slug-to-pageviews mapping fetched from Plausible API v2.
+
+    Returns an empty dict if the API key is not configured or the response
+    contains no matching URLs.
+    Raises requests.HTTPError on a non-2xx response.
+    """
+    if not settings.PLAUSIBLE_STATS_KEY or settings.PLAUSIBLE_STATS_KEY == "changeme":
+        logger.info(
+            "fetch_post_views.skipped", reason="PLAUSIBLE_STATS_KEY not configured"
+        )
+        return {}
+
+    payload = {
+        "site_id": WEB_ANALYTICS_DOMAIN,
+        "metrics": ["pageviews"],
+        "dimensions": ["event:page"],
+        "filters": [["contains", "event:page", [NEWS_ENTRY_PREFIX]]],
+        "date_range": "all",
+    }
+    headers = {
+        "Content-Type": "application/json; charset=utf-8",
+        "Authorization": f"Bearer {settings.PLAUSIBLE_STATS_KEY}",
+    }
+
+    response = requests.post(
+        url=WEB_ANALYTICS_API_URL_V2, json=payload, headers=headers
+    )
+    if not response.ok:
+        raise requests.HTTPError(
+            f"Plausible API error {response.status_code}: {response.text}",
+            response=response,
+        )
+
+    data = response.json()
+    if not data or "results" not in data:
+        raise ValueError(f"Unexpected Plausible API response: {data}")
+
+    slug_views: dict[str, int] = {}
+    for result in data["results"]:
+        path = result["dimensions"][0]
+        if not path.startswith(NEWS_ENTRY_PREFIX):
+            continue
+        slug = path[len(NEWS_ENTRY_PREFIX) :].rstrip("/")
+        if slug:
+            slug_views[slug] = int(result["metrics"][0])
+
+    return slug_views
+
+
+def update_page_views(slug_views: dict[str, int]) -> int:
+    """Bulk-update Entry.page_views from a slug-to-count mapping.
+
+    Returns the number of entries updated.
+    """
+    if not slug_views:
+        return 0
+
+    entries = list(Entry.objects.filter(slug__in=slug_views.keys()))
+    unmatched = set(slug_views) - {e.slug for e in entries}
+    if unmatched:
+        logger.warning("update_page_views.unmatched_slugs", slugs=sorted(unmatched))
+
+    for entry in entries:
+        entry.page_views = slug_views[entry.slug]
+
+    Entry.objects.bulk_update(entries, ["page_views"])
+    return len(entries)

--- a/news/plausible.py
+++ b/news/plausible.py
@@ -60,7 +60,7 @@ def fetch_post_views() -> dict[str, int]:
     return slug_views
 
 
-def update_page_views(slug_views: dict[str, int]) -> int:
+def update_page_views(slug_views: dict[str, int], entries: list | None = None) -> int:
     """Bulk-update Entry.page_views from a slug-to-count mapping.
 
     Returns the number of entries updated.
@@ -68,7 +68,8 @@ def update_page_views(slug_views: dict[str, int]) -> int:
     if not slug_views:
         return 0
 
-    entries = list(Entry.objects.filter(slug__in=slug_views.keys()))
+    if entries is None:
+        entries = list(Entry.objects.filter(slug__in=slug_views.keys()))
     unmatched = set(slug_views) - {e.slug for e in entries}
     if unmatched:
         logger.warning("update_page_views.unmatched_slugs", slugs=sorted(unmatched))

--- a/news/tasks.py
+++ b/news/tasks.py
@@ -149,3 +149,65 @@ def set_thumbnail_for_video_entry(pk: int):
 
     video = Video.objects.get(pk=pk)
     set_video_thumbnail(video)
+
+
+@app.task
+def sync_post_views_from_plausible():
+    """Sync per-post page view counts from Plausible into Entry.page_views."""
+    from django.conf import settings
+
+    import requests as http
+    from news.models import Entry
+    from reports.constants import WEB_ANALYTICS_API_URL_V2, WEB_ANALYTICS_DOMAIN
+
+    if not settings.PLAUSIBLE_STATS_KEY or settings.PLAUSIBLE_STATS_KEY == "changeme":
+        logger.info(
+            "sync_post_views.skipped", reason="PLAUSIBLE_STATS_KEY not configured"
+        )
+        return
+
+    news_entry_prefix = "/news/entry/"
+    payload = {
+        "site_id": WEB_ANALYTICS_DOMAIN,
+        "metrics": ["pageviews"],
+        "dimensions": ["event:page"],
+        "filters": [["contains", "event:page", [news_entry_prefix]]],
+        "date_range": "all",
+    }
+    headers = {
+        "Content-Type": "application/json; charset=utf-8",
+        "Authorization": f"Bearer {settings.PLAUSIBLE_STATS_KEY}",
+    }
+
+    response = http.post(url=WEB_ANALYTICS_API_URL_V2, json=payload, headers=headers)
+    if not response.ok:
+        logger.error(
+            "sync_post_views.api_error",
+            status=response.status_code,
+            body=response.text,
+        )
+        return
+
+    data = response.json()
+    if not data or "results" not in data:
+        logger.error("sync_post_views.unexpected_response", data=data)
+        return
+
+    slug_views: dict[str, int] = {}
+    for result in data["results"]:
+        path = result["dimensions"][0]
+        if not path.startswith(news_entry_prefix):
+            continue
+        slug = path[len(news_entry_prefix) :].rstrip("/")
+        if slug:
+            slug_views[slug] = int(result["metrics"][0])
+
+    if not slug_views:
+        logger.info("sync_post_views.no_results")
+        return
+
+    entries = list(Entry.objects.filter(slug__in=slug_views.keys()))
+    for entry in entries:
+        entry.page_views = slug_views[entry.slug]
+    Entry.objects.bulk_update(entries, ["page_views"])
+    logger.info("sync_post_views.done", updated=len(entries))

--- a/news/tasks.py
+++ b/news/tasks.py
@@ -154,60 +154,17 @@ def set_thumbnail_for_video_entry(pk: int):
 @app.task
 def sync_post_views_from_plausible():
     """Sync per-post page view counts from Plausible into Entry.page_views."""
-    from django.conf import settings
+    from news.plausible import fetch_post_views, update_page_views
 
-    import requests as http
-    from news.models import Entry
-    from reports.constants import WEB_ANALYTICS_API_URL_V2, WEB_ANALYTICS_DOMAIN
-
-    if not settings.PLAUSIBLE_STATS_KEY or settings.PLAUSIBLE_STATS_KEY == "changeme":
-        logger.info(
-            "sync_post_views.skipped", reason="PLAUSIBLE_STATS_KEY not configured"
-        )
+    try:
+        slug_views = fetch_post_views()
+    except Exception as exc:
+        logger.error("sync_post_views.fetch_failed", error=str(exc))
         return
-
-    news_entry_prefix = "/news/entry/"
-    payload = {
-        "site_id": WEB_ANALYTICS_DOMAIN,
-        "metrics": ["pageviews"],
-        "dimensions": ["event:page"],
-        "filters": [["contains", "event:page", [news_entry_prefix]]],
-        "date_range": "all",
-    }
-    headers = {
-        "Content-Type": "application/json; charset=utf-8",
-        "Authorization": f"Bearer {settings.PLAUSIBLE_STATS_KEY}",
-    }
-
-    response = http.post(url=WEB_ANALYTICS_API_URL_V2, json=payload, headers=headers)
-    if not response.ok:
-        logger.error(
-            "sync_post_views.api_error",
-            status=response.status_code,
-            body=response.text,
-        )
-        return
-
-    data = response.json()
-    if not data or "results" not in data:
-        logger.error("sync_post_views.unexpected_response", data=data)
-        return
-
-    slug_views: dict[str, int] = {}
-    for result in data["results"]:
-        path = result["dimensions"][0]
-        if not path.startswith(news_entry_prefix):
-            continue
-        slug = path[len(news_entry_prefix) :].rstrip("/")
-        if slug:
-            slug_views[slug] = int(result["metrics"][0])
 
     if not slug_views:
         logger.info("sync_post_views.no_results")
         return
 
-    entries = list(Entry.objects.filter(slug__in=slug_views.keys()))
-    for entry in entries:
-        entry.page_views = slug_views[entry.slug]
-    Entry.objects.bulk_update(entries, ["page_views"])
-    logger.info("sync_post_views.done", updated=len(entries))
+    updated = update_page_views(slug_views)
+    logger.info("sync_post_views.done", updated=updated)

--- a/news/tests/test_models.py
+++ b/news/tests/test_models.py
@@ -390,3 +390,26 @@ def test_poll():
 def test_poll_choice():
     choice = baker.make("PollChoice")
     assert isinstance(choice.poll, Poll)
+
+
+def test_ranked_annotates_ranking_score(make_entry):
+    make_entry(page_views=50)
+    entry = Entry.objects.ranked().first()
+    assert hasattr(entry, "ranking_score")
+    assert entry.ranking_score >= 0
+
+
+def test_ranked_orders_by_views_when_age_equal(make_entry):
+    same_time = now() - datetime.timedelta(hours=10)
+    low = make_entry(page_views=10, publish_at=same_time)
+    high = make_entry(page_views=100, publish_at=same_time)
+    results = list(Entry.objects.ranked())
+    assert results[0].id == high.id
+    assert results[1].id == low.id
+
+
+def test_ranked_recent_entry_outranks_old_with_more_views(make_entry):
+    make_entry(page_views=1000, publish_at=now() - datetime.timedelta(hours=1000))
+    new = make_entry(page_views=20, publish_at=now() - datetime.timedelta(hours=2))
+    results = list(Entry.objects.ranked())
+    assert results[0].id == new.id

--- a/news/views.py
+++ b/news/views.py
@@ -157,12 +157,19 @@ class EntryListView(V3Mixin, ListView):
         }
 
     def get_queryset(self):
-        result = (
-            super()
-            .get_queryset()
-            .select_related("author")
-            .filter(published=True, deleted_at__isnull=True)
-        )
+        if self.request.GET.get("sort") == "popular":
+            result = (
+                self.model.objects.ranked()
+                .select_related("author")
+                .filter(published=True, deleted_at__isnull=True)
+            )
+        else:
+            result = (
+                super()
+                .get_queryset()
+                .select_related("author")
+                .filter(published=True, deleted_at__isnull=True)
+            )
         right_now = now()
         for entry in result:
             entry.display_publish_at = display_publish_at(entry.publish_at, right_now)

--- a/users/models.py
+++ b/users/models.py
@@ -326,11 +326,11 @@ class User(BaseUser):
             return ca.avatar_url
         return ""
 
-    def to_v3_profile_dict(self, role):
+    def to_v3_profile_dict(self, role=None):
         return {
             "name": self.display_name or str(self),
             "profile_url": None,
-            "role": role,
+            "role": role if role is not None else self.role,
             "avatar_url": self.get_avatar_url(),
             "badge_url": None,
         }


### PR DESCRIPTION
# Issue: #2435

## Summary & Context
Implements a recency-weighted ranking algorithm for posts using the formula `score = views / (age_in_hours + 2) ^ gravity`. View counts are stored on the `Entry` model, synced daily from Plausible via a Celery beat task, and the score is computed as a Django ORM annotation at query time.

- **Figma link**: N/A (backend only)
- **Link to components/page:** `localhost:8000/news/?sort=popular` and `localhost:8000/` (v3 homepage posts card)

## Changes

- Added `page_views` field to `Entry` model (migration `0014`)
- Added `EntryManager.ranked()` - annotates each entry with a `ranking_score` and orders by it descending; gravity is tunable via `POSTS_RANKING_GRAVITY` env var (default `2.0`)
- Added `news/plausible.py` with two shared helpers: `fetch_post_views()` (Plausible API call) and `update_page_views()` (bulk DB update)
- Added `sync_post_views` management command (supports `--dry-run`) and `just sync_post_views` justfile shortcut - both delegate to the shared helpers
- Added `sync_post_views_from_plausible` Celery task (in `news/tasks.py`) that also delegates to the shared helpers; scheduled daily at 6:00 AM in `config/celery.py`
- Exposed `?sort=popular` query param in `EntryListView` (and subclasses) to sort by ranking score; default ordering (`-publish_at`) is unchanged; this is just for the sake of testing, and I think it's ok to leave this "hidden" feature here
- V3 homepage posts card now shows the top 5 popularity-ranked published entries instead of demo data; "View all posts" CTA links to `/news/`

## ‼️ Risks & Considerations ‼️
- All posts start with `page_views = 0`, so both `?sort=popular` and the homepage card will rank entries arbitrarily until the Celery task (or manual sync command) has run at least once.
- The Plausible filter uses `"contains"` on `/news/entry/` - any URL that happens to contain that substring (e.g. redirects, query strings) would also match, though in practice this is unlikely.

## Screenshots

N/A - no visual design changes; the homepage card now shows real data where it previously showed demo content.

## Peer-review testing steps
1. Ask me for the `PLAUSIBLE_STATS_KEY`, I'll provide it to you on a DM;
2. Run `just migrate`;
3. Run `just sync_post_views --dry-run` - should list entries with their current and incoming `page_views` values (requires a valid `PLAUSIBLE_STATS_KEY`).
4. Run `just sync_post_views` - verify `page_views` is populated on entries.
5. Visit `http://localhost:8000/` - the "Posts from the Boost Community" card should show real ranked posts with working links.
6. Visit `/news/?sort=popular` - entries should be ordered by ranking score, not publish date.
7. Visit `/news/` (no param) - default publish-date ordering should be unchanged.
8. Adjust `POSTS_RANKING_GRAVITY` in `.env` and restart - verify the sort order shifts accordingly without a migration.

## Self-review Checklist
- [x] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket