### PR TITLE
feat: implements spike outcome for testing the Github Activity query

### DIFF
--- a/core/githubhelper.py
+++ b/core/githubhelper.py
@@ -1,7 +1,7 @@
 import base64
 import re
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone as dt_timezone, timedelta
 from socket import gaierror
 import time
 from urllib.error import URLError
@@ -23,6 +23,37 @@ from fastcore.xtras import obj2dict
 from ghapi.all import GhApi, paged
 
 logger = structlog.get_logger()
+
+# Module-level cache for GitHub org node IDs (fetched once per process).
+_org_node_id_cache: dict[str, str] = {}
+
+_CONTRIBUTIONS_QUERY = """
+query BoostActivity($login: String!, $orgId: ID!, $from: DateTime!, $to: DateTime!) {
+  user(login: $login) {
+    contributionsCollection(organizationID: $orgId, from: $from, to: $to) {
+      totalCommitContributions
+      totalRepositoriesWithContributedCommits
+      totalPullRequestContributions
+      totalRepositoriesWithContributedPullRequests
+      totalPullRequestReviewContributions
+      totalRepositoriesWithContributedPullRequestReviews
+      repositoryContributions(first: 1) {
+        totalCount
+      }
+      pullRequestContributions(first: 50) {
+        nodes {
+          pullRequest {
+            title
+            url
+            repository { nameWithOwner }
+            comments { totalCount }
+          }
+        }
+      }
+    }
+  }
+}
+"""
 
 
 class GithubAPIClient:
@@ -554,6 +585,23 @@ class GithubAPIClient:
         with myzip.open(myzip.filelist[0]) as f:
             return f.read().decode()
 
