### PR TITLE
feat(2431): add email templates and send email test command

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -561,15 +561,30 @@ NEWS_MODERATION_ALLOWLIST = [
     # with PKs is safe since users.User's PKs are integers.
 ]
 
-# EMAIL SETTINGS -- THESE NEED ADJUSTMENT WHEN DECIDED WHICH ESP WILL BE USED
-EMAIL_HOST = "maildev"
-EMAIL_PORT = 1025
-DEFAULT_FROM_EMAIL = "boost@cppalliance.org"
+# EMAIL SETTINGS
+# Production sends through Mailgun (Anymail). In local development the default
+# is the maildev SMTP container, but every setting below is overridable via env
+# so you can route test sends through your own email service provider -- either
+# an SMTP provider (set EMAIL_HOST/EMAIL_PORT/EMAIL_HOST_USER/
+# EMAIL_HOST_PASSWORD/EMAIL_USE_TLS) or an Anymail API backend (set
+# EMAIL_BACKEND plus that backend's credentials in ANYMAIL).
+EMAIL_HOST = env("EMAIL_HOST", default="maildev")
+EMAIL_PORT = env.int("EMAIL_PORT", default=1025)
+EMAIL_HOST_USER = env("EMAIL_HOST_USER", default="")
+EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD", default="")
+EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS", default=False)
+# Use a "from" on a domain your provider has verified (some providers only
+# accept senders on a domain you own).
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="boost@cppalliance.org")
 SERVER_EMAIL = "errors@cppalliance.org"
 
-# Deployed email configuration
 if LOCAL_DEVELOPMENT:
