### PR TITLE
feat(2426): make library intro authors scrollable when authors > 3

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2048,43 +2048,7 @@ class V3ComponentDemoView(V3Mixin, TemplateView):
         # Hardcoded for the demo page. The production library intro context is
         # built by `libraries.utils.build_library_intro_context`; reuse it when
         # integrating this component into the real library pages.
-        context["library_intro"] = {
-            "library_name": "Boost.Beast.",
-            "description": (
-                "Lightweight utilities that power dozens of other Boost libraries"
-            ),
-            "authors": [
-                {
-                    "name": "Vinnie Falco",
-                    "role": "Author",
-                    "avatar_url": large_static("img/v3/demo-page/avatar.png"),
-                    "badge_url": large_static("img/v3/badges/badge-first-place.png"),
-                    "badge": "",
-                    "bio": "Big C++ fan. Not quite kidney-donation level, but close.",
-                    "profile_url": "",
-                },
-                {
-                    "name": "Alex Wells",
-                    "role": "Contributor",
-                    "avatar_url": large_static("img/v3/demo-page/avatar.png"),
-                    "badge_url": "",
-                    "badge": "",
-                    "bio": "C++ enthusiast who has worked at Intel and Microsoft.",
-                    "profile_url": "",
-                },
-                {
-                    "name": "Dave Abrahams",
-                    "role": "Contributor",
-                    "avatar_url": large_static("img/v3/demo-page/avatar.png"),
-                    "badge_url": large_static("img/v3/badges/badge-bronze.png"),
-                    "badge": "",
-                    "bio": "Contributor to Boost since 2009.",
-                    "profile_url": "",
-                },
-            ],
-            "cta_url": "#",
-        }
-
+        #
         # Demo variants for the Library Intro Card scrollable behaviour:
         # "few" stays under the 3-row cap (no scroll); "many" exceeds it.
         _intro_avatar = large_static("img/v3/demo-page/avatar.png")

--- a/core/views.py
+++ b/core/views.py
@@ -2085,6 +2085,90 @@ class V3ComponentDemoView(V3Mixin, TemplateView):
             "cta_url": "#",
         }
 
+        # Demo variants for the Library Intro Card scrollable behaviour:
+        # "few" stays under the 3-row cap (no scroll); "many" exceeds it.
+        _intro_avatar = large_static("img/v3/demo-page/avatar.png")
+        _intro_bio = "Big C++ fan. Not quite kidney-donation level, but close."
+        context["library_intro_few"] = {
+            "library_name": "Boost.Core.",
+            "description": (
+                "Lightweight utilities that power dozens of other Boost libraries"
+            ),
+            "authors": [
+                {
+                    "name": "Vinnie Falco",
+                    "role": "Author",
+                    "avatar_url": _intro_avatar,
+                    "badge": "",
+                    "bio": _intro_bio,
+                    "profile_url": "",
+                },
+                {
+                    "name": "Alex Wells",
+                    "role": "Contributor",
+                    "avatar_url": _intro_avatar,
+                    "badge": "",
+                    "bio": _intro_bio,
+                    "profile_url": "",
+                },
+            ],
+            "cta_url": "#",
+        }
+        context["library_intro_three"] = {
+            "library_name": "Boost.Asio.",
+            "description": (
+                "Lightweight utilities that power dozens of other Boost libraries"
+            ),
+            "authors": [
+                {
+                    "name": name,
+                    "role": role,
+                    "avatar_url": _intro_avatar,
+                    "badge": "",
+                    "bio": _intro_bio,
+                    "profile_url": "",
+                }
+                for name, role in [
+                    ("Vinnie Falco", "Author"),
+                    ("Alex Wells", "Maintainer"),
+                    ("Dave Abrahams", "Contributor"),
+                ]
+            ],
+            "cta_url": "#",
+        }
+        context["library_intro_many"] = {
+            "library_name": "Boost.Beast.",
+            "description": (
+                "Lightweight utilities that power dozens of other Boost libraries"
+            ),
+            "authors": [
+                {
+                    "name": name,
+                    "role": role,
+                    "avatar_url": _intro_avatar,
+                    "badge": "",
+                    "bio": _intro_bio,
+                    "profile_url": "",
+                }
+                for name, role in [
+                    ("Vinnie Falco", "Author"),
+                    ("Alex Wells", "Maintainer"),
+                    ("Dave Abrahams", "Contributor"),
+                    ("Beman Dawes", "Contributor"),
+                    ("Hartmut Kaiser", "Contributor"),
+                    ("Andrey Semashev", "Contributor"),
+                ]
+            ],
+            "cta_url": "#",
+        }
+        context["library_intro_code"] = (
+            '{% include "v3/includes/_library_intro_card.html" with '
+            'library_name="Boost.Core." '
+            'description="Lightweight utilities…" '
+            "authors=library_authors "
+            'cta_url="/libs/core/" %}'
+        )
+
         latest = Version.objects.most_recent()
         if latest:
             lv = (

--- a/core/views.py
+++ b/core/views.py
@@ -2057,17 +2057,17 @@ class V3ComponentDemoView(V3Mixin, TemplateView):
             "Lightweight utilities that power dozens of other Boost libraries"
         )
 
