### PR TITLE
Story 2436: Mailing List Subscription Post Auth

### DIFF
--- a/ak/views.py
+++ b/ak/views.py
@@ -4,6 +4,7 @@ from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse
 from django.shortcuts import render
+from django.urls import reverse
 from django.views import View
 from django.views.generic import TemplateView
 

--- a/ak/views.py
+++ b/ak/views.py
@@ -19,6 +19,7 @@ from core.mixins import V3Mixin
 from core.models import PopularSearchTerm
 from libraries.constants import LATEST_RELEASE_URL_PATH_STR
 from libraries.mixins import ContributorMixin
+from mailing_list.constants import MAILING_LIST_LABELS
 from news.models import Entry
 from testimonials.models import Testimonial
 from ak.homepage import (
@@ -130,6 +131,21 @@ class HomepageView(V3Mixin, ContributorMixin, TemplateView):
 
         # Hero Image
         ctx.update(hero_image_context())
+
+        user = self.request.user
+        if user.is_authenticated and self.request.session.pop(
+            "show_ml_post_auth_modal", False
+        ):
+            user.data["ml_post_auth_seen"] = True
+            user.save(update_fields=["data"])
+            ctx["show_ml_post_auth_modal"] = True
+            ctx["post_auth_modal_subscribe_url"] = reverse(
+                "mailing-list-post-auth-subscribe"
+            )
+            ctx["post_auth_modal_mailing_lists"] = [
+                {**v} for v in MAILING_LIST_LABELS.values()
+            ]
+            ctx["post_auth_modal_user_email"] = user.email
 
         return ctx
 

--- a/mailing_list/urls.py
+++ b/mailing_list/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from mailing_list.views import ConfirmSubscriptionView
 from mailing_list.views import ModalSubscribeView
+from mailing_list.views import PostAuthSubscribeView
 from mailing_list.views import QuickSubscribeView
 from mailing_list.views import SubscribeView
 
@@ -16,6 +17,11 @@ urlpatterns = [
         "modal-subscribe/",
         ModalSubscribeView.as_view(),
         name="mailing-list-modal-subscribe",
+    ),
+    path(
+        "post-auth-subscribe/",
+        PostAuthSubscribeView.as_view(),
+        name="mailing-list-post-auth-subscribe",
     ),
     path(
         "confirm/<str:token>/",

--- a/mailing_list/views.py
+++ b/mailing_list/views.py
@@ -7,9 +7,9 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core import signing
 from django.core.cache import cache
-from django.db import IntegrityError, transaction
 from django.core.mail import send_mail
-from django.http import HttpResponseRedirect
+from django.db import IntegrityError, transaction
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -81,6 +81,43 @@ def _is_rate_limited(request) -> bool:
     key = _rate_limit_key(request)
     cache.add(key, 0, timeout=_SUBSCRIBE_RATE_WINDOW)
     return cache.incr(key) > _SUBSCRIBE_RATE_LIMIT
+
+
+def _subscribe_pending(
+    request, user, email: str, list_ids: list[str]
+) -> tuple[list[str], str | None]:
+    """Create PENDING subscription records and send a confirmation email.
+
+    Returns (succeeded, error_message). On email failure the records are
+    rolled back and error_message is set; on partial IntegrityError the
+    affected list is silently skipped.
+    """
+    succeeded = []
+    for lid in list_ids:
+        try:
+            with transaction.atomic():
+                UserMailingListSubscription.objects.update_or_create(
+                    user=user,
+                    list_id=lid,
+                    defaults={"email": email, "status": SubscriptionStatus.PENDING},
+                )
+            succeeded.append(lid)
+        except IntegrityError:
+            pass
+
+    if not succeeded:
+        return [], None
+
+    try:
+        _send_confirmation_email(request, email, user.pk, succeeded)
+    except Exception as exc:
+        logger.error("Failed to send confirmation email to %s: %s", email, exc)
+        UserMailingListSubscription.objects.filter(
+            user=user, list_id__in=succeeded
+        ).delete()
+        return [], "Could not send confirmation email. Please try again."
+
+    return succeeded, None
 
 
 def _send_confirmation_email(
@@ -594,38 +631,20 @@ class ModalSubscribeView(View):
                 manage_url=manage_url,
             )
 
-        succeeded = []
-        for lid in to_subscribe:
-            try:
-                with transaction.atomic():
-                    UserMailingListSubscription.objects.update_or_create(
-                        user=request.user,
-                        list_id=lid,
-                        defaults={"email": email, "status": SubscriptionStatus.PENDING},
-                    )
-                succeeded.append(lid)
-            except IntegrityError:
-                pass
+        succeeded, error = _subscribe_pending(
+            request, request.user, email, to_subscribe
+        )
+
+        if error:
+            return self._card(
+                request, state="error", error_message=error, user_email=email
+            )
 
         if not succeeded:
             return self._card(
                 request,
                 state="error",
                 error_message="Could not subscribe. Please try again.",
-                user_email=email,
-            )
-
-        try:
-            _send_confirmation_email(request, email, request.user.pk, succeeded)
-        except Exception as exc:
-            logger.error("Failed to send confirmation email to %s: %s", email, exc)
-            UserMailingListSubscription.objects.filter(
-                user=request.user, list_id__in=succeeded
-            ).delete()
-            return self._card(
-                request,
-                state="error",
-                error_message="Could not send confirmation email. Please try again.",
                 user_email=email,
             )
 
@@ -657,3 +676,33 @@ class ModalSubscribeView(View):
             )
 
         return self._card(request, state="pending", user_email=email)
+
+
+class PostAuthSubscribeView(LoginRequiredMixin, View):
+    """Subscribe to one or more lists from the post-login homepage modal.
+
+    Only for authenticated users. Returns an empty fragment so HTMX removes
+    the modal from the DOM. Falls back to a homepage redirect for non-HTMX.
+    """
+
+    def post(self, request):
+        email = (request.POST.get("email") or "").strip() or request.user.email
+        managed_lists = set(constants.MAILMAN_LISTS)
+        list_ids = [
+            lid for lid in request.POST.getlist("list_id") if lid in managed_lists
+        ]
+
+        if list_ids and not _is_rate_limited(request):
+            current = {
+                sub.list_id
+                for sub in UserMailingListSubscription.objects.filter(
+                    user=request.user, list_id__in=managed_lists
+                )
+            }
+            to_subscribe = [lid for lid in list_ids if lid not in current]
+
+            _subscribe_pending(request, request.user, email, to_subscribe)
+
+        if _is_htmx(request):
+            return HttpResponse("")
+        return _prg_redirect(request)

--- a/mailing_list/views.py
+++ b/mailing_list/views.py
@@ -557,9 +557,27 @@ class ModalSubscribeView(View):
     any currently tracked lists that were unchecked.
     Anonymous flow: subscribe-only - sends a single confirmation email for all
     checked lists. Unsubscribe not supported for anonymous users.
+
+    With JS the form posts via HTMX and the card partial is swapped in place.
+    Without JS the form posts natively; we redirect (PRG) back to the page so
+    the card re-renders from DB state on the next GET.
     """
 
     def _card(self, request, **ctx):
+        if not _is_htmx(request):
+            state = ctx.get("state")
+            if state == "error":
+                return _prg_redirect(
+                    request,
+                    ml_state="error",
+                    ml_error=ctx.get("error_message", ""),
+                    ml_email=ctx.get("user_email", ""),
+                )
+            if state == "pending" and not request.user.is_authenticated:
+                return _prg_redirect(
+                    request, ml_state="pending", ml_email=ctx.get("user_email", "")
+                )
+            return _prg_redirect(request)
         return render(
             request,
             "v3/includes/_mailing_list_card.html",

--- a/static/css/v3/dialog.css
+++ b/static/css/v3/dialog.css
@@ -40,8 +40,19 @@
   display: flex !important;
 }
 
+/* Checkbox-driven open (no-JS auto-open / toggle): a checked .dialog-modal__toggle
+   shows the adjacent .dialog-modal, mirroring the :target behaviour. */
+.dialog-modal__toggle {
+  display: none;
+}
+
+.dialog-modal__toggle:checked ~ .dialog-modal {
+  display: flex !important;
+}
+
 /* Lock background page scroll while any dialog is open. */
-html:has(.dialog-modal:target) {
+html:has(.dialog-modal:target),
+html:has(.dialog-modal__toggle:checked) {
   overflow: hidden;
 }
 

--- a/static/css/v3/mailing-list-card.css
+++ b/static/css/v3/mailing-list-card.css
@@ -256,6 +256,16 @@ input.mailing-list-modal__checkbox:focus-visible + .mailing-list-modal__checkbox
   border-color: var(--color-stroke-strong);
 }
 
+.ml-post-auth-modal__email-field--error {
+  background-color: var(--color-surface-error-weak) !important;
+  border-color: var(--color-stroke-error) !important;
+  color: var(--color-text-error);
+}
+
+.ml-post-auth-modal__email-row .field__error {
+  margin-top: var(--space-s);
+}
+
 .ml-post-auth-modal__container .dialog-modal__buttons {
   padding-top: var(--space-large);
 }

--- a/static/css/v3/mailing-list-card.css
+++ b/static/css/v3/mailing-list-card.css
@@ -203,3 +203,114 @@ input.mailing-list-modal__checkbox:focus-visible + .mailing-list-modal__checkbox
   line-height: var(--line-height-default);
   color: var(--color-text-secondary);
 }
+
+/* ============================================
+   POST-AUTH MODAL — first-login subscription prompt
+   ============================================ */
+
+/* Header contains only the title (no close X per design) */
+.ml-post-auth-modal__header {
+  padding: var(--space-large) var(--space-large) 0 var(--space-large);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.ml-post-auth-modal__header .dialog-modal__title {
+  margin: 0;
+}
+
+/* Email input row */
+.ml-post-auth-modal__email-row {
+  padding: 0 var(--space-large);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.ml-post-auth-modal__email-field {
+  display: block;
+  width: 100%;
+  height: 40px;
+  padding: 0 var(--space-large);
+  box-sizing: border-box;
+  background-color: var(--color-surface-weak) !important;
+  border: 1px solid var(--color-stroke-weak) !important;
+  border-radius: var(--border-radius-xl) !important;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-default);
+  letter-spacing: var(--letter-spacing-tight);
+  color: var(--color-text-secondary);
+  outline: none;
+  box-shadow: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.ml-post-auth-modal__email-field::placeholder {
+  color: var(--color-text-secondary);
+}
+
+.ml-post-auth-modal__email-field:focus-visible {
+  background-color: var(--color-surface-mid);
+  border-color: var(--color-stroke-strong);
+}
+
+.ml-post-auth-modal__container .dialog-modal__buttons {
+  padding-top: var(--space-large);
+}
+
+/* Description + list card section */
+.ml-post-auth-modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-default);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.ml-post-auth-modal__description {
+  padding: 0 var(--space-large);
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-default);
+  letter-spacing: var(--letter-spacing-tight);
+  color: var(--color-text-secondary);
+}
+
+.ml-post-auth-modal__list-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-large);
+  padding: 0 var(--space-large) var(--space-large);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Override the bottom margin that .mailing-list-modal__list-card applies
+   since margin is handled by the parent flex gap here */
+.ml-post-auth-modal__list-card {
+  margin: 0;
+}
+
+/* Unselect All link + "X of Y selected" counter */
+.ml-post-auth-modal__footer-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: var(--font-size-small);
+  line-height: var(--line-height-relaxed);
+  letter-spacing: var(--letter-spacing-tight);
+  white-space: nowrap;
+}
+
+.ml-post-auth-modal__count {
+  font-family: var(--font-sans);
+  font-weight: var(--font-weight-regular);
+  color: var(--color-text-secondary);
+}

--- a/static/css/v3/mailing-list-card.css
+++ b/static/css/v3/mailing-list-card.css
@@ -266,6 +266,11 @@ input.mailing-list-modal__checkbox:focus-visible + .mailing-list-modal__checkbox
   margin-top: var(--space-s);
 }
 
+.ml-post-auth-modal__email-row + .card__hr {
+  margin-top: var(--space-large);
+  margin-bottom: var(--space-large);
+}
+
 .ml-post-auth-modal__container .dialog-modal__buttons {
   padding-top: var(--space-large);
 }

--- a/static/js/dialog.js
+++ b/static/js/dialog.js
@@ -80,6 +80,15 @@
     if (hashModal) {
       return hashModal.querySelector('[role="dialog"]') || hashModal;
     }
+    // Checkbox-based dialog modals (.dialog-modal__toggle drives an adjacent .dialog-modal)
+    var dialogToggle = document.querySelector('.dialog-modal__toggle:checked');
+    if (dialogToggle) {
+      var modal = dialogToggle.nextElementSibling;
+      while (modal && !modal.classList.contains('dialog-modal')) {
+        modal = modal.nextElementSibling;
+      }
+      if (modal) return modal.querySelector('[role="dialog"]') || modal;
+    }
     // Checkbox-based modals (library filter)
     var toggle = document.querySelector('.library-filter__toggle:checked');
     if (toggle) {
@@ -99,8 +108,10 @@
         window.location.href = closeLink.href;
       }
     } else {
-      // Checkbox-based: uncheck the toggle
-      var toggle = document.querySelector('.library-filter__toggle:checked');
+      // Checkbox-based (dialog modal or library filter): uncheck the toggle
+      var toggle = document.querySelector(
+        '.dialog-modal__toggle:checked, .library-filter__toggle:checked'
+      );
       if (toggle) {
         toggle.checked = false;
       }
@@ -130,14 +141,32 @@
 
   // Checkbox-based modals open via toggle change
   document.addEventListener('change', function (e) {
-    if (e.target.matches('.library-filter__toggle') && e.target.checked) {
+    if (
+      e.target.matches('.library-filter__toggle, .dialog-modal__toggle') &&
+      e.target.checked
+    ) {
       var dialog = getActiveDialog();
       if (dialog) {
-        triggerElement = e.target.parentElement.querySelector('.library-filter__trigger');
+        triggerElement = e.target.matches('.library-filter__toggle')
+          ? e.target.parentElement.querySelector('.library-filter__trigger')
+          : document.activeElement;
         setInitialFocus(dialog);
       }
     }
   });
+
+  // Auto-opened checkbox dialog (server-renders the toggle checked): focus on load.
+  function focusAutoOpenedDialog() {
+    var dialog = getActiveDialog();
+    if (dialog) {
+      setInitialFocus(dialog);
+    }
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', focusAutoOpenedDialog);
+  } else {
+    focusAutoOpenedDialog();
+  }
 
   // Enter key activates label[role="button"] elements (labels only natively respond to click)
   document.addEventListener('keydown', function (e) {

--- a/templates/v3/homepage.html
+++ b/templates/v3/homepage.html
@@ -62,4 +62,8 @@
       </div>
     </div>
   </div>
+
+  {% if show_ml_post_auth_modal %}
+    {% include "v3/includes/_mailing_list_post_auth_modal.html" with post_auth_modal_subscribe_url=post_auth_modal_subscribe_url post_auth_modal_mailing_lists=post_auth_modal_mailing_lists post_auth_modal_user_email=post_auth_modal_user_email %}
+  {% endif %}
 {% endblock %}

--- a/templates/v3/includes/_content_modal.html
+++ b/templates/v3/includes/_content_modal.html
@@ -18,7 +18,7 @@
   Trigger: <a href="#{{ modal_id }}">…</a>
 {% endcomment %}
 <div class="dialog-modal content-modal" id="{{ modal_id }}">
-  <a class="dialog-modal__backdrop" href="{{ close_url|default:'#_' }}" aria-hidden="true" tabindex="-1"></a>
+  <a class="dialog-modal__backdrop" href="{{ close_url|default:'#_' }}" tabindex="-1"></a>
   <div class="content-modal__container"
        role="dialog"
        aria-modal="true"

--- a/templates/v3/includes/_dialog.html
+++ b/templates/v3/includes/_dialog.html
@@ -25,7 +25,7 @@
 {% endcomment %}
 
 <div class="dialog-modal" id="{{ dialog_id }}">
-  <a class="dialog-modal__backdrop" href="#_" aria-hidden="true" tabindex="-1"></a>
+  <a class="dialog-modal__backdrop" href="#_" tabindex="-1"></a>
   <div class="dialog-modal__container"
        role="dialog"
        aria-modal="true"

--- a/templates/v3/includes/_mailing_list_card.html
+++ b/templates/v3/includes/_mailing_list_card.html
@@ -7,16 +7,20 @@ Variables:
   mailing_lists        - (required) list of dicts: {id, name, address, description}
   list_id              - (optional) list ID for the no-JS hidden input; defaults to "boost.lists.boost.org"
   state                - "active" | "pending" | "error" | None
-  user_email           - (optional) email used in the subscription
-  manage_url           - (optional) URL for managing subscriptions (no-JS fallback for the manage button)
+  user_email           - (optional) email used in the subscription; also rendered into the
+                         modal's hidden email input as the no-JS fallback value
+  manage_url           - (optional) when set, shows the "Manage your lists" modal trigger
+                         (authenticated users); the trigger opens the modal via :target
   subscription_count   - (optional) number of lists subscribed to (shown in active state)
   subscribed_ids       - (optional) set of list IDs the user is currently subscribed to; controls checkbox state
   error_message        - error text shown when state="error"
 
 Modal open/close: CSS-only via :target (id="mailing-list-modal"), matching the _dialog.html pattern.
+The "Manage your lists" trigger and the modal form work without JS (the form posts
+natively via method/action; the view redirects (PRG) for non-HTMX requests).
 dialog.js provides focus trap, ESC close, and initial focus automatically.
-Alpine is used only to capture the email value and bind it to the modal's hidden input.
-After HTMX swaps [data-ml-block], x-init clears the URL hash so the modal closes.
+With JS, Alpine captures the quick-subscribe email and binds it to the modal's hidden input,
+and HTMX swaps [data-ml-block] in place; x-init then clears the URL hash so the modal closes.
 {% endcomment %}
 <div data-ml-block
      x-data="{ mlEmail: '{{ user_email|default:''|escapejs }}' }"
@@ -35,13 +39,9 @@ After HTMX swaps [data-ml-block], x-init clears the URL hash so the modal closes
         </span>
       </div>
       <div class="card__cta_section">
-        <button type="button"
-                class="btn btn-primary"
-                x-cloak
-                @click="window.location.hash = 'mailing-list-modal'">Manage your lists &rarr;</button>
-        <noscript>
-          <a href="{{ manage_url|default:'' }}" class="btn btn-primary">Manage your lists &rarr;</a>
-        </noscript>
+        <a href="#mailing-list-modal"
+           class="btn btn-primary"
+           role="button">Manage your lists &rarr;</a>
       </div>
     </div>
 
@@ -57,13 +57,9 @@ After HTMX swaps [data-ml-block], x-init clears the URL hash so the modal closes
       </div>
       {% if manage_url %}
         <div class="card__cta_section">
-          <button type="button"
-                  class="btn btn-primary"
-                  x-cloak
-                  @click="window.location.hash = 'mailing-list-modal'">Manage your lists &rarr;</button>
-          <noscript>
-            <a href="{{ manage_url }}" class="btn btn-primary">Manage your lists &rarr;</a>
-          </noscript>
+          <a href="#mailing-list-modal"
+             class="btn btn-primary"
+             role="button">Manage your lists &rarr;</a>
         </div>
       {% endif %}
     </div>
@@ -120,11 +116,13 @@ After HTMX swaps [data-ml-block], x-init clears the URL hash so the modal closes
                   class="mailing-list-modal__select-all"
                   @click="$el.closest('.dialog-modal__container').querySelector('form').querySelectorAll('[name=list_id]').forEach(cb => cb.checked = true)">Select All</button>
         </div>
-        <form hx-post="{{ modal_subscribe_url }}"
+        <form method="post"
+              action="{{ modal_subscribe_url }}"
+              hx-post="{{ modal_subscribe_url }}"
               hx-target="closest [data-ml-block]"
               hx-swap="outerHTML">
           {% csrf_token %}
-          <input type="hidden" name="email" :value="mlEmail">
+          <input type="hidden" name="email" value="{{ user_email|default:'' }}" :value="mlEmail">
           <div class="mailing-list-modal__list-card">
           <ul class="mailing-list-modal__list" role="list">
             {% for ml in mailing_lists %}

--- a/templates/v3/includes/_mailing_list_card.html
+++ b/templates/v3/includes/_mailing_list_card.html
@@ -99,7 +99,7 @@ After HTMX swaps [data-ml-block], x-init clears the URL hash so the modal closes
 
   {% if modal_subscribe_url and mailing_lists %}
     <div class="dialog-modal" id="mailing-list-modal">
-      <a class="dialog-modal__backdrop" href="#_" tabindex="-1" aria-hidden="true"></a>
+      <a class="dialog-modal__backdrop" href="#_" tabindex="-1"></a>
       <div class="dialog-modal__container"
            role="dialog"
            aria-modal="true"

--- a/templates/v3/includes/_mailing_list_post_auth_modal.html
+++ b/templates/v3/includes/_mailing_list_post_auth_modal.html
@@ -32,7 +32,7 @@ Close: backdrop link (href="#_"), Cancel button, or ESC via dialog.js.
        }
      }"
      x-init="window.location.hash = 'ml-post-auth-modal'">
-  <a class="dialog-modal__backdrop" href="#_" tabindex="-1"></a>
+  <a class="dialog-modal__backdrop" href="#_" tabindex="-1" aria-label="Close"></a>
   <div class="dialog-modal__container ml-post-auth-modal__container"
        role="dialog"
        aria-modal="true"

--- a/templates/v3/includes/_mailing_list_post_auth_modal.html
+++ b/templates/v3/includes/_mailing_list_post_auth_modal.html
@@ -17,6 +17,10 @@ Close: backdrop link (href="#_"), Cancel button, or ESC via dialog.js.
      id="ml-post-auth-modal"
      x-data="{
        mlEmail: '{{ post_auth_modal_user_email|default:''|escapejs }}',
+       emailTouched: false,
+       get emailInvalid() {
+         return !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(this.mlEmail.trim());
+       },
        totalLists: {{ post_auth_modal_mailing_lists|length }},
        checkedCount: {{ post_auth_modal_mailing_lists|length }},
        updateCount() {
@@ -50,8 +54,12 @@ Close: backdrop link (href="#_"), Cancel button, or ESC via dialog.js.
              type="email"
              autocomplete="email"
              x-model="mlEmail"
+             @blur="emailTouched = true"
+             :class="{ 'ml-post-auth-modal__email-field--error': emailTouched && emailInvalid }"
+             :aria-invalid="emailTouched && emailInvalid"
              placeholder="Email address"
              aria-label="Email address">
+      <p class="field__error" x-cloak x-show="emailTouched && emailInvalid" role="alert">Please enter a valid email address.</p>
     </div>
 
     <hr class="card__hr">
@@ -60,7 +68,9 @@ Close: backdrop link (href="#_"), Cancel button, or ESC via dialog.js.
           hx-post="{{ post_auth_modal_subscribe_url }}"
           hx-target="#ml-post-auth-modal"
           hx-swap="outerHTML"
-          hx-on::before-swap="history.replaceState(null, '', window.location.pathname + window.location.search)">
+          hx-trigger="ml-submit"
+          hx-on::before-swap="history.replaceState(null, '', window.location.pathname + window.location.search)"
+          @submit.prevent="emailTouched = true; if (!emailInvalid) htmx.trigger($el, 'ml-submit')">
       {% csrf_token %}
       <input type="hidden" name="email" :value="mlEmail">
 

--- a/templates/v3/includes/_mailing_list_post_auth_modal.html
+++ b/templates/v3/includes/_mailing_list_post_auth_modal.html
@@ -10,9 +10,14 @@ Variables:
   post_auth_modal_mailing_lists  - list of dicts: {id, name, address, description}
   post_auth_modal_user_email     - logged-in user's email (pre-fills the input)
 
-Auto-open: x-init sets the URL hash, which triggers the CSS :target selector.
-Close: backdrop link (href="#_"), Cancel button, or ESC via dialog.js.
+No-JS: a server-rendered, pre-checked checkbox toggle (.dialog-modal__toggle)
+opens the modal via CSS, and the form submits natively (method/action) — the
+view redirects (PRG) for non-HTMX requests. The backdrop and Cancel are
+<label>s that uncheck the toggle to close.
+JS enhances this with HTMX submit, inline email validation, and ESC/focus trap
+via dialog.js (which recognises the checkbox toggle).
 {% endcomment %}
+<input type="checkbox" id="ml-post-auth-toggle" class="dialog-modal__toggle" checked hidden>
 <div class="dialog-modal"
      id="ml-post-auth-modal"
      x-data="{
@@ -34,9 +39,8 @@ Close: backdrop link (href="#_"), Cancel button, or ESC via dialog.js.
          this.$refs.checkboxContainer.querySelectorAll('[name=list_id]').forEach(cb => { cb.checked = true; });
          this.checkedCount = this.totalLists;
        }
-     }"
-     x-init="window.location.hash = 'ml-post-auth-modal'">
-  <a class="dialog-modal__backdrop" href="#_" tabindex="-1" aria-label="Close"></a>
+     }">
+  <label class="dialog-modal__backdrop" for="ml-post-auth-toggle" aria-label="Close"></label>
   <div class="dialog-modal__container ml-post-auth-modal__container"
        role="dialog"
        aria-modal="true"
@@ -49,30 +53,34 @@ Close: backdrop link (href="#_"), Cancel button, or ESC via dialog.js.
 
     <hr class="card__hr">
 
-    <div class="ml-post-auth-modal__email-row">
-      <input class="ml-post-auth-modal__email-field"
-             type="email"
-             autocomplete="email"
-             x-model="mlEmail"
-             @blur="emailTouched = true"
-             :class="{ 'ml-post-auth-modal__email-field--error': emailTouched && emailInvalid }"
-             :aria-invalid="emailTouched && emailInvalid"
-             placeholder="Email address"
-             aria-label="Email address">
-      <p class="field__error" x-cloak x-show="emailTouched && emailInvalid" role="alert">Please enter a valid email address.</p>
-    </div>
-
-    <hr class="card__hr">
-
     <form id="ml-post-auth-form"
+          method="post"
+          action="{{ post_auth_modal_subscribe_url }}"
+          novalidate
           hx-post="{{ post_auth_modal_subscribe_url }}"
           hx-target="#ml-post-auth-modal"
           hx-swap="outerHTML"
           hx-trigger="ml-submit"
-          hx-on::before-swap="history.replaceState(null, '', window.location.pathname + window.location.search)"
+          hx-on::after-request="document.getElementById('ml-post-auth-toggle').checked = false"
           @submit.prevent="emailTouched = true; if (!emailInvalid) htmx.trigger($el, 'ml-submit')">
       {% csrf_token %}
-      <input type="hidden" name="email" :value="mlEmail">
+
+      <div class="ml-post-auth-modal__email-row">
+        <input class="ml-post-auth-modal__email-field"
+               type="email"
+               name="email"
+               value="{{ post_auth_modal_user_email|default:'' }}"
+               autocomplete="email"
+               x-model="mlEmail"
+               @blur="emailTouched = true"
+               :class="{ 'ml-post-auth-modal__email-field--error': emailTouched && emailInvalid }"
+               :aria-invalid="emailTouched && emailInvalid"
+               placeholder="Email address"
+               aria-label="Email address">
+        <p class="field__error" x-cloak x-show="emailTouched && emailInvalid" role="alert">Please enter a valid email address.</p>
+      </div>
+
+      <hr class="card__hr">
 
       <div class="ml-post-auth-modal__body" id="ml-post-auth-modal-desc">
         <p class="ml-post-auth-modal__description">Subscribe to any of our mailing lists. You can change these any time.</p>
@@ -114,10 +122,10 @@ Close: backdrop link (href="#_"), Cancel button, or ESC via dialog.js.
       <hr class="card__hr">
 
       <div class="dialog-modal__buttons">
-        <a href="#_"
-           class="btn btn-secondary btn-flex"
-           role="button"
-           @click="history.replaceState(null, '', window.location.pathname + window.location.search)">Cancel</a>
+        <label for="ml-post-auth-toggle"
+               class="btn btn-secondary btn-flex"
+               role="button"
+               tabindex="0">Cancel</label>
         {% include "v3/includes/_button.html" with type="submit" label="Subscribe" style="primary" extra_classes="btn-flex" only %}
       </div>
     </form>

--- a/templates/v3/includes/_mailing_list_post_auth_modal.html
+++ b/templates/v3/includes/_mailing_list_post_auth_modal.html
@@ -1,0 +1,116 @@
+{% comment %}
+Post-login mailing list subscription modal.
+
+Shows automatically on the homepage the first time a user visits after logging
+in. The "seen" flag is set server-side when the homepage renders, so
+cancel/close need no backend call.
+
+Variables:
+  post_auth_modal_subscribe_url  - POST endpoint (mailing-list-post-auth-subscribe)
+  post_auth_modal_mailing_lists  - list of dicts: {id, name, address, description}
+  post_auth_modal_user_email     - logged-in user's email (pre-fills the input)
+
+Auto-open: x-init sets the URL hash, which triggers the CSS :target selector.
+Close: backdrop link (href="#_"), Cancel button, or ESC via dialog.js.
+{% endcomment %}
+<div class="dialog-modal"
+     id="ml-post-auth-modal"
+     x-data="{
+       mlEmail: '{{ post_auth_modal_user_email|default:''|escapejs }}',
+       totalLists: {{ post_auth_modal_mailing_lists|length }},
+       checkedCount: {{ post_auth_modal_mailing_lists|length }},
+       updateCount() {
+         this.checkedCount = this.$refs.checkboxContainer.querySelectorAll('[name=list_id]:checked').length;
+       },
+       unselectAll() {
+         this.$refs.checkboxContainer.querySelectorAll('[name=list_id]').forEach(cb => { cb.checked = false; });
+         this.checkedCount = 0;
+       },
+       selectAll() {
+         this.$refs.checkboxContainer.querySelectorAll('[name=list_id]').forEach(cb => { cb.checked = true; });
+         this.checkedCount = this.totalLists;
+       }
+     }"
+     x-init="window.location.hash = 'ml-post-auth-modal'">
+  <a class="dialog-modal__backdrop" href="#_" tabindex="-1"></a>
+  <div class="dialog-modal__container ml-post-auth-modal__container"
+       role="dialog"
+       aria-modal="true"
+       aria-labelledby="ml-post-auth-modal-title"
+       aria-describedby="ml-post-auth-modal-desc">
+
+    <div class="ml-post-auth-modal__header">
+      <h2 class="dialog-modal__title" id="ml-post-auth-modal-title">Never Miss an Update from Boost Community</h2>
+    </div>
+
+    <hr class="card__hr">
+
+    <div class="ml-post-auth-modal__email-row">
+      <input class="ml-post-auth-modal__email-field"
+             type="email"
+             autocomplete="email"
+             x-model="mlEmail"
+             placeholder="Email address"
+             aria-label="Email address">
+    </div>
+
+    <hr class="card__hr">
+
+    <form id="ml-post-auth-form"
+          hx-post="{{ post_auth_modal_subscribe_url }}"
+          hx-target="#ml-post-auth-modal"
+          hx-swap="outerHTML"
+          hx-on::before-swap="history.replaceState(null, '', window.location.pathname + window.location.search)">
+      {% csrf_token %}
+      <input type="hidden" name="email" :value="mlEmail">
+
+      <div class="ml-post-auth-modal__body" id="ml-post-auth-modal-desc">
+        <p class="ml-post-auth-modal__description">Subscribe to any of our mailing lists. You can change these any time.</p>
+        <div class="ml-post-auth-modal__list-section">
+          <div class="mailing-list-modal__list-card ml-post-auth-modal__list-card">
+            <ul class="mailing-list-modal__list" role="list" x-ref="checkboxContainer">
+              {% for ml in post_auth_modal_mailing_lists %}
+                <li class="mailing-list-modal__item">
+                  <label class="mailing-list-modal__label">
+                    <input class="mailing-list-modal__checkbox"
+                           type="checkbox"
+                           name="list_id"
+                           value="{{ ml.id }}"
+                           checked
+                           @change="updateCount()">
+                    <span class="mailing-list-modal__checkbox-box" aria-hidden="true">
+                      {% include "includes/icon.html" with icon_name="check" icon_class="mailing-list-modal__checkbox-check" icon_size=16 %}
+                    </span>
+                    <div class="mailing-list-modal__item-content">
+                      <span class="mailing-list-modal__item-name">{{ ml.name }}</span>
+                      <span class="mailing-list-modal__item-description">{{ ml.description }}</span>
+                    </div>
+                  </label>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+          <div class="ml-post-auth-modal__footer-row">
+            <button type="button"
+                    class="mailing-list-modal__select-all"
+                    @click="checkedCount === totalLists ? unselectAll() : selectAll()"
+                    x-text="checkedCount === totalLists ? 'Unselect All' : 'Select All'"></button>
+            <span class="ml-post-auth-modal__count"
+                  x-text="checkedCount + ' of ' + totalLists + ' selected'"></span>
+          </div>
+        </div>
+      </div>
+
+      <hr class="card__hr">
+
+      <div class="dialog-modal__buttons">
+        <a href="#_"
+           class="btn btn-secondary btn-flex"
+           role="button"
+           @click="history.replaceState(null, '', window.location.pathname + window.location.search)">Cancel</a>
+        {% include "v3/includes/_button.html" with type="submit" label="Subscribe" style="primary" extra_classes="btn-flex" only %}
+      </div>
+    </form>
+
+  </div>
+</div>

--- a/templates/v3/includes/_mailing_list_post_auth_modal.html
+++ b/templates/v3/includes/_mailing_list_post_auth_modal.html
@@ -58,8 +58,7 @@ via dialog.js (which recognises the checkbox toggle).
           action="{{ post_auth_modal_subscribe_url }}"
           novalidate
           hx-post="{{ post_auth_modal_subscribe_url }}"
-          hx-target="#ml-post-auth-modal"
-          hx-swap="outerHTML"
+          hx-swap="none"
           hx-trigger="ml-submit"
           hx-on::after-request="document.getElementById('ml-post-auth-toggle').checked = false"
           @submit.prevent="emailTouched = true; if (!emailInvalid) htmx.trigger($el, 'ml-submit')">

--- a/users/signals.py
+++ b/users/signals.py
@@ -47,3 +47,6 @@ def user_logged_in_handler(request, user, **kwargs):
     except (KeyError, IndexError):
         method = None
     request.session[LOGIN_METHOD_SESSION_FIELD_NAME] = method or "email"
+
+    if not user.data.get("ml_post_auth_seen"):
+        request.session["show_ml_post_auth_modal"] = True


### PR DESCRIPTION
# Issue: #2436

⚠️ Base branch is [teo/2283-mailing-list-modal](https://github.com/boostorg/website-v2/pull/2472)

## Summary & Context
Adds a post-login mailing list subscription modal that appears automatically on the homepage the first (and only) time a user lands there after logging in. The modal pre-fills the user's account email and lets them choose which lists to subscribe to.

- **Figma link**: https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=5247-36931&m=dev
- **Link to components/page:** localhost:8000/ (logged in, first visit after login)

## Changes

- `users/signals.py` - set `request.session["show_ml_post_auth_modal"]` in `user_logged_in` when user hasn't seen the modal yet (`User.data["ml_post_auth_seen"]` falsy)
- `ak/views.py` (HomepageView) - pop session flag in `get_v3_context_data`; mark user as seen immediately; inject modal list context
- `mailing_list/views.py` - add `PostAuthSubscribeView` (login required); reuses existing subscription + confirmation-email logic; returns empty HTMX fragment to remove modal from DOM
- `mailing_list/urls.py` - register `/mailing-list/post-auth-subscribe/`
- `templates/v3/includes/_mailing_list_post_auth_modal.html` - new standalone modal partial; auto-opens via Alpine `x-init` + CSS `:target`; reuses `.mailing-list-modal__*` classes for checkboxes/list items
- `static/css/v3/mailing-list-card.css` - add `.ml-post-auth-modal__*` classes for email row, body, footer row, and count
- `templates/v3/homepage.html` - conditionally include the modal when `show_ml_post_auth_modal` is in context

## How the "seen once" logic works

1. User logs in - `user_logged_in` signal sets `request.session["show_ml_post_auth_modal"] = True` (only if `User.data["ml_post_auth_seen"]` is not set)
2. User lands on homepage - `HomepageView.get_v3_context_data` pops the session key and immediately sets `User.data["ml_post_auth_seen"] = True` on the User record
3. Template renders the modal; Alpine `x-init` opens it by setting the URL hash
4. Close/cancel: no backend call needed - the seen flag is already persisted from step 2
5. Subscribe: HTMX POSTs to `PostAuthSubscribeView`, which creates PENDING subscription records and sends the confirmation email, then returns an empty response that HTMX uses to remove the modal from DOM

## Risks & Considerations

- The `User.data` JSONField is used for the `ml_post_auth_seen` flag - no migration needed since the field already exists and defaults to `{}`
- The modal only renders on V3 homepage (waffle `v3` flag gate via `HomepageView.get_v3_context_data`)
- No-JS: modal won't auto-open (Alpine required), but subscription is still accessible via the mailing list card on other pages

## Screenshots

<img width="1701" height="1309" alt="image" src="https://github.com/user-attachments/assets/0cb1599c-139e-49e1-a313-828c302ddf8e" />
<img width="378" height="668" alt="image" src="https://github.com/user-attachments/assets/ec6e5ef1-972d-4069-82fa-8888009e8f68" />
<img width="1697" height="1302" alt="image" src="https://github.com/user-attachments/assets/4c58df6b-9ea9-4d49-9ef2-2b8bf2aaf293" />



## Peer-review testing steps

1. Mkae sure the `v3` flag is enabled
2. Log out completely
3. Log in - you should be redirected to homepage and the modal should open automatically
4. Subscribe or cancel - modal closes, no reappearance on refresh
5. Log out and log in again - modal should NOT appear (flag set in the user model)
6. For a fresh test (you'll have to log out and log in again):
   - Open a djano shell in a new terminal with `docker compose exec web python manage.py shell`
   - Run (replace your email):
```python
from users.models import User
user = User.objects.get(email="your@email.com")
user.data.pop("ml_post_auth_seen", None)
user.save()
```

## Self-review Checklist

- [x] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. - No hardcoded values
- [ ] Test without JavaScript (if applicable)
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a post-login mailing list subscription modal on the homepage for eligible users, with prefilled email and multi-list selection.
  * Introduced a dedicated post-auth subscription endpoint to complete subscriptions after login.

* **Bug Fixes**
  * Improved multi-list subscription processing to handle partial successes safely, sending confirmations only for lists subscribed successfully.
  * Added clearer error handling and rollback when confirmation email delivery fails.

* **UX / Accessibility**
  * Refined checkbox-driven dialog behavior and backdrop semantics, improving keyboard/open/close interactions and non-JavaScript fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->