+    def graphql(self, query: str, variables: dict) -> dict:
+        """Execute a GitHub GraphQL query using the app-level PAT."""
+        response = requests.post(
+            "https://api.github.com/graphql",
+            json={"query": query, "variables": variables},
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        if "errors" in data:
+            raise ValueError(f"GitHub GraphQL errors: {data['errors']}")
+        return data["data"]
+
 
 class GithubDataParser:
     def get_commits_per_month(self, commits: list[dict]):
@@ -692,3 +740,92 @@ class GithubDataParser:
             val = val.replace(email.group(), "")
 
         return val.strip()
+
+
+def _get_org_node_id(org: str, token: str) -> str:
+    """Return the GitHub GraphQL node ID for an org, caching after first fetch."""
+    if org not in _org_node_id_cache:
+        resp = requests.get(
+            f"https://api.github.com/orgs/{org}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+            timeout=15,
+        )
+        resp.raise_for_status()
+        _org_node_id_cache[org] = resp.json()["node_id"]
+    return _org_node_id_cache[org]
+
+
+def boost_activity(login: str) -> dict:
+    """Fetch Boost org contribution totals for a GitHub user (trailing 12 months).
+
+    Queries both ``boostorg`` and ``cppalliance`` orgs and sums the results.
+    Raises on GraphQL errors so the caller can decide whether to keep the last
+    good snapshot.
+
+    Returns a dict with keys:
+        total_commits, commit_repo_count, repos_created,
+        prs_opened, pr_repo_count, prs_reviewed, review_repo_count,
+        featured_pr (dict or None)
+    """
+    client = GithubAPIClient()
+    orgs = getattr(settings, "BOOST_GITHUB_ORGS", ["boostorg", "cppalliance"])
+
+    now = datetime.now(dt_timezone.utc)
+    from_str = (now - timedelta(days=365)).isoformat()
+    to_str = now.isoformat()
+
+    totals = {
+        "total_commits": 0,
+        "commit_repo_count": 0,
+        "repos_created": 0,
+        "prs_opened": 0,
+        "pr_repo_count": 0,
+        "prs_reviewed": 0,
+        "review_repo_count": 0,
+    }
+    all_prs: list[dict] = []
+
+    for org in orgs:
+        try:
+            org_id = _get_org_node_id(org, client.token)
+        except Exception as exc:
+            logger.warning("boost_activity_org_id_failed", org=org, exc_msg=str(exc))
+            continue
+
+        data = client.graphql(
+            _CONTRIBUTIONS_QUERY,
+            {"login": login, "orgId": org_id, "from": from_str, "to": to_str},
+        )
+
+        user_node = data.get("user")
+        if not user_node:
+            logger.warning("boost_activity_user_not_found", login=login, org=org)
+            continue
+
+        coll = user_node["contributionsCollection"]
+        totals["total_commits"] += coll["totalCommitContributions"]
+        totals["commit_repo_count"] += coll["totalRepositoriesWithContributedCommits"]
+        totals["repos_created"] += coll["repositoryContributions"]["totalCount"]
+        totals["prs_opened"] += coll["totalPullRequestContributions"]
+        totals["pr_repo_count"] += coll["totalRepositoriesWithContributedPullRequests"]
+        totals["prs_reviewed"] += coll["totalPullRequestReviewContributions"]
+        totals["review_repo_count"] += coll[
+            "totalRepositoriesWithContributedPullRequestReviews"
+        ]
+
+        for node in coll["pullRequestContributions"]["nodes"]:
+            pr = node["pullRequest"]
+            all_prs.append(
+                {
+                    "title": pr["title"],
+                    "url": pr["url"],
+                    "repo": pr["repository"]["nameWithOwner"],
+                    "comment_count": pr["comments"]["totalCount"],
+                }
+            )
+
+    featured_pr = max(all_prs, key=lambda p: p["comment_count"]) if all_prs else None
+    return {**totals, "featured_pr": featured_pr}

--- a/templates/admin/user_change_form.html
+++ b/templates/admin/user_change_form.html
@@ -1,0 +1,24 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls %}
+
+{% block submit_buttons_bottom %}
+  {{ block.super }}
+  {% if original and original.github_username %}
+    <div class="submit-row">
+      <a href="{% url 'admin:user_refresh_github_activity' original.pk %}"
+         class="button"
+         style="background: #417690; color: white; padding: 10px 15px; text-decoration: none; border-radius: 4px; display: inline-block;">
+        {% trans "Refresh GitHub Activity" %}
+      </a>
+      <span style="margin-left: 10px; color: #666; font-size: 13px;">
+        {% trans "Queues a background task to fetch this user's Boost org activity from GitHub." %}
+      </span>
+    </div>
+  {% elif original and not original.github_username %}
+    <div class="submit-row">
+      <span style="color: #888; font-size: 13px;">
+        {% trans "No GitHub username set - cannot fetch activity." %}
+      </span>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,12 +1,36 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from django.http import HttpResponseRedirect
+from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from .models import User
+from .models import GithubActivity, User
+
+
+class GithubActivityInline(admin.StackedInline):
+    model = GithubActivity
+    extra = 0
+    can_delete = False
+    readonly_fields = ("last_synced", "data")
+    fields = ("last_synced", "data")
+    verbose_name_plural = "GitHub Activity (cached)"
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
+@admin.register(GithubActivity)
+class GithubActivityAdmin(admin.ModelAdmin):
+    list_display = ("user", "last_synced")
+    readonly_fields = ("user", "last_synced", "data")
+    search_fields = ("user__email", "user__github_username")
 
 
 @admin.register(User)
 class EmailUserAdmin(UserAdmin):
+    change_form_template = "admin/user_change_form.html"
+    inlines = [GithubActivityInline]
+
     fieldsets = (
         (None, {"fields": ("email", "password")}),
         (
@@ -60,3 +84,39 @@ class EmailUserAdmin(UserAdmin):
         "claimed",
     )
     search_fields = ("email", "display_name__unaccent")
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "<int:user_pk>/refresh_github_activity/",
+                self.admin_site.admin_view(self.refresh_github_activity_view),
+                name="user_refresh_github_activity",
+            ),
+        ]
+        return custom + urls
+
+    def refresh_github_activity_view(self, request, user_pk):
+        from users.tasks import refresh_github_activity
+
+        try:
+            user = User.objects.get(pk=user_pk)
+        except User.DoesNotExist:
+            self.message_user(request, "User not found.", level="error")
+            return HttpResponseRedirect("../../")
+
+        if not user.github_username:
+            self.message_user(
+                request,
+                f"User {user} has no GitHub username set - cannot fetch activity.",
+                level="warning",
+            )
+        else:
+            refresh_github_activity.delay(user_pk)
+            self.message_user(
+                request,
+                f"GitHub activity refresh queued for @{user.github_username}. "
+                "Reload this page in a few seconds to see the result.",
+            )
+
+        return HttpResponseRedirect("../")

