### PR TITLE
Story 2452: User Profile Integration – Contribution Bio

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -366,6 +366,13 @@ CACHES = {
 
 ENABLE_DB_CACHE = env.bool("ENABLE_DB_CACHE", default=False)
 
+# Per-user profile contribution data cache. Invalidated on library imports via
+# recompute_displayed_profile_roles; this TTL is only a safety net, sized to the
+# daily recompute cadence (24 hours).
+CONTRIBUTOR_DATA_CACHE_TIMEOUT = env.int(
+    "CONTRIBUTOR_DATA_CACHE_TIMEOUT", default=60 * 60 * 24
+)
+
 # Default interval by which to clear the static content cache
 # New method: "never" clear, just overwrite, so that the id
 # field doesn't expand without bounds.

--- a/users/models.py
+++ b/users/models.py
@@ -701,6 +701,20 @@ class User(BaseUser):
         pairs = sorted(self._role_library_pairs(), key=sort_key)
         return [{"role": role, "library": library} for role, library, _ in pairs]
 
+    def get_contributor_data(self):
+        """Library contributions grouped by role for the profile bio card.
+
+        Returns an ordered dict {role_label: [library_short_name, ...]} in role
+        precedence order; a role the user holds in no library is omitted, and an
+        empty dict means no contributions at all. Backed by the same source of
+        truth as the edit-page role dropdown (`get_role_library_options`).
+        """
+        data = {}
+        for option in self.get_role_library_options():
+            label = ProfileRole(option["role"]).label
+            data.setdefault(label, []).append(option["library"].display_name_short)
+        return data
+
     def _role_library_pairs(self):
         """(role, library, commit_count) tuples the user holds, computed live."""
         from libraries.models import Library, Commit

--- a/users/models.py
+++ b/users/models.py
@@ -280,12 +280,22 @@ CONTRIBUTOR_DATA_CACHE_PREFIX = "contributor_data_"
 
 
 def contributor_data_cache_key(user_id):
-    """Redis key for a user's cached profile contribution data.
-
-    Shared with the import-time cache invalidation in
-    `recompute_displayed_profile_roles`.
-    """
+    """Cache key for a user's cached profile contribution data."""
     return f"{CONTRIBUTOR_DATA_CACHE_PREFIX}{user_id}"
+
+
+def invalidate_contributor_data_cache():
+    """Drop every user's cached contribution data.
+
+    Called by `recompute_displayed_profile_roles`: a library import can change
+    anyone's contributions, not just the users whose role columns moved.
+    """
+    cache.delete_many(
+        [
+            contributor_data_cache_key(user_id)
+            for user_id in User.objects.values_list("id", flat=True)
+        ]
+    )
 
 
 def encode_role_option(role, library_id):

--- a/users/models.py
+++ b/users/models.py
@@ -9,6 +9,7 @@ from django.contrib.auth.models import (
     BaseUserManager,
     PermissionsMixin,
 )
+from django.core.cache import cache
 from django.core.mail import send_mail
 from django.db import models, transaction
 from django.db.models.signals import post_save
@@ -274,6 +275,17 @@ NO_PUBLIC_ROLE_OPTION = "__no_public_role__"
 NO_PUBLIC_ROLE_LABEL = (
     "No Public Role - Your role won't be linked to your name elsewhere on the site."
 )
+
+CONTRIBUTOR_DATA_CACHE_PREFIX = "contributor_data_"
+
+
+def contributor_data_cache_key(user_id):
+    """Redis key for a user's cached profile contribution data.
+
+    Shared with the import-time cache invalidation in
+    `recompute_displayed_profile_roles`.
+    """
+    return f"{CONTRIBUTOR_DATA_CACHE_PREFIX}{user_id}"
 
 
 def encode_role_option(role, library_id):
@@ -708,11 +720,21 @@ class User(BaseUser):
         precedence order; a role the user holds in no library is omitted, and an
         empty dict means no contributions at all. Backed by the same source of
         truth as the edit-page role dropdown (`get_role_library_options`).
+
+        Cached per user. The underlying roles only change on library imports,
+        which drop the entry via `recompute_displayed_profile_roles`; the TTL is
+        a safety net. An empty dict is a real cached value (distinct from a
+        cache miss, which returns None).
         """
+        cache_key = contributor_data_cache_key(self.pk)
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
         data = {}
         for option in self.get_role_library_options():
             label = ProfileRole(option["role"]).label
             data.setdefault(label, []).append(option["library"].display_name_short)
+        cache.set(cache_key, data, settings.CONTRIBUTOR_DATA_CACHE_TIMEOUT)
         return data
 
     def _role_library_pairs(self):

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -251,6 +251,12 @@ def recompute_displayed_profile_roles():
                 displayed_profile_role=role,
                 displayed_profile_role_library_id=lib_id,
             ).update(displayed_profile_role="", displayed_profile_role_library=None)
+    # Roles just changed, so drop every user's cached profile contribution data.
+    from django.core.cache import cache
+    from users.models import CONTRIBUTOR_DATA_CACHE_PREFIX
+
+    cache.delete_pattern(f"{CONTRIBUTOR_DATA_CACHE_PREFIX}*")
+
     logger.info(
         "recompute_displayed_profile_roles finished",
         resolved=len(top),

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -252,10 +252,9 @@ def recompute_displayed_profile_roles():
                 displayed_profile_role_library_id=lib_id,
             ).update(displayed_profile_role="", displayed_profile_role_library=None)
     # Roles just changed, so drop every user's cached profile contribution data.
-    from django.core.cache import cache
-    from users.models import CONTRIBUTOR_DATA_CACHE_PREFIX
+    from users.models import invalidate_contributor_data_cache
 
-    cache.delete_pattern(f"{CONTRIBUTOR_DATA_CACHE_PREFIX}*")
+    invalidate_contributor_data_cache()
 
     logger.info(
         "recompute_displayed_profile_roles finished",

--- a/users/tests/test_profile_role.py
+++ b/users/tests/test_profile_role.py
@@ -4,6 +4,7 @@ import pytest
 from model_bakery import baker
 
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 
@@ -11,14 +12,28 @@ from django.contrib.admin.sites import site
 
 from users.admin import EmailUserAdmin, EmailUserAdminForm
 from users.models import (
+    CONTRIBUTOR_DATA_CACHE_PREFIX,
     NO_PUBLIC_ROLE_OPTION,
     ProfileRole,
+    contributor_data_cache_key,
     decode_role_option,
     encode_role_option,
 )
 from users.serializers import CurrentUserSerializer
 
 User = get_user_model()
+
+
+@pytest.fixture(autouse=True)
+def _clear_contributor_cache():
+    """Keep the per-user contribution cache from leaking across tests.
+
+    The default cache is real Redis in this suite, so entries persist between
+    tests; scrub our namespace before and after each one.
+    """
+    cache.delete_pattern(f"{CONTRIBUTOR_DATA_CACHE_PREFIX}*")
+    yield
+    cache.delete_pattern(f"{CONTRIBUTOR_DATA_CACHE_PREFIX}*")
 
 
 def _apply_role(user, value):
@@ -133,6 +148,51 @@ def test_contributor_role_from_commits_only(user, library):
     assert roles == ["Contributor"]
     _recompute()
     assert User.objects.get(pk=user.pk).role == "Contributor"
+
+
+# --- contributor data (profile bio card) ------------------------------------
+
+
+def test_contributor_data_caches_empty(user):
+    """No contributions -> empty dict, and the empty dict is cached (not a miss)."""
+    assert user.get_contributor_data() == {}
+    assert cache.get(contributor_data_cache_key(user.pk)) == {}
+
+
+def test_contributor_data_groups_by_role_and_omits_empty(user, library, other_library):
+    library.authors.add(user)  # Author of Beast
+    _make_version(other_library).maintainers.add(user)  # Maintainer of Math
+    data = user.get_contributor_data()
+    # Author and Maintainer present, in precedence order; Contributor omitted.
+    assert list(data) == ["Author", "Maintainer"]
+    assert data["Author"] == ["Beast"]
+    assert data["Maintainer"] == ["Math"]
+
+
+def test_contributor_data_lists_libraries_by_commit_count(user, library, other_library):
+    library.authors.add(user)
+    other_library.authors.add(user)
+    _add_commits(user, other_library, 5)
+    _add_commits(user, library, 1)
+    # Busier library ranks first within the role group.
+    assert user.get_contributor_data()["Author"] == ["Math", "Beast"]
+
+
+def test_contributor_data_served_from_cache(user, library, other_library):
+    library.authors.add(user)
+    assert user.get_contributor_data() == {"Author": ["Beast"]}  # now cached
+    # Add a second author link. Only the import-time recompute invalidates the
+    # cache, so until then the prior result is still served.
+    other_library.authors.add(user)
+    assert user.get_contributor_data() == {"Author": ["Beast"]}
+
+
+def test_recompute_task_clears_cache(user, library):
+    library.authors.add(user)
+    user.get_contributor_data()  # populate cache
+    assert cache.get(contributor_data_cache_key(user.pk)) is not None
+    _recompute()
+    assert cache.get(contributor_data_cache_key(user.pk)) is None
 
 
 # --- display composition -----------------------------------------------------

--- a/users/tests/test_profile_role.py
+++ b/users/tests/test_profile_role.py
@@ -12,7 +12,6 @@ from django.contrib.admin.sites import site
 
 from users.admin import EmailUserAdmin, EmailUserAdminForm
 from users.models import (
-    CONTRIBUTOR_DATA_CACHE_PREFIX,
     NO_PUBLIC_ROLE_OPTION,
     ProfileRole,
     contributor_data_cache_key,
@@ -28,12 +27,13 @@ User = get_user_model()
 def _clear_contributor_cache():
     """Keep the per-user contribution cache from leaking across tests.
 
-    The default cache is real Redis in this suite, so entries persist between
-    tests; scrub our namespace before and after each one.
+    The cache lives for the whole process, so wipe it around each test. Clearing
+    outright rather than calling `invalidate_contributor_data_cache`, which reads
+    the user table this fixture has no database access to.
     """
-    cache.delete_pattern(f"{CONTRIBUTOR_DATA_CACHE_PREFIX}*")
+    cache.clear()
     yield
-    cache.delete_pattern(f"{CONTRIBUTOR_DATA_CACHE_PREFIX}*")
+    cache.clear()
 
 
 def _apply_role(user, value):

--- a/users/views.py
+++ b/users/views.py
@@ -309,6 +309,9 @@ class CurrentUserProfileView(
             "flag_emoji": user.flag_emoji,
         }
 
+        # Library contributions grouped by role (Author/Maintainer/Contributor)
+        ctx["contributor_data"] = user.get_contributor_data()
+
         # Data shared between both versions, Boost Github and Mailing List activity
         ctx["github_activity_card_data"] = {
             "title": "Latest Boost Github activity",
@@ -379,20 +382,6 @@ class CurrentUserProfileView(
 
                 These interests have shaped my contributions to the C++ ecosystem, particularly in developing libraries that make network programming more accessible and efficient for developers.
             """)