-        def _intro_authors(*names_and_roles):
+        def _intro_authors(*authors):
             return [
                 {
                     "name": name,
                     "role": role,
                     "avatar_url": _intro_avatar,
-                    "badge": "",
+                    "badge": badge,
                     "bio": _intro_bio,
                     "profile_url": "",
                 }
-                for name, role in names_and_roles
+                for name, role, badge in authors
             ]
 
         def _intro_card(library_name, authors):
@@ -2081,27 +2081,27 @@ class V3ComponentDemoView(V3Mixin, TemplateView):
         context["library_intro_few"] = _intro_card(
             "Boost.Core.",
             _intro_authors(
-                ("Vinnie Falco", "Author"),
-                ("Alex Wells", "Contributor"),
+                ("Vinnie Falco", "Author", BadgeToken.TIER_3),
+                ("Alex Wells", "Contributor", BadgeToken.TIER_2),
             ),
         )
         context["library_intro_three"] = _intro_card(
             "Boost.Asio.",
             _intro_authors(
-                ("Vinnie Falco", "Author"),
-                ("Alex Wells", "Maintainer"),
-                ("Dave Abrahams", "Contributor"),
+                ("Vinnie Falco", "Author", BadgeToken.TIER_3),
+                ("Alex Wells", "Maintainer", BadgeToken.TIER_2),
+                ("Dave Abrahams", "Contributor", BadgeToken.TIER_1),
             ),
         )
         context["library_intro_many"] = _intro_card(
             "Boost.Beast.",
             _intro_authors(
-                ("Vinnie Falco", "Author"),
-                ("Alex Wells", "Maintainer"),
-                ("Dave Abrahams", "Contributor"),
-                ("Beman Dawes", "Contributor"),
-                ("Hartmut Kaiser", "Contributor"),
-                ("Andrey Semashev", "Contributor"),
+                ("Vinnie Falco", "Author", BadgeToken.TIER_3),
+                ("Alex Wells", "Maintainer", BadgeToken.TIER_2),
+                ("Dave Abrahams", "Contributor", BadgeToken.TIER_1),
+                ("Beman Dawes", "Contributor", BadgeToken.TIER_3),
+                ("Hartmut Kaiser", "Contributor", BadgeToken.TIER_2),
+                ("Andrey Semashev", "Contributor", BadgeToken.TIER_1),
             ),
         )
 

--- a/core/views.py
+++ b/core/views.py
@@ -2089,37 +2089,12 @@ class V3ComponentDemoView(V3Mixin, TemplateView):
         # "few" stays under the 3-row cap (no scroll); "many" exceeds it.
         _intro_avatar = large_static("img/v3/demo-page/avatar.png")
         _intro_bio = "Big C++ fan. Not quite kidney-donation level, but close."