--- a/users/migrations/0022_githubactivity.py
+++ b/users/migrations/0022_githubactivity.py
@@ -1,0 +1,41 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0021_add_v3_testers_group"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="GithubActivity",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("data", models.JSONField(blank=True, default=dict)),
+                ("last_synced", models.DateTimeField(blank=True, null=True)),
+                (
+                    "user",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="github_activity",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "GitHub Activity",
+                "verbose_name_plural": "GitHub Activities",
+            },
+        ),
+    ]

--- a/users/models.py
+++ b/users/models.py
@@ -521,6 +521,37 @@ class Preferences(models.Model):
         self.change_notification_allowed(self.TERMS_CHANGED, value)
 
 
+class GithubActivity(models.Model):
+    """Cached Boost org GitHub contribution data for a user.
+
+    Populated by the ``refresh_github_activity`` Celery task. One row per user
+    with a linked GitHub account; never written during a web request.
+    """
+
+    user = models.OneToOneField(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="github_activity",
+    )
+    data = models.JSONField(default=dict, blank=True)
+    last_synced = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        verbose_name = "GitHub Activity"
+        verbose_name_plural = "GitHub Activities"
+
+    def __str__(self):
+        return f"GitHub Activity for {self.user}"
+
+    @classmethod
+    def upsert_for_user(cls, user, activity_data: dict) -> "GithubActivity":
+        obj, _ = cls.objects.update_or_create(
+            user=user,
+            defaults={"data": activity_data, "last_synced": timezone.now()},
+        )
+        return obj
+
+
 @receiver(post_save, sender=User)
 def create_last_seen_for_user(sender, instance, created, raw, **kwargs):
     """Create LastSeen row when a User is created"""

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -95,6 +95,44 @@ def send_account_deleted_email(email):
     )
 
 
+@app.task
+def refresh_github_activity(user_pk):
+    """Fetch and cache Boost org GitHub activity for a single user.
+
+    Keeps the last good snapshot on API error rather than blanking the row.
+    """
+    from core.githubhelper import boost_activity
+    from users.models import GithubActivity
+
+    try:
+        user = User.objects.get(pk=user_pk)
+    except User.DoesNotExist:
+        logger.exception("refresh_github_activity_user_not_found", user_pk=user_pk)
+        raise
+
+    if not user.github_username:
+        logger.info("refresh_github_activity_no_username", user_pk=user_pk)
+        return
+
+    try:
+        activity_data = boost_activity(user.github_username)
+    except Exception as exc:
+        logger.error(
+            "refresh_github_activity_failed",
+            user_pk=user_pk,
+            login=user.github_username,
+            exc_msg=str(exc),
+        )
+        raise
+
+    GithubActivity.upsert_for_user(user, activity_data)
+    logger.info(
+        "refresh_github_activity_done",
+        user_pk=user_pk,
+        login=user.github_username,
+    )
+
+
 @shared_task
 def remove_unverified_users():
     """


### PR DESCRIPTION
# Draft PR for  #2454 

Ticket origin: https://github.com/boostorg/website-v2/issues/2454

I simply asked Claude to implement what was in the Spike outcome to test the findings after my own review, along with a button in the user panel to trigger it. 

- Go to http://localhost:8000/admin/users/user/
- find the user you wanna query the Activities of
- add a Github handle at the top, if they don't have one yet
- scroll to the bottom and hit "Refresh Github Acitivity"
- in a few seconds, refresh the page, you should see the activity in a json payload right above that button

This draft pr is only intended to help with validating the ticket and maybe speed things up for the person who actually takes this feature to fully implement it. It's possibly part of #2492 btw.










# Issue: #[number]

## Summary & Context
<!-- *1-2 sentences describing what this PR does and why* -->

- **Figma link**: <!-- Add link to relevant Figma design here -->
- **Link to components/page:** <!-- e.g. localhost:8000/news/add -->

## Changes

-
-
-

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*

## Screenshots

<!-- Before | After
-- | -- -->

<!-- Desktop Light Mode | Desktop Dark Mode | Mobile
-- | -- | -- -->


## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [ ] UI implementation matches Figma design
- [ ] Tested in light and dark mode
- [ ] Responsive / mobile verified
- [ ] Accessibility checked (keyboard navigation, etc.)
- [ ] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [ ] Test without JavaScript (if applicable)
- [ ] No console errors or warnings
