### PR TITLE
Remove uv.lock file and add it to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,10 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# uv
+#   Dependencies are managed via requirements.txt; uv.lock is unused.
+uv.lock
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.11"


### PR DESCRIPTION
# Issue: #2513 

## Summary
- Remove `uv.lock` file and added it to `.gitignore`

## ‼️ Risks & Considerations ‼️
- None as dependencies are managed via `requirements.txt` – `uv.lock` is unused.
## Screenshots


## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignored files to exclude an unused lockfile related to local dependency management.
  * Added a note clarifying that dependencies continue to be managed through the existing requirements file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->