### PR TITLE
Story 2466: Update global Text Field component with disabled state

### DIFF
--- a/static/css/v3/forms.css
+++ b/static/css/v3/forms.css
@@ -216,15 +216,15 @@
 .field__control--disabled,
 .field__control--disabled:hover,
 .field__control--disabled:focus-within {
-  background-color: var(--color-surface-mid, #f7f7f8);
-  border-color: var(--color-stroke-strong, #05081640);
+  background-color: var(--color-surface-mid);
+  border-color: var(--color-stroke-strong);
   cursor: not-allowed;
 }
 
 .field__control--disabled .field__input,
 .field__control--disabled .field__input::placeholder,
 .field__control--disabled:hover .field__input::placeholder {
-  color: var(--color-text-secondary, #6b6d78);
+  color: var(--color-text-secondary);
 }
 
 .field__control--disabled .field__input {
@@ -234,7 +234,7 @@
 .field__control--disabled .field__icon,
 .field__control--disabled:hover .field__icon,
 .field__control--disabled:focus-within .field__icon {
-  color: var(--color-icon-secondary, #6b6d78);
+  color: var(--color-icon-secondary);
 }
 
 /* ========== Datetime-local: hide native icon, full-area click ========== */

--- a/static/css/v3/forms.css
+++ b/static/css/v3/forms.css
@@ -216,12 +216,25 @@
 .field__control--disabled,
 .field__control--disabled:hover,
 .field__control--disabled:focus-within {
-  opacity: 0.5;
+  background-color: var(--color-surface-mid, #f7f7f8);
+  border-color: var(--color-stroke-strong, #05081640);
   cursor: not-allowed;
+}
+
+.field__control--disabled .field__input,
+.field__control--disabled .field__input::placeholder,
+.field__control--disabled:hover .field__input::placeholder {
+  color: var(--color-text-secondary, #6b6d78);
 }
 
 .field__control--disabled .field__input {
   cursor: not-allowed;
+}
+
+.field__control--disabled .field__icon,
+.field__control--disabled:hover .field__icon,
+.field__control--disabled:focus-within .field__icon {
+  color: var(--color-icon-secondary, #6b6d78);
 }
 
 /* ========== Datetime-local: hide native icon, full-area click ========== */

--- a/templates/v3/examples/_v3_example_section.html
+++ b/templates/v3/examples/_v3_example_section.html
@@ -505,6 +505,7 @@
           {% include "v3/includes/_field_text.html" with name="ex_basic" label="Text field" placeholder="Enter text..." %}
           {% include "v3/includes/_field_text.html" with name="ex_search" label="With icon" placeholder="Search..." icon_left="search" %}
           {% include "v3/includes/_field_text.html" with name="ex_error" label="Error state" placeholder="Enter value" error="This field is required." %}
+          {% include "v3/includes/_field_text.html" with name="ex_disabled" label="Disabled state" placeholder="Enter value" value="Disabled value" disabled="true" %}
           {% include "v3/includes/_field_checkbox.html" with name="ex_agree" label="I agree to the terms and conditions" %}
           {% include "v3/includes/_field_dropdown.html" with name="ex_type" label="Dropdown" options=demo_dropdown_options placeholder="Select type..." %}
           {% include "v3/includes/_field_combo.html" with name="ex_library" label="Combo (searchable)" placeholder="Search libraries..." options=demo_libs %}

--- a/templates/v3/includes/_field_text.html
+++ b/templates/v3/includes/_field_text.html
@@ -109,7 +109,11 @@
            aria-describedby="field-{{ name }}-help"
            {% endif %}
            {% if validate_type == "email" %}x-model="value" @blur="touched = true"{% elif submit_icon %}x-model="q" {% if dispatch_field_change %}@input.debounce.150ms="$dispatch('field-change', { name: '{{ name }}', value: q })"{% endif %}{% elif max_chars %}x-model="value"{% endif %}>
-    {% if submit_icon %}
+    {% if disabled %}
+      <span class="field__icon" aria-hidden="true">
+        {% include "includes/icon.html" with icon_name="lock" icon_class="field__icon" icon_size=16 icon_viewbox="0 0 16 16" %}
+      </span>
+    {% elif submit_icon %}
       <button type="submit"
               class="field__submit"
               aria-label="{{ submit_label|default:'Submit' }}"


### PR DESCRIPTION
# Issue: #2466

## Summary & Context
<!-- *1-2 sentences describing what this PR does and why* -->

Updates the global **Text Field** component's disabled state to match the Figma UI Kit. The disabled styling now uses a gray surface + stronger border + muted text/icon with a lock icon in the trailing slot, replacing the previous `opacity: 0.5` dim and bringing the shared component to parity with the search bar's no-JS (disabled) state.

- **Figma link**: [UI Kit — Foundations Delivery, Text Field (node 89-2769)](https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=89-2769&m=dev)
- **Link to components/page:** No live page currently renders a disabled Text Field. The closest existing instance is the header search bar's no-JS state. For recording, a throwaway demo page was used at `localhost:8000/v3/field-demo/` . Please refer to the Screenshots section for more details.

## Changes

- Replaced the disabled treatment in `static/css/v3/forms.css` (`.field__control--disabled`): swapped `opacity: 0.5` for `background-color: --color-surface-mid`, `border-color: --color-stroke-strong`, muted text/placeholder (`--color-text-secondary`) and icon (`--color-icon-secondary`), including hover/focus overrides so a disabled field no longer reacts to hover.
- Updated `templates/v3/includes/_field_text.html` to render a `lock` icon in the trailing slot when `disabled`, taking priority over both `submit_icon` and `icon_right`.

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*

- **No live disabled instances today**: no template currently passes `disabled=True` into `_field_text.html`, so this defines correct behavior going forward rather than altering an existing screen. Low regression risk.
- **Shared class side effect (intentional/positive)**: `_field_datetime.html` reuses `.field__control--disabled`, so it automatically picks up the new gray styling. It keeps its own calendar affordance (no lock icon); this is consistent, not a regression.
- **Mobile hover left unchanged**: the search bar's mobile hover (which intentionally does not turn gray on touch) is out of scope for this ticket and was not modified.
- **Tokens**: all colors use existing design tokens (`--color-surface-mid`, `--color-stroke-strong`, `--color-text-secondary`, `--color-icon-secondary`) with the repo's standard hex fallbacks. No new hardcoded values.

## Screenshots

> **About the recording:** the video was captured on a temporary demo page (`localhost:8000/v3/field-demo/`) created **only for testing/verification**. It renders the real `_field_text.html` partial in Idle / Filled / Disabled states side by side so the disabled state can be seen in isolation. **This demo page and its route are not part of this PR.**

https://github.com/user-attachments/assets/a6fd4ce3-d8cd-4a6a-858d-c58dd5609639


## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refreshed disabled form field styling with stronger disabled background/border, improved disabled text/placeholder contrast, and consistent `not-allowed` cursor behavior across base, hover, and focus-within states.
  * Disabled icon color now updates to the secondary icon color for normal, hover, and focus-within states.
* **UI**
  * Disabled form fields now show a lock icon in the right-side slot instead of the previous right-side icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->