-        context["library_intro_few"] = {
-            "library_name": "Boost.Core.",
-            "description": (
-                "Lightweight utilities that power dozens of other Boost libraries"
-            ),
-            "authors": [
-                {
-                    "name": "Vinnie Falco",
-                    "role": "Author",
-                    "avatar_url": _intro_avatar,
-                    "badge": "",
-                    "bio": _intro_bio,
-                    "profile_url": "",
-                },
-                {
-                    "name": "Alex Wells",
-                    "role": "Contributor",
-                    "avatar_url": _intro_avatar,
-                    "badge": "",
-                    "bio": _intro_bio,
-                    "profile_url": "",
-                },
-            ],
-            "cta_url": "#",
-        }
-        context["library_intro_three"] = {
-            "library_name": "Boost.Asio.",
-            "description": (
-                "Lightweight utilities that power dozens of other Boost libraries"
-            ),
-            "authors": [
+        _intro_description = (
+            "Lightweight utilities that power dozens of other Boost libraries"
+        )
+
+        def _intro_authors(*names_and_roles):
+            return [
                 {
                     "name": name,
                     "role": role,
@@ -2128,39 +2103,43 @@ class V3ComponentDemoView(V3Mixin, TemplateView):
                     "bio": _intro_bio,
                     "profile_url": "",
                 }
-                for name, role in [
-                    ("Vinnie Falco", "Author"),
-                    ("Alex Wells", "Maintainer"),
-                    ("Dave Abrahams", "Contributor"),
-                ]
-            ],
-            "cta_url": "#",
-        }
-        context["library_intro_many"] = {
-            "library_name": "Boost.Beast.",
-            "description": (
-                "Lightweight utilities that power dozens of other Boost libraries"
+                for name, role in names_and_roles
+            ]
+
+        def _intro_card(library_name, authors):
+            return {
+                "library_name": library_name,
+                "description": _intro_description,
+                "authors": authors,
+                "cta_url": "#",
+            }
+
+        context["library_intro_few"] = _intro_card(
+            "Boost.Core.",
+            _intro_authors(
+                ("Vinnie Falco", "Author"),
+                ("Alex Wells", "Contributor"),
             ),
-            "authors": [
-                {
-                    "name": name,
-                    "role": role,
-                    "avatar_url": _intro_avatar,
-                    "badge": "",
-                    "bio": _intro_bio,
-                    "profile_url": "",
-                }
-                for name, role in [
-                    ("Vinnie Falco", "Author"),
-                    ("Alex Wells", "Maintainer"),
-                    ("Dave Abrahams", "Contributor"),
-                    ("Beman Dawes", "Contributor"),
-                    ("Hartmut Kaiser", "Contributor"),
-                    ("Andrey Semashev", "Contributor"),
-                ]
-            ],
-            "cta_url": "#",
-        }
+        )
+        context["library_intro_three"] = _intro_card(
+            "Boost.Asio.",
+            _intro_authors(
+                ("Vinnie Falco", "Author"),
+                ("Alex Wells", "Maintainer"),
+                ("Dave Abrahams", "Contributor"),
+            ),
+        )
+        context["library_intro_many"] = _intro_card(
+            "Boost.Beast.",
+            _intro_authors(
+                ("Vinnie Falco", "Author"),
+                ("Alex Wells", "Maintainer"),
+                ("Dave Abrahams", "Contributor"),
+                ("Beman Dawes", "Contributor"),
+                ("Hartmut Kaiser", "Contributor"),
+                ("Andrey Semashev", "Contributor"),
+            ),
+        )
 
         latest = Version.objects.most_recent()
         if latest:

--- a/core/views.py
+++ b/core/views.py
@@ -2161,13 +2161,6 @@ class V3ComponentDemoView(V3Mixin, TemplateView):
             ],
             "cta_url": "#",
         }
-        context["library_intro_code"] = (
-            '{% include "v3/includes/_library_intro_card.html" with '
-            'library_name="Boost.Core." '
-            'description="Lightweight utilities…" '
-            "authors=library_authors "
-            'cta_url="/libs/core/" %}'
-        )
 
         latest = Version.objects.most_recent()
         if latest:

--- a/static/css/v3/library-intro-card.css
+++ b/static/css/v3/library-intro-card.css
@@ -73,7 +73,7 @@
 }
 
 .library-intro-card__authors:focus-visible {
-  outline: 2px solid var(--color-text-primary);
+  outline: 2px solid var(--color-stroke-link-accent);
   outline-offset: -2px;
 }
 

--- a/static/css/v3/library-intro-card.css
+++ b/static/css/v3/library-intro-card.css
@@ -56,6 +56,27 @@
   border-radius: var(--border-radius-m, 6px);
 }
 