-    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    EMAIL_BACKEND = env(
+        "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"
+    )
+    # Credentials for an Anymail backend, as a JSON env var, e.g.
+    # ANYMAIL='{"<PROVIDER>_API_TOKEN": "..."}'. Empty/ignored for plain SMTP.
+    ANYMAIL = env.json("ANYMAIL", default={})
 else:
     EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
     ANYMAIL = {

--- a/templates/emails/_social_icon.html
+++ b/templates/emails/_social_icon.html
@@ -1,0 +1,1 @@
+{% load custom_static %}<td style="padding:0 16px 0 0;" valign="middle"><a href="{{ url }}" target="_blank" rel="noopener noreferrer" style="text-decoration:none;"><img src="{% large_static 'img/emails/'|add:icon %}" width="24" height="24" alt="{{ name }}" style="display:block;width:24px;height:24px;"></a></td>

--- a/templates/emails/base_email.html
+++ b/templates/emails/base_email.html
@@ -1,8 +1,8 @@
 {% load custom_static %}{% comment %}
-  Shared base for Boost transactional emails (Story #2431).
+  Shared base for Boost transactional emails.
 
   Frontend / markup only — sending logic lives in the sign-up and
-  password-reset integration tickets. Render this with a context that
+  password-reset flows. Render this with a context that
   provides absolute-URL helpers so images and links resolve in an inbox:
 
     scheme            "https" (request.scheme)

--- a/templates/emails/base_email.html
+++ b/templates/emails/base_email.html
@@ -1,0 +1,140 @@
+{% load custom_static %}{% comment %}
+  Shared base for Boost transactional emails (Story #2431).
+
+  Frontend / markup only — sending logic lives in the sign-up and
+  password-reset integration tickets. Render this with a context that
+  provides absolute-URL helpers so images and links resolve in an inbox:
+
+    scheme            "https" (request.scheme)
+    host              "www.boost.org" (request.get_host)
+    action_url        the CTA + fallback URL (confirmation or reset link)
+    preferences_url   manage-email-preferences URL (optional, defaults to #)
+    unsubscribe_url   unsubscribe URL (optional, defaults to #)
+
+  Child templates override the blocks: preheader, hero, card_title,
+  card_body, cta_label and after_card.
+{% endcomment %}<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="x-apple-disable-message-reformatting">
+    <meta name="color-scheme" content="light">
+    <meta name="supported-color-schemes" content="light">
+    <meta name="format-detection" content="telephone=no, date=no, address=no, email=no">
+    <title>{% block title %}Boost{% endblock %}</title>
+    <!--[if mso]>
+    <style type="text/css">table,td{border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt}</style>
+    <![endif]-->
+    <style type="text/css">
+      body{margin:0;padding:0;width:100%!important;background-color:#f7fdfe;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;}
+      img{border:0;line-height:100%;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic;}
+      a{color:#050816;}
+      table{border-collapse:collapse;}
+      .email-card{border-collapse:separate!important;}
+      @media only screen and (max-width:600px){
+        .email-container{width:100%!important;}
+        .email-px{padding-left:16px!important;padding-right:16px!important;}
+      }
+    </style>
+  </head>
+  <body style="margin:0;padding:0;background-color:#f7fdfe;">
+    <!-- Preheader (hidden preview text) -->
+    <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;font-size:1px;line-height:1px;color:#f7fdfe;opacity:0;">
+      {% block preheader %}{% endblock %}
+    </div>
+
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#f7fdfe;">
+      <tr>
+        <td align="center" style="padding:0;">
+          <!--[if mso]><table role="presentation" align="center" width="600" cellpadding="0" cellspacing="0" border="0"><tr><td><![endif]-->
+          <table role="presentation" class="email-container" width="600" cellpadding="0" cellspacing="0" border="0" style="width:600px;max-width:600px;background-color:#f7fdfe;">
+
+            <!-- Header: Boost logo -->
+            <tr>
+              <td style="padding:18px 16px;" align="left">
+                <a href="{{ scheme }}://{{ host }}/" style="text-decoration:none;">
+                  <img src="{% large_static 'img/emails/email-logo.png' %}" width="184" height="43" alt="Boost" style="display:block;width:184px;height:43px;">
+                </a>
+              </td>
+            </tr>
+
+            <!-- Content -->
+            <tr>
+              <td class="email-px" style="padding:8px 16px 32px 16px;">
+
+                {% block hero %}{% endblock %}
+
+                <!-- Verify card -->
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="email-card" style="background-color:#ffffff;border:1px solid #e2e2e4;border-radius:12px;">
+                  <tr>
+                    <td style="padding:24px 20px;">
+                      <!-- Title -->
+                      <div style="font-family:Arial,Helvetica,sans-serif;font-size:24px;line-height:1.2;letter-spacing:-0.24px;color:#050816;text-align:center;">
+                        {% block card_title %}{% endblock %}
+                      </div>
+                      <!-- Divider -->
+                      <div style="height:1px;line-height:1px;font-size:0;margin:20px 0;background-color:#e2e2e4;">&nbsp;</div>
+                      <!-- Body -->
+                      <div style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:1.45;color:#050816;">
+                        {% block card_body %}{% endblock %}
+                      </div>
+                      <!-- CTA button -->
+                      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:16px 0 0 0;">
+                        <tr>
+                          <td bgcolor="#ffa000" align="center" style="border-radius:4px;">
+                            <a href="{{ action_url|default:'#' }}" style="display:block;padding:12px 24px;font-family:Arial,Helvetica,sans-serif;font-size:12px;font-weight:bold;line-height:1.5;letter-spacing:-0.24px;color:#050816;text-decoration:none;border-radius:4px;">{% block cta_label %}{% endblock %}</a>
+                          </td>
+                        </tr>
+                      </table>
+                      <!-- Fallback URL -->
+                      <div style="font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.45;color:#71737b;margin:16px 0 0 0;">
+                        Or copy and paste this URL into your browser:<br>
+                        <a href="{{ action_url|default:'#' }}" style="color:#71737b;text-decoration:underline;word-break:break-all;">{{ action_url|default:'#' }}</a>
+                      </div>
+                    </td>
+                  </tr>
+                </table>
+
+                {% block after_card %}{% endblock %}
+
+              </td>
+            </tr>
+
+            <!-- Footer -->
+            <tr>
+              <td style="padding:0 16px;">
+                <div style="height:1px;line-height:1px;font-size:0;background-color:#e2e2e4;">&nbsp;</div>
+              </td>
+            </tr>
+            <tr>
+              <td class="email-px" style="padding:24px 16px 40px 16px;">
+                <!-- Social icons -->
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 12px 0;">
+                  <tr>
+                    {% include "emails/_social_icon.html" with url="https://x.com/boost_libraries" name="X" icon="email-social-x.png" %}
+                    {% include "emails/_social_icon.html" with url="https://bsky.app/profile/boost.org" name="Bluesky" icon="email-social-bluesky.png" %}
+                    {% include "emails/_social_icon.html" with url="https://mastodon.social/@boostlibs" name="Mastodon" icon="email-social-mastodon.png" %}
+                    {% include "emails/_social_icon.html" with url="https://www.reddit.com/user/boostlibs/" name="Reddit" icon="email-social-reddit.png" %}
+                    {% include "emails/_social_icon.html" with url="https://github.com/boostorg" name="GitHub" icon="email-social-github.png" %}
+                    {% include "emails/_social_icon.html" with url="https://www.linkedin.com/company/cppalliance/" name="LinkedIn" icon="email-social-linkedin.png" %}
+                  </tr>
+                </table>
+                <!-- Footer text -->
+                <div style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:1.45;letter-spacing:0.14px;color:#050816;">
+                  <a href="https://www.boost.org/" style="color:#050816;text-decoration:underline;">Boost.org</a> is supported by grants from <a href="https://cppalliance.org/" style="color:#050816;text-decoration:underline;">The C++ Alliance.</a>
+                  <br><br>
+                  Want to change how you receive these emails?<br>
+                  You can <a href="{{ preferences_url|default:'#' }}" style="color:#050816;text-decoration:underline;">update your preferences</a> or <a href="{{ unsubscribe_url|default:'#' }}" style="color:#050816;text-decoration:underline;">unsubscribe from this list</a>.
+                </div>
+              </td>
+            </tr>
+
+          </table>
+          <!--[if mso]></td></tr></table><![endif]-->
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/templates/emails/base_email.html
+++ b/templates/emails/base_email.html
@@ -11,6 +11,10 @@
     preferences_url   manage-email-preferences URL (optional, defaults to #)
     unsubscribe_url   unsubscribe URL (optional, defaults to #)
 
+  Body copy uses the platform UI font stack (Segoe UI on Windows, San Francisco
+  on Apple, Roboto on Android) at a light 300 weight; the title, button and
+  footer use Arial.
+
   Child templates override the blocks: preheader, hero, card_title,
   card_body, cta_label and after_card.
 {% endcomment %}<!DOCTYPE html>
@@ -77,7 +81,7 @@
                       <!-- Divider -->
                       <div style="height:1px;line-height:1px;font-size:0;margin:20px 0;background-color:#e2e2e4;">&nbsp;</div>
                       <!-- Body -->
-                      <div style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:1.45;color:#050816;">
+                      <div style="font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:14px;line-height:1.45;color:#050816;">
                         {% block card_body %}{% endblock %}
                       </div>
                       <!-- CTA button -->
@@ -89,7 +93,7 @@
                         </tr>
                       </table>
                       <!-- Fallback URL -->
-                      <div style="font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.45;color:#71737b;margin:16px 0 0 0;">
+                      <div style="font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:12px;line-height:1.45;color:#71737b;margin:16px 0 0 0;">
                         Or copy and paste this URL into your browser:<br>
                         <a href="{{ action_url|default:'#' }}" style="color:#71737b;text-decoration:underline;word-break:break-all;">{{ action_url|default:'#' }}</a>
                       </div>

--- a/templates/emails/confirm_email.html
+++ b/templates/emails/confirm_email.html
@@ -16,7 +16,7 @@
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
     <tr>
       <td style="padding:0 0 24px 0;">
-        <img src="{% large_static 'img/emails/email-octopus.jpg' %}" width="568" alt="" style="display:block;width:100%;max-width:568px;height:auto;border-radius:12px;">
+        <img src="{% large_static 'img/emails/email-welcome.jpg' %}" width="568" alt="" style="display:block;width:100%;max-width:568px;height:auto;border-radius:12px;">
       </td>
     </tr>
   </table>
@@ -35,7 +35,7 @@
 {% block after_card %}
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
     <tr>
-      <td style="padding:24px 0 0 0;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.45;color:#71737b;text-align:center;">
+      <td style="padding:24px 0 0 0;font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:12px;line-height:1.45;color:#71737b;text-align:center;">
         If you didn&#39;t create a Boost account, you can safely ignore this email.
       </td>
     </tr>

--- a/templates/emails/confirm_email.html
+++ b/templates/emails/confirm_email.html
@@ -4,7 +4,8 @@
 {% comment %}
   Sign-up confirmation email.
   Subject: "Confirm your email" (see confirm_email_subject.txt).
-  Context: first_name, action_url (confirmation URL), scheme, host.
+  Context: first_name, action_url (confirmation URL), scheme, host,
+  confirmation_link_lifetime (e.g. "3 days").
 {% endcomment %}
 
 {% block title %}Confirm your email{% endblock %}
@@ -26,7 +27,7 @@
 {% block card_body %}
   <p style="margin:0;">Hi {{ first_name|default:"there" }},</p>
   <p style="margin:14px 0 0 0;">Thanks for signing up for Boost. To activate your account, please confirm your email address by clicking the button below.</p>
-  <p style="margin:14px 0 0 0;">This link expires in 24 hours.</p>
+  <p style="margin:14px 0 0 0;">This link expires in {{ confirmation_link_lifetime }}.</p>
 {% endblock %}
 
 {% block cta_label %}Confirm my email{% endblock %}

--- a/templates/emails/confirm_email.html
+++ b/templates/emails/confirm_email.html
@@ -1,0 +1,42 @@
+{% extends "emails/base_email.html" %}
+{% load custom_static %}
+
+{% comment %}
+  Email 1 — Sign-up confirmation (Story #2431).
+  Subject: "Confirm your email" (see confirm_email_subject.txt).
+  Context: first_name, action_url (confirmation URL), scheme, host.
+{% endcomment %}
+
+{% block title %}Confirm your email{% endblock %}
+
+{% block preheader %}Confirm your email address to activate your Boost account.{% endblock %}
+
+{% block hero %}
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td style="padding:0 0 24px 0;">
+        <img src="{% large_static 'img/emails/email-octopus.jpg' %}" width="568" alt="" style="display:block;width:100%;max-width:568px;height:auto;border-radius:12px;">
+      </td>
+    </tr>
+  </table>
+{% endblock %}
+
+{% block card_title %}Welcome to Boost{% endblock %}
+
+{% block card_body %}
+  <p style="margin:0;">Hi {{ first_name|default:"there" }},</p>
+  <p style="margin:14px 0 0 0;">Thanks for signing up for Boost. To activate your account, please confirm your email address by clicking the button below.</p>
+  <p style="margin:14px 0 0 0;">This link expires in 24 hours.</p>
+{% endblock %}
+
+{% block cta_label %}Confirm my email{% endblock %}
+
+{% block after_card %}
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td style="padding:24px 0 0 0;font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.45;color:#71737b;text-align:center;">
+        If you didn&#39;t create a Boost account, you can safely ignore this email.
+      </td>
+    </tr>
+  </table>
+{% endblock %}

--- a/templates/emails/confirm_email.html
+++ b/templates/emails/confirm_email.html
@@ -2,7 +2,7 @@
 {% load custom_static %}
 
 {% comment %}
-  Email 1 — Sign-up confirmation (Story #2431).
+  Sign-up confirmation email.
   Subject: "Confirm your email" (see confirm_email_subject.txt).
   Context: first_name, action_url (confirmation URL), scheme, host.
 {% endcomment %}

--- a/templates/emails/confirm_email.txt
+++ b/templates/emails/confirm_email.txt
@@ -5,7 +5,7 @@ Hi {{ first_name|default:"there" }},
 Thanks for signing up for Boost. To activate your account, please confirm
 your email address by visiting the link below.
 
-This link expires in 24 hours.
+This link expires in {{ confirmation_link_lifetime }}.
 
 Confirm my email:
 {{ action_url }}

--- a/templates/emails/confirm_email.txt
+++ b/templates/emails/confirm_email.txt
@@ -1,0 +1,19 @@
+Welcome to Boost
+
+Hi {{ first_name|default:"there" }},
+
+Thanks for signing up for Boost. To activate your account, please confirm
+your email address by visiting the link below.
+
+This link expires in 24 hours.
+
+Confirm my email:
+{{ action_url }}
+
+If you didn't create a Boost account, you can safely ignore this email.
+
+--
+Boost.org is supported by grants from The C++ Alliance.
+
+Want to change how you receive these emails?
+You can update your preferences or unsubscribe from this list.

--- a/templates/emails/confirm_email_subject.txt
+++ b/templates/emails/confirm_email_subject.txt
@@ -1,0 +1,1 @@
+Confirm your email

--- a/templates/emails/password_reset.html
+++ b/templates/emails/password_reset.html
@@ -15,8 +15,8 @@
 {% block hero %}
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
     <tr>
-      <td align="center" style="padding:20px 0 24px 0;">
-        <img src="{% large_static 'img/emails/email-lock.png' %}" width="26" height="32" alt="" style="display:block;width:26px;height:32px;">
+      <td style="padding:0 0 24px 0;">
+        <img src="{% large_static 'img/emails/email-password-reset.jpg' %}" width="568" alt="" style="display:block;width:100%;max-width:568px;height:auto;border-radius:12px;">
       </td>
     </tr>
   </table>
@@ -41,7 +41,7 @@
             <td valign="top" style="padding:2px 12px 0 0;">
               <img src="{% large_static 'img/emails/email-warning.png' %}" width="16" height="16" alt="" style="display:block;width:16px;height:16px;">
             </td>
-            <td valign="top" style="font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.45;color:#050816;">
+            <td valign="top" style="font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:12px;line-height:1.45;color:#050816;">
               Didn&#39;t ask for this? Maybe someone typed your email by accident. You can ignore this email safely &mdash; your password will stay the same.
             </td>
           </tr>

--- a/templates/emails/password_reset.html
+++ b/templates/emails/password_reset.html
@@ -2,7 +2,7 @@
 {% load custom_static %}
 
 {% comment %}
-  Email 2 — Password reset (Story #2431).
+  Password reset email.
   Subject: "Password reset link" (see password_reset_subject.txt).
   Context: first_name, user_email, action_url (reset URL), scheme, host.
 {% endcomment %}

--- a/templates/emails/password_reset.html
+++ b/templates/emails/password_reset.html
@@ -4,7 +4,8 @@
 {% comment %}
   Password reset email.
   Subject: "Password reset link" (see password_reset_subject.txt).
-  Context: first_name, user_email, action_url (reset URL), scheme, host.
+  Context: first_name, user_email, action_url (reset URL), scheme, host,
+  password_reset_link_lifetime (e.g. "3 days").
 {% endcomment %}
 
 {% block title %}Password reset link{% endblock %}
@@ -26,7 +27,7 @@
 {% block card_body %}
   <p style="margin:0;">Hi {{ first_name|default:"there" }},</p>
   <p style="margin:14px 0 0 0;">We received a request to reset the password for your Boost account ({{ user_email }}).</p>
-  <p style="margin:14px 0 0 0;">Click the button below to set a new password. This link will expire in 1 hour.</p>
+  <p style="margin:14px 0 0 0;">Click the button below to set a new password. This link will expire in {{ password_reset_link_lifetime }}.</p>
 {% endblock %}
 
 {% block cta_label %}Reset my password{% endblock %}

--- a/templates/emails/password_reset.html
+++ b/templates/emails/password_reset.html
@@ -1,0 +1,51 @@
+{% extends "emails/base_email.html" %}
+{% load custom_static %}
+
+{% comment %}
+  Email 2 — Password reset (Story #2431).
+  Subject: "Password reset link" (see password_reset_subject.txt).
+  Context: first_name, user_email, action_url (reset URL), scheme, host.
+{% endcomment %}
+
+{% block title %}Password reset link{% endblock %}
+
+{% block preheader %}Reset the password for your Boost account.{% endblock %}
+
+{% block hero %}
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td align="center" style="padding:20px 0 24px 0;">
+        <img src="{% large_static 'img/emails/email-lock.png' %}" width="26" height="32" alt="" style="display:block;width:26px;height:32px;">
+      </td>
+    </tr>
+  </table>
+{% endblock %}
+
+{% block card_title %}Reset your password{% endblock %}
+
+{% block card_body %}
+  <p style="margin:0;">Hi {{ first_name|default:"there" }},</p>
+  <p style="margin:14px 0 0 0;">We received a request to reset the password for your Boost account ({{ user_email }}).</p>
+  <p style="margin:14px 0 0 0;">Click the button below to set a new password. This link will expire in 1 hour.</p>
+{% endblock %}
+
+{% block cta_label %}Reset my password{% endblock %}
+
+{% block after_card %}
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:24px 0 0 0;">
+    <tr>
+      <td style="background-color:#fef7f7;border:1px solid #f2c9c9;border-radius:8px;padding:12px 14px;">
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+          <tr>
+            <td valign="top" style="padding:2px 12px 0 0;">
+              <img src="{% large_static 'img/emails/email-warning.png' %}" width="16" height="16" alt="" style="display:block;width:16px;height:16px;">
+            </td>
+            <td valign="top" style="font-family:Arial,Helvetica,sans-serif;font-size:12px;line-height:1.45;color:#050816;">
+              Didn&#39;t ask for this? Maybe someone typed your email by accident. You can ignore this email safely &mdash; your password will stay the same.
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+{% endblock %}

--- a/templates/emails/password_reset.txt
+++ b/templates/emails/password_reset.txt
@@ -1,0 +1,20 @@
+Reset your password
+
+Hi {{ first_name|default:"there" }},
+
+We received a request to reset the password for your Boost account
+({{ user_email }}).
+
+Click the link below to set a new password. This link will expire in 1 hour.
+
+Reset my password:
+{{ action_url }}
+
+Didn't ask for this? Maybe someone typed your email by accident. You can
+ignore this email safely - your password will stay the same.
+
+--
+Boost.org is supported by grants from The C++ Alliance.
+
+Want to change how you receive these emails?
+You can update your preferences or unsubscribe from this list.

--- a/templates/emails/password_reset.txt
+++ b/templates/emails/password_reset.txt
@@ -5,7 +5,7 @@ Hi {{ first_name|default:"there" }},
 We received a request to reset the password for your Boost account
 ({{ user_email }}).
 
-Click the link below to set a new password. This link will expire in 1 hour.
+Click the link below to set a new password. This link will expire in {{ password_reset_link_lifetime }}.
 
 Reset my password:
 {{ action_url }}

--- a/templates/emails/password_reset_subject.txt
+++ b/templates/emails/password_reset_subject.txt
@@ -1,0 +1,1 @@
+Password reset link

--- a/users/management/commands/send_test_emails.py
+++ b/users/management/commands/send_test_emails.py
@@ -30,14 +30,32 @@ that provider has verified.
 
 import re
 import time
+from datetime import timedelta
 from email.message import EmailMessage as PyEmailMessage
 from email.mime.image import MIMEImage
 
 import djclick as click
+from allauth.account import app_settings as allauth_account_settings
 from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.core.mail import EmailMultiAlternatives, get_connection
 from django.template.loader import render_to_string
+
+
+def _humanize_link_lifetime(delta):
+    """Return a short phrase for a link lifetime, e.g. "3 days" or "1 hour".
+
+    Picks the largest whole unit so the copy reads naturally for whole-day or
+    whole-hour settings, and pluralizes correctly (so a one-day or one-hour
+    timeout never renders as "1 days" / "0 days").
+    """
+    seconds = int(delta.total_seconds())
+    for unit_seconds, name in ((86400, "day"), (3600, "hour"), (60, "minute")):
+        count = seconds // unit_seconds
+        if count:
+            return f"{count} {name}{'' if count == 1 else 's'}"
+    return f"{seconds} second{'' if seconds == 1 else 's'}"
+
 
 # Available templates: key -> subject / text / html templates + a sample link.
 TEMPLATES = {
@@ -226,6 +244,15 @@ def command(
             "action_url": spec["action_url"],
             "preferences_url": f"{base_url}/account/preferences",
             "unsubscribe_url": f"{base_url}/account/unsubscribe",
+            # Link lifetimes shown in the email bodies, sourced from the same
+            # settings the real flows enforce (allauth email confirmation in
+            # days, Django's password reset token timeout in seconds).
+            "confirmation_link_lifetime": _humanize_link_lifetime(
+                timedelta(days=allauth_account_settings.EMAIL_CONFIRMATION_EXPIRE_DAYS)
+            ),
+            "password_reset_link_lifetime": _humanize_link_lifetime(
+                timedelta(seconds=settings.PASSWORD_RESET_TIMEOUT)
+            ),
         }
         subject = render_to_string(spec["subject"], context).strip()
         text_body = render_to_string(spec["text"], context)

--- a/users/management/commands/send_test_emails.py
+++ b/users/management/commands/send_test_emails.py
@@ -1,7 +1,7 @@
-"""Send the transactional email templates (Story #2431) to a test inbox.
+"""Send the transactional email templates to a test inbox.
 
 Frontend test helper only -- this does NOT touch the real sign-up / password
-reset flows (those live in their own integration tickets). It renders the
+reset flows. It renders the
 templates in ``templates/emails/`` and sends them through the project's
 configured email backend (``settings.EMAIL_BACKEND``) -- the same backend the
 real transactional emails use. Locally that is the ``maildev`` SMTP container
@@ -195,7 +195,7 @@ def command(
     inline_images,
     delay,
 ):
-    """Render and send the Story #2431 transactional email templates."""
+    """Render and send the transactional email templates."""
     scheme, _, host = base_url.partition("://")
     if not host:  # base_url given without a scheme
         scheme, host = "https", base_url

--- a/users/management/commands/send_test_emails.py
+++ b/users/management/commands/send_test_emails.py
@@ -1,0 +1,207 @@
+"""Send the transactional email templates (Story #2431) to a test inbox.
+
+Frontend test helper only -- this does NOT touch the real sign-up / password
+reset flows (those live in their own integration tickets). It renders the
+templates in ``templates/emails/`` and sends them through the project's
+configured email backend (``settings.EMAIL_BACKEND``) -- the same backend the
+real transactional emails use. Locally that is the ``maildev`` SMTP container
+(``EMAIL_HOST``/``EMAIL_PORT``); deployed environments use the configured ESP.
+
+Examples
+--------
+Send both emails to your local maildev inbox::
+
+    python manage.py send_test_emails --to you@example.com
+
+By default the email images are embedded inline (multipart/related CID parts) so
+they render even when the static host is not publicly reachable. This requires an
+SMTP backend (the local default). Pass ``--no-inline-images`` together with
+``--base-url`` to instead reference the images served from the real host (S3
+large-static) -- needed when sending through a non-SMTP ESP backend.
+"""
+
+import re
+import time
+from email.message import EmailMessage as PyEmailMessage
+
+import djclick as click
+from django.conf import settings
+from django.contrib.staticfiles import finders
+from django.core.mail import EmailMultiAlternatives, get_connection
+from django.template.loader import render_to_string
+
+# Available templates: key -> subject / text / html templates + a sample link.
+TEMPLATES = {
+    "confirm": {
+        "subject": "emails/confirm_email_subject.txt",
+        "text": "emails/confirm_email.txt",
+        "html": "emails/confirm_email.html",
+        "action_url": "https://www.boost.org/auth/confirm?token=test-confirm-token-abc123",
+    },
+    "password_reset": {
+        "subject": "emails/password_reset_subject.txt",
+        "text": "emails/password_reset.txt",
+        "html": "emails/password_reset.html",
+        "action_url": "https://www.boost.org/auth/reset?token=test-reset-token-xyz789",
+    },
+}
+
+# Matches the URL of any email image, e.g. src="/static/static-large/img/emails/x.png"
+# (local dev) or the absolute S3 URL (prod) -- both end in "img/emails/<file>".
+EMAIL_IMG_RE = re.compile(r'src="[^"]*?(img/emails/[^"]+\.(?:png|jpe?g))"')
+EXT_SUBTYPE = {"png": "png", "jpg": "jpeg", "jpeg": "jpeg"}
+
+
+def _collect_inline_images(html):
+    """Rewrite email image ``src`` to ``cid:`` refs; return (html, images).
+
+    ``images`` is a list of ``(cid, subtype, bytes)`` for each referenced file.
+    """
+    relpaths = {m.group(1) for m in EMAIL_IMG_RE.finditer(html)}
+    html = EMAIL_IMG_RE.sub(
+        lambda m: 'src="cid:{}"'.format(m.group(1).split("/")[-1]), html
+    )
+    images = []
+    for relpath in sorted(relpaths):
+        # Email images are served from large static (static/static-large/, synced
+        # to S3); the rendered URL drops that prefix, so add it back to locate the
+        # file on disk for inline embedding.
+        path = finders.find(f"static-large/{relpath}")
+        if not path:
+            raise click.ClickException(f"Static file not found: {relpath}")
+        cid = relpath.split("/")[-1]
+        subtype = EXT_SUBTYPE[relpath.rsplit(".", 1)[1].lower()]
+        with open(path, "rb") as fh:
+            images.append((cid, subtype, fh.read()))
+    return html, images
+
+
+def _send_inline(connection, subject, text_body, html_body, from_email, recipient):
+    """Build a multipart/related message with inline images and SMTP-send it."""
+    html_body, images = _collect_inline_images(html_body)
+
+    msg = PyEmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = from_email
+    msg["To"] = recipient
+    msg.set_content(text_body)
+    msg.add_alternative(html_body, subtype="html")
+    # The HTML alternative is the last payload; attach images related to it so
+    # clients resolve the cid: references (multipart/related).
+    html_part = msg.get_payload()[-1]
+    for cid, subtype, data in images:
+        html_part.add_related(data, maintype="image", subtype=subtype, cid=f"<{cid}>")
+
+    connection.open()
+    connection.connection.send_message(msg, from_addr=from_email, to_addrs=[recipient])
+
+
+@click.command()
+@click.option("--to", "recipient", required=True, help="Recipient email address.")
+@click.option(
+    "--template",
+    "which",
+    type=click.Choice(["confirm", "password_reset", "all"]),
+    default="all",
+    show_default=True,
+    help="Which template(s) to send.",
+)
+@click.option("--first-name", default="Vinnie", show_default=True)
+@click.option(
+    "--user-email",
+    default="",
+    help="Account email shown in the password reset body (defaults to --to).",
+)
+@click.option(
+    "--from-email",
+    default=settings.DEFAULT_FROM_EMAIL,
+    show_default=True,
+    help="From address.",
+)
+@click.option(
+    "--base-url",
+    default="https://www.boost.org",
+    show_default=True,
+    help="scheme://host used to build absolute asset/link URLs.",
+)
+@click.option(
+    "--inline-images/--no-inline-images",
+    default=True,
+    show_default=True,
+    help="Embed images as inline CID parts (recommended for previews; SMTP only).",
+)
+@click.option(
+    "--delay",
+    type=float,
+    default=0.0,
+    show_default=True,
+    help="Seconds to wait between messages (raise it if your ESP rate-limits bursts).",
+)
+def command(
+    recipient,
+    which,
+    first_name,
+    user_email,
+    from_email,
+    base_url,
+    inline_images,
+    delay,
+):
+    """Render and send the Story #2431 transactional email templates."""
+    scheme, _, host = base_url.partition("://")
+    if not host:  # base_url given without a scheme
+        scheme, host = "https", base_url
+
+    # Use the project's configured email backend -- the same one the real
+    # transactional emails go through (local maildev SMTP, or the deployed ESP).
+    connection = get_connection()
+    is_smtp = "smtp" in settings.EMAIL_BACKEND
+    if inline_images and not is_smtp:
+        raise click.ClickException(
+            "Inline images require an SMTP backend, but EMAIL_BACKEND is "
+            f"{settings.EMAIL_BACKEND!r}. Re-run with --no-inline-images."
+        )
+    target = (
+        f"{settings.EMAIL_HOST}:{settings.EMAIL_PORT}"
+        if is_smtp
+        else settings.EMAIL_BACKEND
+    )
+
+    keys = ["confirm", "password_reset"] if which == "all" else [which]
+    click.secho(f"Sending via {target} -> {recipient}", fg="green")
+
+    for index, key in enumerate(keys):
+        if index and delay:
+            time.sleep(delay)
+        spec = TEMPLATES[key]
+        context = {
+            "scheme": scheme,
+            "host": host,
+            "first_name": first_name,
+            "user_email": user_email or recipient,
+            "action_url": spec["action_url"],
+            "preferences_url": f"{base_url}/account/preferences",
+            "unsubscribe_url": f"{base_url}/account/unsubscribe",
+        }
+        subject = render_to_string(spec["subject"], context).strip()
+        text_body = render_to_string(spec["text"], context)
+        html_body = render_to_string(spec["html"], context)
+
+        if inline_images:
+            _send_inline(
+                connection, subject, text_body, html_body, from_email, recipient
+            )
+        else:
+            msg = EmailMultiAlternatives(
+                subject=subject,
+                body=text_body,
+                from_email=from_email,
+                to=[recipient],
+                connection=connection,
+            )
+            msg.attach_alternative(html_body, "text/html")
+            msg.send()
+        click.secho(f"  sent: {key} — {subject!r}", fg="cyan")
+
+    connection.close()
+    click.secho("Done.", fg="green")

--- a/users/management/commands/send_test_emails.py
+++ b/users/management/commands/send_test_emails.py
@@ -5,7 +5,8 @@ reset flows (those live in their own integration tickets). It renders the
 templates in ``templates/emails/`` and sends them through the project's
 configured email backend (``settings.EMAIL_BACKEND``) -- the same backend the
 real transactional emails use. Locally that is the ``maildev`` SMTP container
-(``EMAIL_HOST``/``EMAIL_PORT``); deployed environments use the configured ESP.
+(``EMAIL_HOST``/``EMAIL_PORT``); deployed environments use the configured email
+service provider.
 
 Examples
 --------
@@ -14,15 +15,23 @@ Send both emails to your local maildev inbox::
     python manage.py send_test_emails --to you@example.com
 
 By default the email images are embedded inline (multipart/related CID parts) so
-they render even when the static host is not publicly reachable. This requires an
-SMTP backend (the local default). Pass ``--no-inline-images`` together with
-``--base-url`` to instead reference the images served from the real host (S3
-large-static) -- needed when sending through a non-SMTP ESP backend.
+they render even when the static host is not publicly reachable. This works with
+both SMTP backends (maildev, or your own SMTP server) and API
+email-service-provider backends (any Anymail backend). Pass
+``--no-inline-images`` together with ``--base-url`` to instead reference the
+images served from the real host (S3 large-static).
+
+To send real preview emails through your own email service provider in local
+development, point the email settings at it -- an SMTP provider via the
+``EMAIL_*`` settings, or an Anymail API backend via ``EMAIL_BACKEND`` +
+``ANYMAIL`` -- and use a ``DEFAULT_FROM_EMAIL`` / ``--from-email`` on a domain
+that provider has verified.
 """
 
 import re
 import time
 from email.message import EmailMessage as PyEmailMessage
+from email.mime.image import MIMEImage
 
 import djclick as click
 from django.conf import settings
@@ -77,23 +86,55 @@ def _collect_inline_images(html):
 
 
 def _send_inline(connection, subject, text_body, html_body, from_email, recipient):
-    """Build a multipart/related message with inline images and SMTP-send it."""
+    """Send a message with inline (CID) images, for any email backend.
+
+    The two backends need different handling (Django 6 dropped the high-level
+    ``multipart/related`` hooks, so attachments otherwise land in a flat
+    ``multipart/mixed``):
+
+    * SMTP (maildev, or your own SMTP server) -- hand-build a proper
+      ``multipart/alternative[text, multipart/related[html, images]]`` tree so
+      clients render the ``cid:`` references inline.
+    * API email service provider (any Anymail backend) -- attach the images
+      as ``Content-ID`` inline parts; Anymail turns those into the provider's
+      native inline images.
+    """
     html_body, images = _collect_inline_images(html_body)
 
-    msg = PyEmailMessage()
-    msg["Subject"] = subject
-    msg["From"] = from_email
-    msg["To"] = recipient
-    msg.set_content(text_body)
-    msg.add_alternative(html_body, subtype="html")
-    # The HTML alternative is the last payload; attach images related to it so
-    # clients resolve the cid: references (multipart/related).
-    html_part = msg.get_payload()[-1]
-    for cid, subtype, data in images:
-        html_part.add_related(data, maintype="image", subtype=subtype, cid=f"<{cid}>")
+    if "smtp" in settings.EMAIL_BACKEND:
+        msg = PyEmailMessage()
+        msg["Subject"] = subject
+        msg["From"] = from_email
+        msg["To"] = recipient
+        msg.set_content(text_body)
+        msg.add_alternative(html_body, subtype="html")
+        # The HTML alternative is the last payload; attach the images to it so
+        # they form a multipart/related group resolving the cid: references.
+        html_part = msg.get_payload()[-1]
+        for cid, subtype, data in images:
+            html_part.add_related(
+                data, maintype="image", subtype=subtype, cid=f"<{cid}>"
+            )
+        connection.open()
+        # No from_addr/to_addrs: let smtplib derive the envelope from the
+        # headers so a "Name <addr>" --from-email still yields a bare MAIL FROM.
+        connection.connection.send_message(msg)
+        return
 
-    connection.open()
-    connection.connection.send_message(msg, from_addr=from_email, to_addrs=[recipient])
+    msg = EmailMultiAlternatives(
+        subject=subject,
+        body=text_body,
+        from_email=from_email,
+        to=[recipient],
+        connection=connection,
+    )
+    msg.attach_alternative(html_body, "text/html")
+    for cid, subtype, data in images:
+        image = MIMEImage(data, _subtype=subtype)
+        image.add_header("Content-ID", f"<{cid}>")
+        image.add_header("Content-Disposition", "inline", filename=cid)
+        msg.attach(image)
+    msg.send()
 
 
 @click.command()
@@ -116,7 +157,11 @@ def _send_inline(connection, subject, text_body, html_body, from_email, recipien
     "--from-email",
     default=settings.DEFAULT_FROM_EMAIL,
     show_default=True,
-    help="From address.",
+    help=(
+        "From address. Overrides DEFAULT_FROM_EMAIL -- use a domain your email "
+        "service provider has verified (most providers require the sender "
+        "domain to be verified)."
+    ),
 )
 @click.option(
     "--base-url",
@@ -128,14 +173,17 @@ def _send_inline(connection, subject, text_body, html_body, from_email, recipien
     "--inline-images/--no-inline-images",
     default=True,
     show_default=True,
-    help="Embed images as inline CID parts (recommended for previews; SMTP only).",
+    help="Embed images as inline CID parts (recommended for previews).",
 )
 @click.option(
     "--delay",
     type=float,
     default=0.0,
     show_default=True,
-    help="Seconds to wait between messages (raise it if your ESP rate-limits bursts).",
+    help=(
+        "Seconds to wait between messages (raise it if your email service "
+        "provider rate-limits bursts)."
+    ),
 )
 def command(
     recipient,
@@ -153,14 +201,10 @@ def command(
         scheme, host = "https", base_url
 
     # Use the project's configured email backend -- the same one the real
-    # transactional emails go through (local maildev SMTP, or the deployed ESP).
+    # transactional emails go through (local maildev SMTP, or the deployed
+    # email service provider).
     connection = get_connection()
     is_smtp = "smtp" in settings.EMAIL_BACKEND
-    if inline_images and not is_smtp:
-        raise click.ClickException(
-            "Inline images require an SMTP backend, but EMAIL_BACKEND is "
-            f"{settings.EMAIL_BACKEND!r}. Re-run with --no-inline-images."
-        )
     target = (
         f"{settings.EMAIL_HOST}:{settings.EMAIL_PORT}"
         if is_smtp


### PR DESCRIPTION
# Issue: #2431 

## Summary & Context
Adds the templates and images (sync down from S3) for Email Confirmation and Password Reset.

- **Figma link**: 
    - Email Confirmation and Password Reset https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=6635-5187&t=vZWJaoznUsHhdFqw-4

## Changes

- Email templates (HTML and text)
- Images uploaded to large_static S3 buckets
- send_test_email command

## ‼️ Risks & Considerations ‼️
- Should we move smaller images to the repo instead of S3?
- ~[ ] Get email credentials so it's easier to test emails in local development.~
- To send some email tests just give me your email and I'll trigger the test command which is setup with my personal email sending API credentials.

## Screenshots
### Confirm email: HTML / Desktop
<img width="1342" height="1290" alt="image" src="https://github.com/user-attachments/assets/3cd1d339-baa0-4123-b19c-3f6c31a2394f" />

### Confirm email: text
```
Welcome to Boost

Hi Vinnie,

Thanks for signing up for Boost. To activate your account, please confirm
your email address by visiting the link below.

This link expires in 24 hours.

Confirm my email:
https://www.boost.org/auth/confirm?token=test-confirm-token-abc123

If you didn't create a Boost account, you can safely ignore this email.

--
Boost.org is supported by grants from The C++ Alliance.

Want to change how you receive these emails?
You can update your preferences or unsubscribe from this list.
```

### Confirm email: HTML mobile
<img width="426" height="817" alt="image" src="https://github.com/user-attachments/assets/aeaea0f3-3e38-4fba-a916-0216fe208470" />

### Password reset: HTML Desktop
<img width="733" height="881" alt="image" src="https://github.com/user-attachments/assets/85019296-da56-4040-9d1a-18da54c0479a" />

### Password reset: HTML mobile
<img width="486" height="833" alt="image" src="https://github.com/user-attachments/assets/ceac7f45-871f-456d-bc80-3d19055fb102" />

### Password reset: text
```
Reset your password

Hi Vinnie,

We received a request to reset the password for your Boost account
(vinnie@cppalliance.org).

Click the link below to set a new password. This link will expire in 1 hour.

Reset my password:
https://www.boost.org/auth/reset?token=test-reset-token-xyz789

Didn't ask for this? Maybe someone typed your email by accident. You can
ignore this email safely - your password will stay the same.

--
Boost.org is supported by grants from The C++ Alliance.

Want to change how you receive these emails?
You can update your preferences or unsubscribe from this list.
```

### Gmail

#### iOS
<img width="1290" height="2617" alt="IMG_6213" src="https://github.com/user-attachments/assets/36eccc6b-293c-469a-94af-2e6015de1186" />

<img width="1290" height="2546" alt="image" src="https://github.com/user-attachments/assets/e3a3da43-a416-47b1-8f4c-76916f9eaa12" />


#### Web
<img width="691" height="1116" alt="image" src="https://github.com/user-attachments/assets/b0854f1a-b2be-45e7-b4d3-ed2ef369a7c3" />

<img width="690" height="1038" alt="image" src="https://github.com/user-attachments/assets/b3e94c9f-f9f1-4020-b324-9fbaffd96d73" />

### Apple Mail

<img width="1290" height="2657" alt="image" src="https://github.com/user-attachments/assets/d4a7f355-18ee-4b73-8047-b772211eb251" />
<img width="1290" height="2619" alt="image" src="https://github.com/user-attachments/assets/63e9d2b0-decd-43e5-b47e-7d7afecadc46" />




## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [ ] Tested in light and dark mode
- [x] Responsive / mobile verified
- [ ] Accessibility checked (keyboard navigation, etc.)
- [ ] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a shared HTML base template and new transactional email templates for confirming email and resetting passwords (HTML + subject + plain-text variants).
  * Social icons are now included in the email footer.
  * Added a management command to send test transactional emails, with optional inline image embedding.

* **Chores**
  * Updated email configuration to be fully environment-variable driven, including local development backend settings and Mailgun/Anymail options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->