-            ctx["contributor_data"] = {
-                "Author": ["Beast", "JSON"],
-                "Maintainer": ["Beast", "Accumulator"],
-                "Contributor": [
-                    "Beast",
-                    "JSON",
-                    "Accumulator",
-                    "Asio",
-                    "Blood",
-                    "Redis",
-                    "MQTT5",
-                ],
-                "Reviews": ["Asio", "Blood (Manager)", "Redis", "MQTT5"],
-            }
             ctx["profile_post_cta_label"] = "View All Posts"
             ctx["profile_post_cta_url"] = "#"
             ctx["achievements_data"] = {


### PR DESCRIPTION
# Issue: #2452 

> ⚠️ **Stacked PR** — based on `julia/implement-user-roles`, not `develop`. ⚠️

## Summary & Context
Populates the bio card on the user profile page with each user's real library contributions instead of the hardcoded demo dict. Contributions are grouped by role (Author, Maintainer, Contributor), sourced from the same role data that backs the Edit User profile role dropdown.

- **Figma link**: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?t=B7R6mP6e79MWJwF5-0
- **Link to page**: http://localhost:8000/users/me/ or http://localhost:8000/users/me/?filled=True

## Changes
#### Wire real contribution data to the bio card
- Add `User.get_contributor_data()` — returns library contributions grouped by role label (`{role: [library, …]}`), in precedence order Author → Maintainer → Contributor, with each role's libraries ordered by commit count. Reuses the existing `get_role_library_options()` source of truth rather than adding new queries.
- Omit any role the user holds in no library; return an empty dict when the user has no contributions at all, which the bio card already treats as "hide the whole contribution section."
- Set `contributor_data` from the real query on `CurrentUserProfileView`

### Cache the computed data

Cache each user's contribution data (`CONTRIBUTOR_DATA_CACHE_TIMEOUT`, default 24h), keyed per user. An empty dict is cached as a real value, distinct from a miss. Invalidate in `recompute_displayed_profile_roles` via `invalidate_contributor_data_cache()`, which drops every user's entry with `cache.delete_many`. That task already runs after every author/maintainer/commit import and on the daily beat, so the cache clears whenever the underlying data actually changes. The TTL is only a backstop for a missed invalidation.

Invalidation is blanket rather than per-user because contribution data derives from `Library.authors`, `LibraryVersion.maintainers` and `Commit` rows – an import can change any user's data, not just those whose role columns moved. It enumerates user ids and deletes their keys (one query plus one `delete_many`, once per import) instead of a Redis prefix delete, so it works on the `LocMemCache` backend the test suite uses.

### Risks & Considerations

**Freshness relies on the import workflow, not manual edits.** Author/Maintainer/Contributor data only changes through the Celery import (which ends in `recompute_displayed_profile_roles` → cache clear), so no signal-based invalidation is wired. The uncovered paths are direct edits of `Library.authors` on the Library admin form or `LibraryVersion.maintainers` on the LibraryVersion admin form; either would show stale data until the next import or the 24h TTL. Acceptable because those admin edits aren't part of the real workflow. If either becomes one, we can add an `m2m_changed` signal on the through models.

**Why 24h TTL:** the explicit invalidation is the real freshness mechanism; the TTL only fires if that invalidation is missed (e.g. an import task that errors before clearing). Sized to the daily recompute cadence – long enough for a high cache hit rate, short enough to cap worst-case staleness at a day.

## Peer-Testing Guidelines
1. Log in as a user who authors/maintains/has commits in at least one library
2. Visit http://localhost:8000/users/me/ – the bio card's contribution section should list each role with its libraries, ordered Author → Maintainer → Contributor.
3. Confirm a role you don't hold (e.g. Author) is not shown at all, rather than shown empty.
4. Log in as another user with no library contributions and visit http://localhost:8000/users/me/ again — the entire contribution section should be hidden.

## Screenshots
Sample user with contributions | Empty State with No Contributions
-- | --
<img width="720" height="530" alt="Screenshot 2026-07-20 at 6 34 53 PM" src="https://github.com/user-attachments/assets/bca51aef-978c-461e-9ceb-e6251dee8054" /> | <img width="731" height="271" alt="Screenshot 2026-07-20 at 6 37 23 PM" src="https://github.com/user-attachments/assets/cbf0ef1a-670f-4b8c-9dee-43c5a8d1fa70" />


## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Contributor information in profiles now reflects each person’s assigned roles and contributions, with libraries ordered by activity.
  - Added support for badges, feedback, and Postorius integration.
  - Added configurable email routing and delivery settings for different deployment environments.

- **Bug Fixes**
  - Profile contribution data now refreshes after role information is recalculated.

- **Documentation**
  - Updated email configuration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->