+/* Authors list — scrollable only when entries exceed the visible card cap.
+   With ≤ 3 authors the card grows naturally; with 4+ it caps at 3 rows. */
+
+.library-intro-card__authors {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--color-stroke-weak);
+}
+
+.library-intro-card__authors:has(> .library-intro-card__author:nth-of-type(4)) {
+  overflow-y: auto;
+  /* ≈ 3 rows × 80px (48px avatar + 2 × 16px padding) + 2 × 1px hr separators */
+  max-height: 242px;
+  scrollbar-color: var(--color-icon-primary) var(--color-surface-strong);
+}
+
+.library-intro-card__authors:focus-visible {
+  outline: 2px solid var(--color-text-primary);
+  outline-offset: -2px;
+}
+
 /* Author row */
 
 .library-intro-card__author {

--- a/templates/v3/examples/_v3_example_section.html
+++ b/templates/v3/examples/_v3_example_section.html
@@ -312,9 +312,20 @@
       <div class="v3-examples-section__block" id="{{ section_title|slugify }}">
         <h3>{{ section_title }}</h3>
         <div class="v3-examples-section__example-box">
-          {% with intro=library_intro %}
+          <h4 class="py-large">Few contributors — no scroll</h4>
+          {% with intro=library_intro_few %}
             {% include "v3/includes/_library_intro_card.html" with library_name=intro.library_name description=intro.description authors=intro.authors cta_url=intro.cta_url %}
           {% endwith %}
+          <h4 class="py-large">Three contributors — at the visible cap, no scroll</h4>
+          {% with intro=library_intro_three %}
+            {% include "v3/includes/_library_intro_card.html" with library_name=intro.library_name description=intro.description authors=intro.authors cta_url=intro.cta_url %}
+          {% endwith %}
+          <h4 class="py-large">Many contributors — scroll visible</h4>
+          {% with intro=library_intro_many %}
+            {% include "v3/includes/_library_intro_card.html" with library_name=intro.library_name description=intro.description authors=intro.authors cta_url=intro.cta_url %}
+          {% endwith %}
+          <h4 class="py-large">Usage</h4>
+          {% include "v3/includes/_code_block.html" with code=library_intro_code variant="grey-bg" language="django" %}
         </div>
       </div>
     {% endwith %}

--- a/templates/v3/examples/_v3_example_section.html
+++ b/templates/v3/examples/_v3_example_section.html
@@ -324,8 +324,6 @@
           {% with intro=library_intro_many %}
             {% include "v3/includes/_library_intro_card.html" with library_name=intro.library_name description=intro.description authors=intro.authors cta_url=intro.cta_url %}
           {% endwith %}
-          <h4 class="py-large">Usage</h4>
-          {% include "v3/includes/_code_block.html" with code=library_intro_code variant="grey-bg" language="django" %}
         </div>
       </div>
     {% endwith %}

--- a/templates/v3/examples/_v3_example_section.html
+++ b/templates/v3/examples/_v3_example_section.html
@@ -307,7 +307,7 @@
     </div>
   {% endwith %}
 
-  {% if library_intro %}
+  {% if library_intro_few or library_intro_three or library_intro_many %}
     {% with section_title="Library Intro Card" %}
       <div class="v3-examples-section__block" id="{{ section_title|slugify }}">
         <h3>{{ section_title }}</h3>

--- a/templates/v3/includes/_library_intro_card.html
+++ b/templates/v3/includes/_library_intro_card.html
@@ -20,9 +20,11 @@
   </div>
   {% if authors %}
     <div class="library-intro-card__authors"
+         {% if authors|length > 3 %}
          tabindex="0"
          role="region"
-         aria-label="Contributors for {{ library_name }}">
+         aria-label="Contributors for {{ library_name }}"
+         {% endif %}>
       {% for author in authors %}
         {% if not forloop.first %}<hr class="card__hr">{% endif %}
         <div class="library-intro-card__author">

--- a/templates/v3/includes/_library_intro_card.html
+++ b/templates/v3/includes/_library_intro_card.html
@@ -18,12 +18,19 @@
     </div>
     <p class="library-intro-card__description">{{ description }}</p>
   </div>
-  {% for author in authors %}
-    <hr class="card__hr">
-    <div class="library-intro-card__author">
-      {% include "v3/includes/_user_profile.html" with author=author %}
+  {% if authors %}
+    <div class="library-intro-card__authors"
+         tabindex="0"
+         role="region"
+         aria-label="Contributors for {{ library_name }}">
+      {% for author in authors %}
+        {% if not forloop.first %}<hr class="card__hr">{% endif %}
+        <div class="library-intro-card__author">
+          {% include "v3/includes/_user_profile.html" with author=author %}
+        </div>
+      {% endfor %}
     </div>
-  {% endfor %}
+  {% endif %}
   {% if cta_url %}
     <hr class="card__hr">
     <div class="card__cta_section library-intro-card__cta">


### PR DESCRIPTION
# Issue: #2426 

## Summary & Context
Allows the component to receive more authors and enables scrolling them.

- **Figma link**: https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=492-4408&t=y0fc1z2NIUtnm2D3-4
- **Link to components/page:** http://localhost:8000/v3/demo/components/#library-intro-card

## Changes
- Template: wrap authors loop in a scrollable region with tabindex, role="region", aria-label.
  - CSS: scroll only kicks in for 4+ authors (via :has()), caps at 3 rows; themed scrollbar + focus
  outline.
  - Demo page: shows the 3 variants side-by-side with labels and code block.
  - Accessibility / no-JS: native scroll, keyboard-scrollable, screen-reader discoverable.

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*

## Screenshots
<img width="1487" height="422" alt="4" src="https://github.com/user-attachments/assets/664644dd-897b-444a-9396-ad9f94c58362" />



## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [x] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings
