### PR TITLE
Fix importing archives during beta releases

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -82,7 +82,7 @@ Import `VersionFile` objects from Artifactory.
 
 | Options    | Format | Description                                                                                                                  |
 |------------|--------|------------------------------------------------------------------------------------------------------------------------------|
-| `--new`    | bool   | Default: 'true'. If 'true', will import only the newest release data. Set to 'false' to import archive data for all releases |
+| `--new`    | bool   | Default: 'true'. If 'true', imports archive data for the most recent full release and (if one exists) the most recent beta release. Set to 'false' to import archive data for all releases |
 | `--release` | string   | Format: `boost-1.63.0`. If passed, will import Archive urls for only that release. Overrides --new                        |
 
 **More Information**

--- a/versions/management/commands/import_archives_release_data.py
+++ b/versions/management/commands/import_archives_release_data.py
@@ -46,7 +46,13 @@ def command(release: str, new: bool):
         name = f"boost-{release}" if release not in ["master", "develop"] else release
         versions = [Version.objects.with_partials().get(name=name)]
     elif new:
-        versions = [Version.objects.with_partials().most_recent()]
+        # Include both the most recent full release and the most recent beta
+        # (if one exists), so that a newly-imported beta is not silently
+        # skipped just because `most_recent()` filters out betas.
+        qs = Version.objects.with_partials()
+        versions = [
+            v for v in (qs.most_recent(), qs.most_recent_beta()) if v is not None
+        ]
     else:
         versions = Version.objects.with_partials().filter(name__gte=last_release)
     logger.info(f"import_archive_release_data {versions=}")
@@ -59,9 +65,16 @@ def command(release: str, new: bool):
             binaries_urls = get_binary_download_uris_for_release(version_num)
             file_urls = archives_urls + binaries_urls
         except requests.exceptions.HTTPError:
-            logger.info(f"Skipping {version_num}, error retrieving release data")
+            # Promoted from INFO to WARNING: an empty/missing archives listing
+            # leaves the version with zero downloads, which previously looked
+            # indistinguishable from a successful import in the logs.
+            logger.warning(
+                f"Skipping {version_num}, error retrieving release data "
+                f"(archives listing unavailable)"
+            )
             continue
 
+        stored_count = 0
         download_data = []
         checksums = dict()
         for url in file_urls:
@@ -79,4 +92,18 @@ def command(release: str, new: bool):
                 continue
             logger.info(f"Data for {v.name=} at {url=}: {download_data=}")
             store_release_downloads_for_version(v, download_data)
+            stored_count += 1
             logger.info(f"Stored download data from {url=} for {v.name}")
+
+        # Summary log so operators can tell at a glance whether anything was
+        # actually imported for this version vs. silently zero.
+        if stored_count == 0:
+            logger.warning(
+                f"import_archive_release_data {v.name=}: no download files "
+                f"stored (listing returned {len(file_urls)} candidate URLs)"
+            )
+        else:
+            logger.info(
+                f"import_archive_release_data {v.name=}: stored "
+                f"{stored_count} download file(s)"
+            )

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -161,7 +161,12 @@ def import_versions(
 def import_release_notes(new_versions_only=True):
     """Imports release notes from the existing rendered
     release notes in the repository."""
-    versions = [Version.objects.with_partials().most_recent()]
+    # Include both the most recent full release and the most recent beta (if
+    # one exists). `most_recent()` filters out betas, so without this a
+    # freshly-imported beta would be silently skipped when running with
+    # ``new_versions_only=True`` (e.g. ``./manage.py import_release_notes``).
+    qs = Version.objects.with_partials()
+    versions = [v for v in (qs.most_recent(), qs.most_recent_beta()) if v is not None]
     if not new_versions_only:
         versions = (
             Version.objects.exclude(name__in=["master", "develop"])


### PR DESCRIPTION
Resolve https://github.com/boostorg/website-v2/issues/2160

The file `versions/management/commands/import_archives_release_data.py` is checking `most_recent()` which is a relatively new change, less than a year ago, it would have imported all versions.   `most_recent()`  skips over beta releases.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes and archive imports now include the most recent beta release when available, along with the latest stable release.
  * Archive downloads are now saved with clearer per-release tracking and summaries.

* **Bug Fixes**
  * Improved handling when archive listings are unavailable, with clearer warnings and continued processing of other versions.
  * Prevents newly imported beta releases from being skipped during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->