### PR TITLE
Story #2438: Account Deletion

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -388,6 +388,10 @@ MAILMAN_REST_API_VERSION = env("MAILMAN_REST_API_VERSION", default="3.1")
 MAILMAN_REST_API_USER = env("MAILMAN_REST_API_USER", default="restadmin")
 MAILMAN_REST_API_PASS = env("MAILMAN_REST_API_PASS", default="restpass")
 
+# External Postorius (Mailman) instance where users manage their own mailing
+# list subscriptions.
+POSTORIUS_URL = env("POSTORIUS_URL", default="https://lists.boost.org/mailman3/lists/")
+
 # Fastly API credentials
 FASTLY_SERVICE = env("FASTLY_SERVICE", default="empty")
 FASTLY_SERVICE2 = env("FASTLY_SERVICE2", default="empty")

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -235,6 +235,7 @@ def header_context(request):
         "nav_links": nav_links,
         "releases_url": reverse("releases-most-recent"),
         "edit_profile_url": edit_profile_url(),
+        "profile_cancel_delete_url": reverse("profile-cancel-delete"),
     }
 
 

--- a/static/css/v3/account-deletion-banner.css
+++ b/static/css/v3/account-deletion-banner.css
@@ -1,0 +1,97 @@
+/**
+ * Account deletion banner (V3)
+ *
+ * Site-wide banner shown while a logged-in user's account is scheduled for
+ * deletion (rendered from base.html behind the v3 flag). It is `position: sticky`
+ * at the top so it sits above the navbar and, being in normal document flow,
+ * pushes the page content down (nothing is hidden behind it). Red error styling
+ * via semantic tokens (light/dark handled by semantics.css + themes.css).
+ *
+ * Only "Cancel deletion" is offered - immediate deletion is not exposed in V3.
+ */
+.deletion-banner {
+  position: sticky;
+  top: 0;
+  z-index: 1100;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-large);
+  width: 100%;
+  padding: var(--space-default) var(--space-large);
+  box-sizing: border-box;
+  background-color: var(--color-surface-error-strong);
+  color: var(--color-text-reversed);
+}
+
+.deletion-banner__body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-default) var(--space-large);
+}
+
+.deletion-banner__message {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-default);
+  color: var(--color-text-reversed);
+}
+
+.deletion-banner__form {
+  margin: 0;
+}
+
+.deletion-banner__cancel {
+  padding: 0;
+  background: transparent;
+  border: 0;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--line-height-default);
+  color: var(--color-text-reversed);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.deletion-banner__cancel:hover {
+  opacity: 0.85;
+}
+
+.deletion-banner__close {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-xs);
+  background: transparent;
+  border: 0;
+  border-radius: var(--border-radius-s);
+  color: var(--color-icon-reverse);
+  cursor: pointer;
+}
+
+.deletion-banner__close:hover {
+  opacity: 0.7;
+}
+
+.deletion-banner__close-icon {
+  width: 16px;
+  height: 16px;
+  fill: var(--color-icon-reverse);
+}
+
+@media (max-width: 767px) {
+  .deletion-banner {
+    align-items: flex-start;
+  }
+
+  .deletion-banner__body {
+    justify-content: flex-start;
+  }
+}

--- a/static/css/v3/components.css
+++ b/static/css/v3/components.css
@@ -34,6 +34,7 @@
 @import "./animations.css";
 @import "./account-connections.css";
 @import "./dialog.css";
+@import "./delete-account-modal.css";
 @import "./content-modal.css";
 @import "./achivement-card.css";
 @import "./inline-card.css";

--- a/static/css/v3/components.css
+++ b/static/css/v3/components.css
@@ -35,6 +35,7 @@
 @import "./account-connections.css";
 @import "./dialog.css";
 @import "./delete-account-modal.css";
+@import "./account-deletion-banner.css";
 @import "./content-modal.css";
 @import "./achivement-card.css";
 @import "./inline-card.css";

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -93,10 +93,12 @@
 }
 
 .delete-account-modal__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-default);
   margin: 0;
-  padding-left: 1.2em;
-  list-style: disc;
-  list-style-position: outside;
+  padding: 0;
+  list-style: none;
   font-family: var(--font-sans);
   font-size: var(--font-size-small);
   font-weight: var(--font-weight-regular);
@@ -104,21 +106,25 @@
   color: var(--color-text-secondary);
 }
 
+/* Each row is a small dot + text (Figma bullet 6635:25514), replacing the
+   native disc marker so the dot's size, colour and alignment match the design. */
 .delete-account-modal__list li {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-large);
   padding: 0;
 }
 
-/* Shrink the disc so it reads as a bullet, not a block, and tighten the
-   marker-to-text gap (matches the create-account-card list pattern). */
-.delete-account-modal__list li::marker {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-tertiary);
-}
-
-/* Figma spaces the bullet rows 6px apart, but those rows are 20px tall vs our
-   ~17px text line, so an 8px margin reproduces the same text-to-text rhythm. */
-.delete-account-modal__list li + li {
-  margin-top: var(--space-default);
+/* 3px rounded tertiary dot, vertically centred on the first text line
+   (Figma dot 6635:25516). */
+.delete-account-modal__list li::before {
+  content: "";
+  flex-shrink: 0;
+  width: 3px;
+  height: 3px;
+  margin-top: 0.5em;
+  border-radius: var(--border-radius-xs);
+  background-color: var(--color-text-tertiary);
 }
 
 .delete-account-modal__note {

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -82,6 +82,12 @@
   color: var(--color-text-tertiary);
 }
 
+.delete-account-modal__link {
+  color: var(--color-text-link-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 .delete-account-modal__divider {
   width: 100%;
   height: 1px;

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -146,3 +146,14 @@
   border: 0;
   background-color: var(--color-stroke-weak);
 }
+
+/* Destructive submit: solid fill matches Figma node 6635:25533. Scoped here
+   because the shared .btn-error is an outline style used elsewhere (Delete
+   Avatar, the Delete Account trigger link). */
+.delete-account-modal .btn-error,
+.delete-account-modal .btn-error:hover,
+.delete-account-modal .btn-error[data-hover] {
+  background-color: var(--color-surface-error-strong);
+  border-color: var(--color-surface-error-strong);
+  color: var(--color-text-reversed);
+}

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -154,10 +154,12 @@
 
 /* Destructive submit: solid fill matches Figma node 6635:25533. Scoped here
    because the shared .btn-error is an outline style used elsewhere (Delete
-   Avatar, the Delete Account trigger link). */
-.delete-account-modal .btn-error,
-.delete-account-modal .btn-error:hover,
-.delete-account-modal .btn-error[data-hover] {
+   Avatar, the Delete Account trigger link). Only applied while enabled - the
+   button is disabled until the confirmation phrase is typed, and the disabled
+   state keeps the shared outline + 0.5 opacity. */
+.delete-account-modal .btn-error:not(:disabled),
+.delete-account-modal .btn-error:not(:disabled):hover,
+.delete-account-modal .btn-error:not(:disabled)[data-hover] {
   background-color: var(--color-surface-error-strong);
   border-color: var(--color-surface-error-strong);
   color: var(--color-text-reversed);

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -1,23 +1,3 @@
-/**
- * Delete-account modal
- *
- * Destructive variation of the shared Dialog Modal (dialog.css). It reuses the
- * .dialog-modal overlay / container / header / buttons shell.
- *
- * Layout mirrors the Figma spec (node 6635:25490): the whole container is a
- * light-red canvas holding a white, rounded inner card. A 16px gap separates
- * the header, warning, card and buttons; the header carries a bottom divider
- * between the title and the warning. The card's sections (summary /
- * confirmation) are separated by full-bleed dividers that touch both edges.
- *
- * All colours go through semantic tokens, so light/dark are handled by
- * semantics.css + themes.css.
- */
-
-/* The whole dialog is a light-red canvas (Figma container fill #fdf2f2).
-   Layer the error tint over an opaque page surface so the modal stays fully
-   opaque in dark mode, where --color-surface-error-weak is a translucent tint
-   (in light mode the tint is fully opaque and covers the base entirely). */
 .delete-account-modal .dialog-modal__container {
   background-color: var(--color-surface-page);
   background-image: linear-gradient(
@@ -26,9 +6,6 @@
   );
 }
 
-/* The form is the container's single child, so it owns the vertical stack.
-   The 16px gap reproduces the Figma container spacing between the header,
-   warning, card and buttons, so those children only carry horizontal padding. */
 .delete-account-modal__form {
   display: flex;
   flex-direction: column;
@@ -36,9 +13,6 @@
   width: 100%;
 }
 
-/* Header sits transparently on the light-red canvas but keeps the shared
-   bottom divider (Figma node 6635:25492), which separates the title from the
-   warning line below it. */
 .delete-account-modal__header {
   background-color: transparent;
 }
@@ -58,7 +32,6 @@
   padding: 0 var(--space-large);
 }
 
-/* White, rounded inner card sitting on the light-red canvas. */
 .delete-account-modal__card {
   display: flex;
   flex-direction: column;
@@ -68,8 +41,6 @@
   overflow: hidden;
 }
 
-/* Fixed, consistent spacing for every card section (Figma summary group
-   6635:25510 stacks its title and bullets 16px apart). */
 .delete-account-modal__section {
   display: flex;
   flex-direction: column;
@@ -77,7 +48,6 @@
   padding: var(--space-large);
 }
 
-/* Reset the global `p { py-5 }` base rule so section spacing stays fixed. */
 .delete-account-modal__summary-title,
 .delete-account-modal__note {
   padding: 0;
@@ -106,8 +76,6 @@
   color: var(--color-text-secondary);
 }
 
-/* Each row is a small dot + text (Figma bullet 6635:25514), replacing the
-   native disc marker so the dot's size, colour and alignment match the design. */
 .delete-account-modal__list li {
   display: flex;
   align-items: flex-start;
@@ -115,8 +83,6 @@
   padding: 0;
 }
 
-/* 3px rounded tertiary dot, vertically centred on the first text line
-   (Figma dot 6635:25516). */
 .delete-account-modal__list li::before {
   content: "";
   flex-shrink: 0;
@@ -142,8 +108,6 @@
   text-underline-offset: 2px;
 }
 
-/* Full-bleed divider between card sections: touches both card edges (the
-   sections carry the padding, this rule spans the card's full width). */
 .delete-account-modal__divider {
   width: 100%;
   height: 1px;
@@ -152,15 +116,20 @@
   background-color: var(--color-stroke-weak);
 }
 
-/* Destructive submit: solid fill matches Figma node 6635:25533. Scoped here
-   because the shared .btn-error is an outline style used elsewhere (Delete
-   Avatar, the Delete Account trigger link). Only applied while enabled - the
-   button is disabled until the confirmation phrase is typed, and the disabled
-   state keeps the shared outline + 0.5 opacity. */
-.delete-account-modal .btn-error:not(:disabled),
-.delete-account-modal .btn-error:not(:disabled):hover,
-.delete-account-modal .btn-error:not(:disabled)[data-hover] {
+.delete-account-modal .btn-secondary,
+.delete-account-modal .btn-secondary:hover,
+.delete-account-modal .btn-secondary[data-hover] {
+  background-color: transparent;
+}
+
+.delete-account-modal .btn-error,
+.delete-account-modal .btn-error:hover,
+.delete-account-modal .btn-error[data-hover] {
   background-color: var(--color-surface-error-strong);
   border-color: var(--color-surface-error-strong);
   color: var(--color-text-reversed);
+}
+
+.delete-account-modal .btn-error:disabled {
+  opacity: 0.45;
 }

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -2,13 +2,21 @@
  * Delete-account modal
  *
  * Destructive variation of the shared Dialog Modal (dialog.css). It reuses the
- * .dialog-modal overlay / container / header / buttons shell and adds an
- * error-tinted header, a red warning line, and a summary card listing what a
- * deletion removes plus the confirmation field.
+ * .dialog-modal overlay / container / header / buttons shell.
+ *
+ * Layout mirrors the Figma spec (node 6635:25490): the whole container is a
+ * light-red canvas holding a white, rounded inner card. The card's sections
+ * (summary / confirmation) are separated by full-bleed dividers that touch
+ * both card edges, and a full-bleed rule sits between the warning and the card.
  *
  * All colours go through semantic tokens, so light/dark are handled by
  * semantics.css + themes.css.
  */
+
+/* The whole dialog is a light-red canvas (Figma container fill #fdf2f2). */
+.delete-account-modal .dialog-modal__container {
+  background-color: var(--color-surface-error-weak);
+}
 
 /* The form is the container's single child, so it owns the vertical stack. */
 .delete-account-modal__form {
@@ -17,14 +25,17 @@
   width: 100%;
 }
 
-/* Error-tinted header, overriding the neutral dialog header background. */
+/* Header sits directly on the light-red canvas; drop the shared divider so the
+   only rule between header/warning and the card is our full-bleed one. */
 .delete-account-modal__header {
-  background-color: var(--color-surface-error-weak);
+  background-color: transparent;
+  border-bottom: 0;
+  padding-bottom: 0;
 }
 
 .delete-account-modal__warning {
   margin: 0;
-  padding: var(--space-default) var(--space-large) 0;
+  padding: var(--space-default) var(--space-large) var(--space-large);
   font-family: var(--font-sans);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-regular);
@@ -32,18 +43,41 @@
   color: var(--color-text-error);
 }
 
+/* Full-bleed rule between the warning and the white card (Figma "Line 161"). */
+.delete-account-modal__rule {
+  width: 100%;
+  height: 1px;
+  margin: 0;
+  border: 0;
+  background-color: var(--color-stroke-weak);
+}
+
 .delete-account-modal__body {
   padding: var(--space-large);
 }
 
-.delete-account-modal__summary {
+/* White, rounded inner card sitting on the light-red canvas. */
+.delete-account-modal__card {
+  display: flex;
+  flex-direction: column;
+  background-color: var(--color-surface-weak);
+  border: 1px solid var(--color-stroke-weak);
+  border-radius: var(--border-radius-xl);
+  overflow: hidden;
+}
+
+/* Fixed, consistent spacing for every card section. */
+.delete-account-modal__section {
   display: flex;
   flex-direction: column;
   gap: var(--space-default);
   padding: var(--space-large);
-  background-color: var(--color-surface-weak);
-  border: 1px solid var(--color-stroke-weak);
-  border-radius: var(--border-radius-l);
+}
+
+/* Reset the global `p { py-5 }` base rule so section spacing stays fixed. */
+.delete-account-modal__summary-title,
+.delete-account-modal__note {
+  padding: 0;
 }
 
 .delete-account-modal__summary-title {
@@ -88,10 +122,12 @@
   text-underline-offset: 2px;
 }
 
+/* Full-bleed divider between card sections: touches both card edges (the
+   sections carry the padding, this rule spans the card's full width). */
 .delete-account-modal__divider {
   width: 100%;
   height: 1px;
-  margin: var(--space-xs) 0;
+  margin: 0;
   border: 0;
   background-color: var(--color-stroke-weak);
 }

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -42,12 +42,13 @@
 
 .delete-account-modal__warning {
   margin: 0;
-  padding: var(--space-default) var(--space-large) var(--space-large);
+  padding: 0 var(--space-large) var(--space-large);
   font-family: var(--font-sans);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-regular);
   line-height: var(--line-height-default);
-  color: var(--color-text-error);
+  letter-spacing: var(--letter-spacing-tight);
+  color: var(--color-text-error-emphasis);
 }
 
 /* Full-bleed rule between the warning and the white card (Figma "Line 161"). */

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -1,0 +1,95 @@
+/**
+ * Delete-account modal
+ *
+ * Destructive variation of the shared Dialog Modal (dialog.css). It reuses the
+ * .dialog-modal overlay / container / header / buttons shell and adds an
+ * error-tinted header, a red warning line, and a summary card listing what a
+ * deletion removes plus the confirmation field.
+ *
+ * All colours go through semantic tokens, so light/dark are handled by
+ * semantics.css + themes.css.
+ */
+
+/* The form is the container's single child, so it owns the vertical stack. */
+.delete-account-modal__form {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+/* Error-tinted header, overriding the neutral dialog header background. */
+.delete-account-modal__header {
+  background-color: var(--color-surface-error-weak);
+}
+
+.delete-account-modal__warning {
+  margin: 0;
+  padding: var(--space-default) var(--space-large) 0;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-default);
+  color: var(--color-text-error);
+}
+
+.delete-account-modal__body {
+  padding: var(--space-large);
+}
+
+.delete-account-modal__summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-default);
+  padding: var(--space-large);
+  background-color: var(--color-surface-weak);
+  border: 1px solid var(--color-stroke-weak);
+  border-radius: var(--border-radius-l);
+}
+
+.delete-account-modal__summary-title {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--line-height-default);
+  color: var(--color-text-primary);
+}
+
+.delete-account-modal__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin: 0;
+  padding-left: var(--space-large);
+  list-style: disc;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-default);
+  color: var(--color-text-secondary);
+}
+
+.delete-account-modal__list li {
+  padding: 0;
+}
+
+.delete-account-modal__divider {
+  width: 100%;
+  height: 1px;
+  margin: var(--space-xs) 0;
+  border: 0;
+  background-color: var(--color-stroke-weak);
+}
+
+/* Delete-account card actions: cancel / delete-now sit side by side. */
+.user-profile__delete-account-actions {
+  display: flex;
+  flex-direction: row;
+  gap: var(--space-default);
+  align-items: center;
+}
+
+.user-profile__delete-inline-form {
+  margin: 0;
+  display: contents;
+}

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -5,9 +5,10 @@
  * .dialog-modal overlay / container / header / buttons shell.
  *
  * Layout mirrors the Figma spec (node 6635:25490): the whole container is a
- * light-red canvas holding a white, rounded inner card. The card's sections
- * (summary / confirmation) are separated by full-bleed dividers that touch
- * both card edges, and a full-bleed rule sits between the warning and the card.
+ * light-red canvas holding a white, rounded inner card. A 16px gap separates
+ * the header, warning, card and buttons; the header carries a bottom divider
+ * between the title and the warning. The card's sections (summary /
+ * confirmation) are separated by full-bleed dividers that touch both edges.
  *
  * All colours go through semantic tokens, so light/dark are handled by
  * semantics.css + themes.css.
@@ -25,24 +26,26 @@
   );
 }
 
-/* The form is the container's single child, so it owns the vertical stack. */
+/* The form is the container's single child, so it owns the vertical stack.
+   The 16px gap reproduces the Figma container spacing between the header,
+   warning, card and buttons, so those children only carry horizontal padding. */
 .delete-account-modal__form {
   display: flex;
   flex-direction: column;
+  gap: var(--space-large);
   width: 100%;
 }
 
-/* Header sits directly on the light-red canvas; drop the shared divider so the
-   only rule between header/warning and the card is our full-bleed one. */
+/* Header sits transparently on the light-red canvas but keeps the shared
+   bottom divider (Figma node 6635:25492), which separates the title from the
+   warning line below it. */
 .delete-account-modal__header {
   background-color: transparent;
-  border-bottom: 0;
-  padding-bottom: 0;
 }
 
 .delete-account-modal__warning {
   margin: 0;
-  padding: 0 var(--space-large) var(--space-large);
+  padding: 0 var(--space-large);
   font-family: var(--font-sans);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-regular);
@@ -51,17 +54,8 @@
   color: var(--color-text-error-emphasis);
 }
 
-/* Full-bleed rule between the warning and the white card (Figma "Line 161"). */
-.delete-account-modal__rule {
-  width: 100%;
-  height: 1px;
-  margin: 0;
-  border: 0;
-  background-color: var(--color-stroke-weak);
-}
-
 .delete-account-modal__body {
-  padding: var(--space-large);
+  padding: 0 var(--space-large);
 }
 
 /* White, rounded inner card sitting on the light-red canvas. */

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -146,16 +146,3 @@
   border: 0;
   background-color: var(--color-stroke-weak);
 }
-
-/* Delete-account card actions: cancel / delete-now sit side by side. */
-.user-profile__delete-account-actions {
-  display: flex;
-  flex-direction: row;
-  gap: var(--space-default);
-  align-items: center;
-}
-
-.user-profile__delete-inline-form {
-  margin: 0;
-  display: contents;
-}

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -117,6 +117,7 @@
    marker-to-text gap (matches the create-account-card list pattern). */
 .delete-account-modal__list li::marker {
   font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
 }
 
 .delete-account-modal__list li + li {

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -91,7 +91,7 @@
 .delete-account-modal__summary-title {
   margin: 0;
   font-family: var(--font-sans);
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-small);
   font-weight: var(--font-weight-medium);
   line-height: var(--line-height-default);
   color: var(--color-text-primary);
@@ -103,9 +103,9 @@
   list-style: disc;
   list-style-position: outside;
   font-family: var(--font-sans);
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-small);
   font-weight: var(--font-weight-regular);
-  line-height: var(--line-height-default);
+  line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
 }
 

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -90,12 +90,10 @@
 }
 
 .delete-account-modal__list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
   margin: 0;
-  padding-left: var(--space-large);
+  padding-left: 1.2em;
   list-style: disc;
+  list-style-position: outside;
   font-family: var(--font-sans);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-regular);
@@ -105,6 +103,16 @@
 
 .delete-account-modal__list li {
   padding: 0;
+}
+
+/* Shrink the disc so it reads as a bullet, not a block, and tighten the
+   marker-to-text gap (matches the create-account-card list pattern). */
+.delete-account-modal__list li::marker {
+  font-size: var(--font-size-xs);
+}
+
+.delete-account-modal__list li + li {
+  margin-top: var(--space-xs);
 }
 
 .delete-account-modal__note {

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -73,6 +73,15 @@
   padding: 0;
 }
 
+.delete-account-modal__note {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-small);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-default);
+  color: var(--color-text-tertiary);
+}
+
 .delete-account-modal__divider {
   width: 100%;
   height: 1px;

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -68,11 +68,12 @@
   overflow: hidden;
 }
 
-/* Fixed, consistent spacing for every card section. */
+/* Fixed, consistent spacing for every card section (Figma summary group
+   6635:25510 stacks its title and bullets 16px apart). */
 .delete-account-modal__section {
   display: flex;
   flex-direction: column;
-  gap: var(--space-default);
+  gap: var(--space-large);
   padding: var(--space-large);
 }
 
@@ -87,7 +88,7 @@
   font-family: var(--font-sans);
   font-size: var(--font-size-small);
   font-weight: var(--font-weight-medium);
-  line-height: var(--line-height-default);
+  line-height: var(--line-height-relaxed);
   color: var(--color-text-primary);
 }
 
@@ -114,8 +115,10 @@
   color: var(--color-text-tertiary);
 }
 
+/* Figma spaces the bullet rows 6px apart, but those rows are 20px tall vs our
+   ~17px text line, so an 8px margin reproduces the same text-to-text rhythm. */
 .delete-account-modal__list li + li {
-  margin-top: var(--space-xs);
+  margin-top: var(--space-default);
 }
 
 .delete-account-modal__note {

--- a/static/css/v3/delete-account-modal.css
+++ b/static/css/v3/delete-account-modal.css
@@ -13,9 +13,16 @@
  * semantics.css + themes.css.
  */
 
-/* The whole dialog is a light-red canvas (Figma container fill #fdf2f2). */
+/* The whole dialog is a light-red canvas (Figma container fill #fdf2f2).
+   Layer the error tint over an opaque page surface so the modal stays fully
+   opaque in dark mode, where --color-surface-error-weak is a translucent tint
+   (in light mode the tint is fully opaque and covers the base entirely). */
 .delete-account-modal .dialog-modal__container {
-  background-color: var(--color-surface-error-weak);
+  background-color: var(--color-surface-page);
+  background-image: linear-gradient(
+    var(--color-surface-error-weak),
+    var(--color-surface-error-weak)
+  );
 }
 
 /* The form is the container's single child, so it owns the vertical stack. */

--- a/static/css/v3/semantics.css
+++ b/static/css/v3/semantics.css
@@ -101,6 +101,11 @@
      TEXT SEMANTIC COLORS
      ============================================ */
   --color-text-error: var(--color-error-strong);
+  /* Brighter red for high-emphasis warning banners (e.g. destructive-action
+     notices), distinct from --color-text-error's smaller inline field
+     validation text. Same value in both themes - already has good contrast
+     against dark surfaces, so no themes.css override is needed. */
+  --color-text-error-emphasis: var(--color-error-mid);
   --color-text-link-accent: var(--color-secondary-dark-blue);
   --color-text-on-accent: var(--color-primary-black);
   --color-text-reversed: var(--color-primary-white);

--- a/static/css/v3/user-profile-page.css
+++ b/static/css/v3/user-profile-page.css
@@ -337,3 +337,16 @@
         width: 528px;
     }
 }
+
+/* Delete-account card actions: cancel / delete-now sit side by side. */
+.user-profile__delete-account-actions {
+    display: flex;
+    flex-direction: row;
+    gap: var(--space-default);
+    align-items: center;
+}
+
+.user-profile__delete-inline-form {
+    margin: 0;
+    display: contents;
+}

--- a/static/css/v3/user-profile-page.css
+++ b/static/css/v3/user-profile-page.css
@@ -338,7 +338,8 @@
     }
 }
 
-/* Delete-account card actions: cancel / delete-now sit side by side. */
+/* Delete-account card actions: holds either the Cancel-deletion button or the
+   Delete-account trigger, never both. */
 .user-profile__delete-account-actions {
     display: flex;
     flex-direction: row;

--- a/templates/base.html
+++ b/templates/base.html
@@ -362,6 +362,11 @@
         class="h-screen {% flag "v3" %}v3{% else %}bg-gray-200 dark:bg-black{% endflag %}{% if DEBUG %} DEBUG{% endif %}" {% block body_id %}{% endblock %}>
          <div class="modal-overlay" id="modalOverlay"><div class="modal-content"><iframe id="modalFrame" class="w-full h-full rounded-xl m-0 p-0"></iframe><div class="modal-close" id="modalClose" onclick="closeModal()"><i class="fa-solid fa-xmark fa-lg"></i></div></div></div>
       {% flag "v3" %}
+        {% if request.user.is_authenticated and request.user.delete_permanently_at %}
+          {% include "v3/includes/_account_deletion_banner.html" %}
+        {% endif %}
+      {% endflag %}
+      {% flag "v3" %}
       <div class="bg-slate text-white text-center py-2 font-semibold">v3 flag enabled</div>
       {% endflag %}
       {% block main_content_wrapper %}
@@ -382,6 +387,7 @@
       <div class="w-full">
         {% block messages %}{% include "partials/messages.html" %}{% endblock messages %}
       </div>
+      {% flag "v3" %}{% else %}
       {% if request.user.is_authenticated and request.user.delete_permanently_at %}
       <div id="messages" class="w-full text-center transition-opacity" x-data="{show: true}">
         <div x-show="show" class="mx-auto text-left items-center text-white rounded text-base px-3 py-2 bg-red-500 fade show">
@@ -400,6 +406,7 @@
         </div>
       </div>
       {% endif %}
+      {% endflag %}
 
       <div class="md:px-0 min-vh-110">
       {% block content_wrapper %}

--- a/templates/emails/account_deletion_scheduled.html
+++ b/templates/emails/account_deletion_scheduled.html
@@ -32,3 +32,5 @@
 {% endblock %}
 
 {% block cta_label %}Log in to cancel{% endblock %}
+
+{% block footer_links %}{% endblock %}

--- a/templates/emails/account_deletion_scheduled.html
+++ b/templates/emails/account_deletion_scheduled.html
@@ -1,0 +1,34 @@
+{% extends "emails/base_email.html" %}
+{% load custom_static %}
+
+{% comment %}
+  Sent when a user schedules their account for deletion (V3 flow). Subject:
+  "Your account is scheduled for deletion" (see
+  account_deletion_scheduled_subject.txt).
+  Context: first_name, grace_days, action_url (login URL used as the CTA),
+  postorius_url, scheme, host.
+{% endcomment %}
+
+{% block title %}Your account is scheduled for deletion{% endblock %}
+
+{% block preheader %}Your account is scheduled for deletion in {{ grace_days }} day{{ grace_days|pluralize }}. You can cancel anytime before then by logging back in.{% endblock %}
+
+{% block card_title %}Account scheduled for deletion{% endblock %}
+
+{% block card_body %}
+  <p style="margin:0;">Hi {{ first_name|default:"there" }},</p>
+  <p style="margin:14px 0 0 0;">We've received your request to delete your account. It's now scheduled for deletion in {{ grace_days }} day{{ grace_days|pluralize }}.</p>
+  <p style="margin:14px 0 0 0;">You can cancel this anytime before then by logging back in.</p>
+  <p style="margin:18px 0 8px 0;">What happens when deletion completes:</p>
+  <ul style="margin:0;padding-left:20px;">
+    <li style="margin:0 0 6px 0;">Your profile (name, email, photo, GitHub username, and links) will be anonymized</li>
+    <li style="margin:0 0 6px 0;">Your GitHub/Google sign-ins will be disconnected and saved email addresses removed</li>
+    <li style="margin:0;">Your notification preferences will be removed</li>
+  </ul>
+  <p style="margin:14px 0 0 0;">Posts and contributions you've made will remain on the site but will no longer be linked to you.</p>
+  <p style="margin:14px 0 0 0;">If you have mailing list subscriptions, you can still manage those through <a href="{{ postorius_url }}" style="color:#050816;text-decoration:underline;">Postorius</a>.</p>
+  <p style="margin:14px 0 0 0;">If you didn't request this, log in and cancel the deletion before the {{ grace_days }} day{{ grace_days|pluralize }} are up.</p>
+  <p style="margin:18px 0 0 0;">Thanks,<br>The Boost Team</p>
+{% endblock %}
+
+{% block cta_label %}Log in to cancel{% endblock %}

--- a/templates/emails/account_deletion_scheduled.txt
+++ b/templates/emails/account_deletion_scheduled.txt
@@ -1,0 +1,35 @@
+Your account is scheduled for deletion
+
+Hi {{ first_name|default:"there" }},
+
+We've received your request to delete your account. It's now scheduled for
+deletion in {{ grace_days }} day{{ grace_days|pluralize }}.
+
+You can cancel this anytime before then by logging back in.
+
+What happens when deletion completes:
+
+- Your profile (name, email, photo, GitHub username, and links) will be
+  anonymized
+- Your GitHub/Google sign-ins will be disconnected and saved email addresses
+  removed
+- Your notification preferences will be removed
+
+Posts and contributions you've made will remain on the site but will no longer
+be linked to you.
+
+If you have mailing list subscriptions, you can still manage those through
+Postorius ({{ postorius_url }}).
+
+If you didn't request this, log in and cancel the deletion before the
+{{ grace_days }} day{{ grace_days|pluralize }} are up:
+{{ action_url }}
+
+Thanks,
+The Boost Team
+
+--
+Boost.org is supported by grants from The C++ Alliance.
+
+Want to change how you receive these emails?
+You can update your preferences or unsubscribe from this list.

--- a/templates/emails/account_deletion_scheduled.txt
+++ b/templates/emails/account_deletion_scheduled.txt
@@ -30,6 +30,3 @@ The Boost Team
 
 --
 Boost.org is supported by grants from The C++ Alliance.
-
-Want to change how you receive these emails?
-You can update your preferences or unsubscribe from this list.

--- a/templates/emails/account_deletion_scheduled_subject.txt
+++ b/templates/emails/account_deletion_scheduled_subject.txt
@@ -1,0 +1,1 @@
+Your account is scheduled for deletion

--- a/templates/emails/base_email.html
+++ b/templates/emails/base_email.html
@@ -128,9 +128,11 @@
                 <!-- Footer text -->
                 <div style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:1.45;letter-spacing:0.14px;color:#050816;">
                   <a href="https://www.boost.org/" style="color:#050816;text-decoration:underline;">Boost.org</a> is supported by grants from <a href="https://cppalliance.org/" style="color:#050816;text-decoration:underline;">The C++ Alliance.</a>
-                  <br><br>
-                  Want to change how you receive these emails?<br>
-                  You can <a href="{{ preferences_url|default:'#' }}" style="color:#050816;text-decoration:underline;">update your preferences</a> or <a href="{{ unsubscribe_url|default:'#' }}" style="color:#050816;text-decoration:underline;">unsubscribe from this list</a>.
+                  {% block footer_links %}
+                    <br><br>
+                    Want to change how you receive these emails?<br>
+                    You can <a href="{{ preferences_url|default:'#' }}" style="color:#050816;text-decoration:underline;">update your preferences</a> or <a href="{{ unsubscribe_url|default:'#' }}" style="color:#050816;text-decoration:underline;">unsubscribe from this list</a>.
+                  {% endblock %}
                 </div>
               </td>
             </tr>

--- a/templates/v3/includes/_account_deletion_banner.html
+++ b/templates/v3/includes/_account_deletion_banner.html
@@ -1,0 +1,33 @@
+{% comment %}
+  V3 site-wide "account scheduled for deletion" banner.
+
+  Rendered from base.html (behind the v3 flag) whenever the logged-in user has a
+  pending scheduled deletion. It is sticky at the very top of the page so it
+  sits above the navbar and, being in normal flow, pushes page content down.
+
+  Only "Cancel deletion" is offered - immediate deletion is intentionally not
+  exposed in V3. Cancel is a POST form (CancelDeletionView redirects V3 users
+  to their profile edit page). The dismiss (x) is a JS enhancement; with JS off
+  the banner simply stays visible.
+{% endcomment %}
+<div class="deletion-banner"
+     role="region"
+     aria-label="Account deletion notice"
+     x-data="{ show: true }"
+     x-show="show">
+  <div class="deletion-banner__body">
+    <span class="deletion-banner__message">
+      Your account is scheduled for deletion on {{ request.user.delete_permanently_at|date:'N j, Y, P e' }}.
+    </span>
+    <form method="post" action="{% url 'profile-cancel-delete' %}" class="deletion-banner__form">
+      {% csrf_token %}
+      <button type="submit" class="deletion-banner__cancel">Cancel deletion</button>
+    </form>
+  </div>
+  <button type="button"
+          class="deletion-banner__close"
+          aria-label="Dismiss"
+          x-on:click="show = false">
+    {% include "includes/icon.html" with icon_name="close" icon_class="deletion-banner__close-icon" icon_size=16 %}
+  </button>
+</div>

--- a/templates/v3/includes/_account_deletion_banner.html
+++ b/templates/v3/includes/_account_deletion_banner.html
@@ -19,7 +19,7 @@
     <span class="deletion-banner__message">
       Your account is scheduled for deletion on {{ request.user.delete_permanently_at|date:'N j, Y, P e' }}.
     </span>
-    <form method="post" action="{% url 'profile-cancel-delete' %}" class="deletion-banner__form">
+    <form method="post" action="{{ profile_cancel_delete_url }}" class="deletion-banner__form">
       {% csrf_token %}
       <button type="submit" class="deletion-banner__cancel">Cancel deletion</button>
     </form>

--- a/templates/v3/includes/_account_deletion_banner.html
+++ b/templates/v3/includes/_account_deletion_banner.html
@@ -7,8 +7,9 @@
 
   Only "Cancel deletion" is offered - immediate deletion is intentionally not
   exposed in V3. Cancel is a POST form (CancelDeletionView redirects V3 users
-  to their profile edit page). The dismiss (x) is a JS enhancement; with JS off
-  the banner simply stays visible.
+  to their profile edit page). The dismiss (x) is a JS enhancement; it is
+  x-cloaked so it never renders without JS, and the banner simply stays
+  visible.
 {% endcomment %}
 <div class="deletion-banner"
      role="region"
@@ -27,6 +28,7 @@
   <button type="button"
           class="deletion-banner__close"
           aria-label="Dismiss"
+          x-cloak
           x-on:click="show = false">
     {% include "includes/icon.html" with icon_name="close" icon_class="deletion-banner__close-icon" icon_size=16 %}
   </button>

--- a/templates/v3/user_profile_edit.html
+++ b/templates/v3/user_profile_edit.html
@@ -183,7 +183,7 @@ flushed rather than leaking onto the next page. {% endcomment %}
             {% else %}
               <div>
                 <div class="user-profile__small-section-heading">Remove your account from our system</div>
-                <div class="user-profile__small-section-subheading">This will remove your information and account from Boost completely and is not reversible.</div>
+                <div class="user-profile__small-section-subheading">This action will permanently erase all your information and account from Boost, and it cannot be undone.</div>
               </div>
             {% endif %}
           </div>

--- a/templates/v3/user_profile_edit.html
+++ b/templates/v3/user_profile_edit.html
@@ -178,7 +178,7 @@ flushed rather than leaking onto the next page. {% endcomment %}
             {% if delete_permanently_at %}
               <div>
                 <div class="user-profile__small-section-heading">Account scheduled for deletion</div>
-                <div class="user-profile__small-section-subheading">Your account is scheduled for deletion on {{ delete_permanently_at|date:'N j, Y, P e' }}. You can cancel before then, or delete your account now.</div>
+                <div class="user-profile__small-section-subheading">Your account is scheduled for deletion on {{ delete_permanently_at|date:'N j, Y, P e' }}. You can cancel the deletion before then.</div>
               </div>
             {% else %}
               <div>
@@ -194,15 +194,12 @@ flushed rather than leaking onto the next page. {% endcomment %}
                 {% csrf_token %}
                 <button type="submit" class="btn btn-secondary btn-flex">Cancel deletion</button>
               </form>
-              <a href="#delete-now-dialog" class="btn btn-error btn-flex" role="button">Delete now</a>
             {% else %}
               <a href="#delete-account-dialog" class="btn btn-error btn-flex" role="button">Delete Account</a>
             {% endif %}
           </div>
         </div>
-        {% if delete_permanently_at %}
-          {% include "v3/users/_delete_account_modal.html" with dialog_id="delete-now-dialog" title="Delete your account" warning="This will permanently delete your account now. This action cannot be undone." action_url=profile_delete_immediately_url submit_label="Delete my account" delete_form=delete_account_form %}
-        {% else %}
+        {% if not delete_permanently_at %}
           {% include "v3/users/_delete_account_modal.html" with dialog_id="delete-account-dialog" title="Delete your account" warning=delete_schedule_warning action_url=profile_delete_url submit_label="Delete my account" delete_form=delete_account_form %}
         {% endif %}
       </div>

--- a/templates/v3/user_profile_edit.html
+++ b/templates/v3/user_profile_edit.html
@@ -200,7 +200,7 @@ flushed rather than leaking onto the next page. {% endcomment %}
           </div>
         </div>
         {% if not delete_permanently_at %}
-          {% include "v3/users/_delete_account_modal.html" with dialog_id="delete-account-dialog" title="Delete your account" warning=delete_schedule_warning action_url=profile_delete_url submit_label="Delete my account" delete_form=delete_account_form postorius_url=postorius_url %}
+          {% include "v3/users/_delete_account_modal.html" with dialog_id="delete-account-dialog" title="Delete your account" warning=delete_schedule_warning action_url=profile_delete_url submit_label="Delete my account" delete_form=delete_account_form postorius_url=postorius_url error=delete_account_error %}
         {% endif %}
       </div>
       <div class="user-profile__col">

--- a/templates/v3/user_profile_edit.html
+++ b/templates/v3/user_profile_edit.html
@@ -200,7 +200,7 @@ flushed rather than leaking onto the next page. {% endcomment %}
           </div>
         </div>
         {% if not delete_permanently_at %}
-          {% include "v3/users/_delete_account_modal.html" with dialog_id="delete-account-dialog" title="Delete your account" warning=delete_schedule_warning action_url=profile_delete_url submit_label="Delete my account" delete_form=delete_account_form postorius_url=postorius_url error=delete_account_error %}
+          {% include "v3/users/_delete_account_modal.html" with dialog_id="delete-account-dialog" title="Delete your account" warning=delete_schedule_warning action_url=profile_delete_url submit_label="Delete my account" postorius_url=postorius_url error=delete_account_error %}
         {% endif %}
       </div>
       <div class="user-profile__col">

--- a/templates/v3/user_profile_edit.html
+++ b/templates/v3/user_profile_edit.html
@@ -175,16 +175,36 @@ flushed rather than leaking onto the next page. {% endcomment %}
           </div>
           <hr class="card__hr" aria-hidden="true" />
           <div class="card__column px-large">
-            <div>
-              <div class="user-profile__small-section-heading">Remove your account from our system</div>
-              <div class="user-profile__small-section-subheading">This will remove your information and account from Boost completely and is not reversible.</div>
-            </div>
+            {% if delete_permanently_at %}
+              <div>
+                <div class="user-profile__small-section-heading">Account scheduled for deletion</div>
+                <div class="user-profile__small-section-subheading">Your account is scheduled for deletion on {{ delete_permanently_at|date:'N j, Y, P e' }}. You can cancel before then, or delete your account now.</div>
+              </div>
+            {% else %}
+              <div>
+                <div class="user-profile__small-section-heading">Remove your account from our system</div>
+                <div class="user-profile__small-section-subheading">This will remove your information and account from Boost completely and is not reversible.</div>
+              </div>
+            {% endif %}
           </div>
           <hr class="card__hr" aria-hidden="true" />
-          <div class="card__cta_section">
-            {% include 'v3/includes/_button.html' with style='error' type='submit' label='Delete Account' only %}
+          <div class="card__cta_section user-profile__delete-account-actions">
+            {% if delete_permanently_at %}
+              <form method="post" action="{{ profile_cancel_delete_url }}" class="user-profile__delete-inline-form">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-secondary btn-flex">Cancel deletion</button>
+              </form>
+              <a href="#delete-now-dialog" class="btn btn-error btn-flex" role="button">Delete now</a>
+            {% else %}
+              <a href="#delete-account-dialog" class="btn btn-error btn-flex" role="button">Delete Account</a>
+            {% endif %}
           </div>
         </div>
+        {% if delete_permanently_at %}
+          {% include "v3/users/_delete_account_modal.html" with dialog_id="delete-now-dialog" title="Delete your account" warning="This will permanently delete your account now. This action cannot be undone." action_url=profile_delete_immediately_url submit_label="Delete my account" delete_form=delete_account_form %}
+        {% else %}
+          {% include "v3/users/_delete_account_modal.html" with dialog_id="delete-account-dialog" title="Delete your account" warning=delete_schedule_warning action_url=profile_delete_url submit_label="Delete my account" delete_form=delete_account_form %}
+        {% endif %}
       </div>
       <div class="user-profile__col">
         <div class="basic-card card user-profile__update-details">

--- a/templates/v3/user_profile_edit.html
+++ b/templates/v3/user_profile_edit.html
@@ -200,7 +200,7 @@ flushed rather than leaking onto the next page. {% endcomment %}
           </div>
         </div>
         {% if not delete_permanently_at %}
-          {% include "v3/users/_delete_account_modal.html" with dialog_id="delete-account-dialog" title="Delete your account" warning=delete_schedule_warning action_url=profile_delete_url submit_label="Delete my account" delete_form=delete_account_form %}
+          {% include "v3/users/_delete_account_modal.html" with dialog_id="delete-account-dialog" title="Delete your account" warning=delete_schedule_warning action_url=profile_delete_url submit_label="Delete my account" delete_form=delete_account_form postorius_url=postorius_url %}
         {% endif %}
       </div>
       <div class="user-profile__col">

--- a/templates/v3/users/_delete_account_modal.html
+++ b/templates/v3/users/_delete_account_modal.html
@@ -50,7 +50,6 @@
         </a>
       </div>
       <p class="delete-account-modal__warning" id="{{ dialog_id }}-desc">{{ warning }}</p>
-      <hr class="delete-account-modal__rule" aria-hidden="true" />
       <div class="delete-account-modal__body">
         <div class="delete-account-modal__card">
           <div class="delete-account-modal__section">

--- a/templates/v3/users/_delete_account_modal.html
+++ b/templates/v3/users/_delete_account_modal.html
@@ -36,12 +36,13 @@
       <p class="delete-account-modal__warning" id="{{ dialog_id }}-desc">{{ warning }}</p>
       <div class="delete-account-modal__body">
         <div class="delete-account-modal__summary">
-          <p class="delete-account-modal__summary-title">Deleting your account will permanently remove:</p>
+          <p class="delete-account-modal__summary-title">Deleting your account will:</p>
           <ul class="delete-account-modal__list">
-            <li>Your profile and contributor history</li>
-            <li>All mailing list subscriptions</li>
-            <li>Saved libraries and notification preferences</li>
+            <li>Anonymize your profile (name, email, photo, GitHub username, and links)</li>
+            <li>Disconnect your GitHub/Google sign-ins and remove your saved email addresses</li>
+            <li>Remove your mailing list subscriptions and notification preferences</li>
           </ul>
+          <p class="delete-account-modal__note">Posts and contributions you've made will remain on the site but will no longer be linked to you.</p>
           <hr class="delete-account-modal__divider" aria-hidden="true" />
           {% include "v3/includes/_field_text.html" with name="verify" type="text" label='To confirm, type "delete my account"' placeholder="delete my account" aria_label="Type delete my account to confirm" only %}
         </div>

--- a/templates/v3/users/_delete_account_modal.html
+++ b/templates/v3/users/_delete_account_modal.html
@@ -1,0 +1,55 @@
+{% comment %}
+  Delete-account dialog (V3).
+
+  A :target-driven modal (no JavaScript required) reusing the shared
+  .dialog-modal shell. It wraps a real POST form so the flow degrades
+  gracefully: the trigger <a href="#{{ dialog_id }}"> opens it, the server
+  validates the confirmation phrase, and on failure the view redirects back
+  with #{{ dialog_id }} so the modal reopens with the error message.
+
+  Variables:
+    dialog_id     (required): unique id / :target anchor for this dialog.
+    title         (required): heading text.
+    warning       (required): red warning line shown under the header.
+    action_url    (required): POST target (schedule or immediate deletion).
+    submit_label  (required): label for the destructive submit button.
+    delete_form   (required): DeleteAccountForm providing the `verify` field.
+{% endcomment %}
+<div class="dialog-modal delete-account-modal" id="{{ dialog_id }}">
+  <a class="dialog-modal__backdrop" href="#_" tabindex="-1" aria-label="Close dialog"></a>
+  <div class="dialog-modal__container"
+       role="dialog"
+       aria-modal="true"
+       aria-labelledby="{{ dialog_id }}-title"
+       aria-describedby="{{ dialog_id }}-desc">
+    <form method="post" action="{{ action_url }}" class="delete-account-modal__form">
+      {% csrf_token %}
+      <div class="dialog-modal__header delete-account-modal__header">
+        <h2 class="dialog-modal__title" id="{{ dialog_id }}-title">{{ title }}</h2>
+        <a class="dialog-modal__close"
+           role="button"
+           href="#_"
+           aria-label="Close dialog">
+          {% include "includes/icon.html" with icon_name="close" icon_class="dialog-modal__close-icon" icon_size=24 %}
+        </a>
+      </div>
+      <p class="delete-account-modal__warning" id="{{ dialog_id }}-desc">{{ warning }}</p>
+      <div class="delete-account-modal__body">
+        <div class="delete-account-modal__summary">
+          <p class="delete-account-modal__summary-title">Deleting your account will permanently remove:</p>
+          <ul class="delete-account-modal__list">
+            <li>Your profile and contributor history</li>
+            <li>All mailing list subscriptions</li>
+            <li>Saved libraries and notification preferences</li>
+          </ul>
+          <hr class="delete-account-modal__divider" aria-hidden="true" />
+          {% include "v3/includes/_field_text.html" with name="verify" type="text" label='To confirm, type "delete my account"' placeholder="delete my account" aria_label="Type delete my account to confirm" only %}
+        </div>
+      </div>
+      <div class="dialog-modal__buttons">
+        <a href="#_" class="btn btn-secondary btn-flex">Cancel</a>
+        <button type="submit" class="btn btn-error btn-flex">{{ submit_label }}</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/templates/v3/users/_delete_account_modal.html
+++ b/templates/v3/users/_delete_account_modal.html
@@ -22,6 +22,8 @@
     submit_label  (required): label for the destructive submit button.
     delete_form   (required): DeleteAccountForm providing the `verify` field.
     postorius_url (required): external Postorius URL for managing subscriptions.
+    error         (optional): confirmation error rendered inline on the field
+                              (set after a failed no-JS submission).
 {% endcomment %}
 <div class="dialog-modal delete-account-modal" id="{{ dialog_id }}">
   <a class="dialog-modal__backdrop" href="#_" tabindex="-1" aria-label="Close dialog"></a>
@@ -60,7 +62,7 @@
           </div>
           <hr class="delete-account-modal__divider" aria-hidden="true" />
           <div class="delete-account-modal__section" @input="confirmText = $event.target.value">
-            {% include "v3/includes/_field_text.html" with name="verify" type="text" label='To confirm, type "delete my account"' placeholder="delete my account" aria_label="Type delete my account to confirm" only %}
+            {% include "v3/includes/_field_text.html" with name="verify" type="text" label='To confirm, type "delete my account"' placeholder="delete my account" aria_label="Type delete my account to confirm" error=error only %}
           </div>
         </div>
       </div>

--- a/templates/v3/users/_delete_account_modal.html
+++ b/templates/v3/users/_delete_account_modal.html
@@ -35,7 +35,11 @@
     <form method="post"
           action="{{ action_url }}"
           class="delete-account-modal__form"
-          x-data="{ confirmText: '' }">
+          x-data="{
+                  confirmText: '',
+                  get confirmed() { return this.confirmText.trim() === 'delete my account'; }
+                  }"
+          @submit="if (!confirmed) $event.preventDefault()">
       {% csrf_token %}
       <div class="dialog-modal__header delete-account-modal__header">
         <h2 class="dialog-modal__title" id="{{ dialog_id }}-title">{{ title }}</h2>
@@ -70,7 +74,7 @@
         <a href="#_" class="btn btn-secondary btn-flex">Cancel</a>
         <button type="submit"
                 class="btn btn-error btn-flex"
-                :disabled="confirmText !== 'delete my account'">{{ submit_label }}</button>
+                :disabled="!confirmed">{{ submit_label }}</button>
       </div>
     </form>
   </div>

--- a/templates/v3/users/_delete_account_modal.html
+++ b/templates/v3/users/_delete_account_modal.html
@@ -7,6 +7,13 @@
   validates the confirmation phrase, and on failure the view redirects back
   with #{{ dialog_id }} so the modal reopens with the error message.
 
+  Layout mirrors the Figma spec: a light-red container holds a white,
+  rounded inner card whose sections are separated by full-bleed dividers.
+
+  Progressive enhancement: Alpine keeps the destructive button disabled until
+  the confirmation phrase is typed exactly. With JS off the button stays
+  enabled and the server validates the phrase.
+
   Variables:
     dialog_id     (required): unique id / :target anchor for this dialog.
     title         (required): heading text.
@@ -14,6 +21,7 @@
     action_url    (required): POST target (schedule or immediate deletion).
     submit_label  (required): label for the destructive submit button.
     delete_form   (required): DeleteAccountForm providing the `verify` field.
+    postorius_url (required): external Postorius URL for managing subscriptions.
 {% endcomment %}
 <div class="dialog-modal delete-account-modal" id="{{ dialog_id }}">
   <a class="dialog-modal__backdrop" href="#_" tabindex="-1" aria-label="Close dialog"></a>
@@ -22,7 +30,10 @@
        aria-modal="true"
        aria-labelledby="{{ dialog_id }}-title"
        aria-describedby="{{ dialog_id }}-desc">
-    <form method="post" action="{{ action_url }}" class="delete-account-modal__form">
+    <form method="post"
+          action="{{ action_url }}"
+          class="delete-account-modal__form"
+          x-data="{ confirmText: '' }">
       {% csrf_token %}
       <div class="dialog-modal__header delete-account-modal__header">
         <h2 class="dialog-modal__title" id="{{ dialog_id }}-title">{{ title }}</h2>
@@ -34,23 +45,30 @@
         </a>
       </div>
       <p class="delete-account-modal__warning" id="{{ dialog_id }}-desc">{{ warning }}</p>
+      <hr class="delete-account-modal__rule" aria-hidden="true" />
       <div class="delete-account-modal__body">
-        <div class="delete-account-modal__summary">
-          <p class="delete-account-modal__summary-title">Deleting your account will:</p>
-          <ul class="delete-account-modal__list">
-            <li>Anonymize your profile (name, email, photo, GitHub username, and links)</li>
-            <li>Disconnect your GitHub/Google sign-ins and remove your saved email addresses</li>
-            <li>Remove your notification preferences</li>
-          </ul>
-          <p class="delete-account-modal__note">Posts and contributions you've made will remain on the site but will no longer be linked to you.</p>
-          <p class="delete-account-modal__note">You'll still be able to manage your mailing list subscriptions through <a class="delete-account-modal__link" href="{{ postorius_url }}" target="_blank" rel="noopener noreferrer">Postorius</a>.</p>
+        <div class="delete-account-modal__card">
+          <div class="delete-account-modal__section">
+            <p class="delete-account-modal__summary-title">Deleting your account will:</p>
+            <ul class="delete-account-modal__list">
+              <li>Anonymize your profile (name, email, photo, GitHub username, and links)</li>
+              <li>Disconnect your GitHub/Google sign-ins and remove your saved email addresses</li>
+              <li>Remove your notification preferences</li>
+            </ul>
+            <p class="delete-account-modal__note">Posts and contributions you've made will remain on the site but will no longer be linked to you.</p>
+            <p class="delete-account-modal__note">You'll still be able to manage your mailing list subscriptions through <a class="delete-account-modal__link" href="{{ postorius_url }}" target="_blank" rel="noopener noreferrer">Postorius</a>.</p>
+          </div>
           <hr class="delete-account-modal__divider" aria-hidden="true" />
-          {% include "v3/includes/_field_text.html" with name="verify" type="text" label='To confirm, type "delete my account"' placeholder="delete my account" aria_label="Type delete my account to confirm" only %}
+          <div class="delete-account-modal__section" @input="confirmText = $event.target.value">
+            {% include "v3/includes/_field_text.html" with name="verify" type="text" label='To confirm, type "delete my account"' placeholder="delete my account" aria_label="Type delete my account to confirm" only %}
+          </div>
         </div>
       </div>
       <div class="dialog-modal__buttons">
         <a href="#_" class="btn btn-secondary btn-flex">Cancel</a>
-        <button type="submit" class="btn btn-error btn-flex">{{ submit_label }}</button>
+        <button type="submit"
+                class="btn btn-error btn-flex"
+                :disabled="confirmText !== 'delete my account'">{{ submit_label }}</button>
       </div>
     </form>
   </div>

--- a/templates/v3/users/_delete_account_modal.html
+++ b/templates/v3/users/_delete_account_modal.html
@@ -20,7 +20,6 @@
     warning       (required): red warning line shown under the header.
     action_url    (required): POST target (schedule or immediate deletion).
     submit_label  (required): label for the destructive submit button.
-    delete_form   (required): DeleteAccountForm providing the `verify` field.
     postorius_url (required): external Postorius URL for managing subscriptions.
     error         (optional): confirmation error rendered inline on the field
                               (set after a failed no-JS submission).

--- a/templates/v3/users/_delete_account_modal.html
+++ b/templates/v3/users/_delete_account_modal.html
@@ -40,9 +40,10 @@
           <ul class="delete-account-modal__list">
             <li>Anonymize your profile (name, email, photo, GitHub username, and links)</li>
             <li>Disconnect your GitHub/Google sign-ins and remove your saved email addresses</li>
-            <li>Remove your mailing list subscriptions and notification preferences</li>
+            <li>Remove your notification preferences</li>
           </ul>
           <p class="delete-account-modal__note">Posts and contributions you've made will remain on the site but will no longer be linked to you.</p>
+          <p class="delete-account-modal__note">You'll still be able to manage your mailing list subscriptions through <a class="delete-account-modal__link" href="{{ postorius_url }}" target="_blank" rel="noopener noreferrer">Postorius</a>.</p>
           <hr class="delete-account-modal__divider" aria-hidden="true" />
           {% include "v3/includes/_field_text.html" with name="verify" type="text" label='To confirm, type "delete my account"' placeholder="delete my account" aria_label="Type delete my account to confirm" only %}
         </div>

--- a/users/forms.py
+++ b/users/forms.py
@@ -191,12 +191,14 @@ class UserProfilePhotoForm(forms.ModelForm):
 
 
 class DeleteAccountForm(forms.Form):
+    CONFIRM_ERROR = 'Please enter "delete my account"'
+
     verify = forms.CharField(help_text='To verify, type "delete my account" above.')
 
     def clean_verify(self):
         verify = self.cleaned_data["verify"]
         if self.cleaned_data["verify"] != "delete my account":
-            raise forms.ValidationError('Please enter "delete my account"')
+            raise forms.ValidationError(self.CONFIRM_ERROR)
         return verify
 
 

--- a/users/management/commands/send_test_emails.py
+++ b/users/management/commands/send_test_emails.py
@@ -63,6 +63,12 @@ TEMPLATES = {
         "html": "emails/unknown_account.html",
         "action_url": "https://www.boost.org/v3/accounts/signup/",
     },
+    "account_deletion_scheduled": {
+        "subject": "emails/account_deletion_scheduled_subject.txt",
+        "text": "emails/account_deletion_scheduled.txt",
+        "html": "emails/account_deletion_scheduled.html",
+        "action_url": "https://www.boost.org/accounts/login/",
+    },
 }
 
 # Matches the URL of any email image, e.g. src="/static/static-large/img/emails/x.png"
@@ -237,6 +243,9 @@ def command(
             "action_url": spec["action_url"],
             "preferences_url": f"{base_url}/account/preferences",
             "unsubscribe_url": f"{base_url}/account/unsubscribe",
+            # Account-deletion-scheduled email context.
+            "grace_days": settings.ACCOUNT_DELETION_GRACE_PERIOD_DAYS,
+            "postorius_url": "https://lists.boost.org/mailman3/lists/",
             # Link lifetimes shown in the email bodies, sourced from the same
             # settings the real flows enforce (allauth email confirmation in
             # days, Django's password reset token timeout in seconds).

--- a/users/management/commands/send_test_emails.py
+++ b/users/management/commands/send_test_emails.py
@@ -245,7 +245,7 @@ def command(
             "unsubscribe_url": f"{base_url}/account/unsubscribe",
             # Account-deletion-scheduled email context.
             "grace_days": settings.ACCOUNT_DELETION_GRACE_PERIOD_DAYS,
-            "postorius_url": "https://lists.boost.org/mailman3/lists/",
+            "postorius_url": settings.POSTORIUS_URL,
             # Link lifetimes shown in the email bodies, sourced from the same
             # settings the real flows enforce (allauth email confirmation in
             # days, Django's password reset token timeout in seconds).

--- a/users/migrations/0024_user_deletion_extended_scrub.py
+++ b/users/migrations/0024_user_deletion_extended_scrub.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0023_user_biography_user_tagline"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="deletion_extended_scrub",
+            field=models.BooleanField(default=False, editable=False),
+        ),
+    ]

--- a/users/migrations/0025_user_deletion_extended_scrub.py
+++ b/users/migrations/0025_user_deletion_extended_scrub.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("users", "0023_user_biography_user_tagline"),
+        ("users", "0024_user_country_user_hide_badges_and_more"),
     ]
 
     operations = [

--- a/users/models.py
+++ b/users/models.py
@@ -431,40 +431,16 @@ class User(BaseUser):
 
     @transaction.atomic
     def delete_account(self):
-        from mailing_list.client import MailmanAPIError, MailmanClient
-        from mailing_list.models import SubscriptionStatus
-
         from . import tasks
 
         email = self.email
         transaction.on_commit(lambda: tasks.send_account_deleted_email.delay(email))
 
-        # Unsubscribe from the external Boost (Mailman) lists, then drop the
-        # local subscription records. The external calls are deferred to
-        # on_commit so a Mailman outage can't roll back the deletion, and the
-        # whole thing only runs at actual-deletion time - a cancelled scheduled
-        # deletion never touches the user's subscriptions.
-        active_subscriptions = [
-            (sub.email, sub.list_id)
-            for sub in self.mailing_list_subscriptions.all()
-            if sub.status == SubscriptionStatus.ACTIVE
-        ]
+        # Delete the local mailing-list subscription rows to remove the stored
+        # email PII. We deliberately do NOT call the Mailman/Postorius API to
+        # unsubscribe - list membership is left for the user to manage in
+        # Postorius.
         self.mailing_list_subscriptions.all().delete()
-        if active_subscriptions:
-
-            def _unsubscribe_external():
-                client = MailmanClient()
-                for sub_email, list_id in active_subscriptions:
-                    try:
-                        client.unsubscribe(sub_email, list_id)
-                    except MailmanAPIError:
-                        logger.exception(
-                            "Mailman unsubscribe failed for list %s during "
-                            "account deletion",
-                            list_id,
-                        )
-
-            transaction.on_commit(_unsubscribe_external)
 
         # Remove linked auth + preference records. Manager-level deletes are
         # idempotent, so a second run (immediate delete racing the scheduled

--- a/users/models.py
+++ b/users/models.py
@@ -450,19 +450,12 @@ class User(BaseUser):
         email = self.email
         transaction.on_commit(lambda: tasks.send_account_deleted_email.delay(email))
 
-        # Delete the local mailing-list subscription rows to remove the stored
-        # email PII. We deliberately do NOT call the Mailman/Postorius API to
-        # unsubscribe - list membership is left for the user to manage in
-        # Postorius.
-        self.mailing_list_subscriptions.all().delete()
-
         # Remove linked auth + preference records. Manager-level deletes are
         # idempotent, so a second run (immediate delete racing the scheduled
         # task) is a harmless no-op.
         self.socialaccount_set.all().delete()
         self.emailaddress_set.all().delete()
         Preferences.objects.filter(user=self).delete()
-        LastSeen.objects.filter(user=self).delete()
 
         # Scrub credentials, profile identity and public PII.
         self.is_active = False
@@ -472,9 +465,15 @@ class User(BaseUser):
         self.display_name = "John Doe"
         self.email = "deleted-{}@example.com".format(uuid.uuid4())
 
-        # These fields are only scrubbed for the V3 deletion flow - gating
-        # them keeps legacy (flag-off) deletion byte-identical to production.
+        # These records and fields are only scrubbed for the V3 deletion flow -
+        # gating them keeps legacy (flag-off) deletion byte-identical to
+        # production.
         if extended_scrub:
+            # The local mailing-list rows store the user's email. We
+            # deliberately do NOT call the Mailman/Postorius API to unsubscribe
+            # - list membership is left for the user to manage in Postorius.
+            self.mailing_list_subscriptions.all().delete()
+            LastSeen.objects.filter(user=self).delete()
             self.github_username = ""
             self.profile_links = {}
             self.indicate_last_login_method = False

--- a/users/models.py
+++ b/users/models.py
@@ -465,8 +465,12 @@ class User(BaseUser):
         self.display_name = "John Doe"
         self.email = "deleted-{}@example.com".format(uuid.uuid4())
 
-        # These records and fields are only scrubbed for the V3 deletion flow -
-        # gating them keeps legacy (flag-off) deletion byte-identical to
+        # Drop the cached avatar render while its source field is still set.
+        self.delete_cached_thumbnail()
+        image_fields = ["profile_image"]
+
+        # These records, fields and files are only scrubbed for the V3 deletion
+        # flow - gating them keeps legacy (flag-off) deletion byte-identical to
         # production.
         if extended_scrub:
             # The local mailing-list rows store the user's email. We
@@ -474,20 +478,18 @@ class User(BaseUser):
             # - list membership is left for the user to manage in Postorius.
             self.mailing_list_subscriptions.all().delete()
             LastSeen.objects.filter(user=self).delete()
+            self.badges.clear()
+
             self.github_username = ""
             self.profile_links = {}
             self.indicate_last_login_method = False
             self.image_uploaded = False
-            self.badges.clear()
 
-        # Remove the avatar/HQ images and the cached thumbnail. File deletes are
-        # deferred to on_commit so a rolled-back transaction leaves them intact.
-        self.delete_cached_thumbnail()
-        if extended_scrub:
             self.delete_cached_hq_render()
-        image_fields = (
-            ("profile_image", "hq_image") if extended_scrub else ("profile_image",)
-        )
+            image_fields.append("hq_image")
+
+        # File deletes are deferred to on_commit so a rolled-back transaction
+        # leaves them intact.
         for field_name in image_fields:
             image = getattr(self, field_name)
             if image:

--- a/users/models.py
+++ b/users/models.py
@@ -304,6 +304,10 @@ class User(BaseUser):
     # If non-null, the user has requested deletion but the grace period has not
     # elapsed.
     delete_permanently_at = models.DateTimeField(null=True, editable=False)
+    # Remembers whether the pending deletion was requested through the V3 flow,
+    # so the grace-period task can apply the same extended PII scrub the V3
+    # immediate delete uses. Legacy requests leave this False.
+    deletion_extended_scrub = models.BooleanField(default=False, editable=False)
 
     def delete_cached_thumbnail(self):
         """Delete the cached ImageKit thumbnail so it regenerates on next access."""
@@ -480,6 +484,7 @@ class User(BaseUser):
             setattr(self, field_name, None)
 
         self.delete_permanently_at = None
+        self.deletion_extended_scrub = False
         self.save()
 
     def __str__(self):

--- a/users/models.py
+++ b/users/models.py
@@ -430,7 +430,7 @@ class User(BaseUser):
         return User.objects.filter(github_username=github_user).first()
 
     @transaction.atomic
-    def delete_account(self):
+    def delete_account(self, extended_scrub=False):
         from . import tasks
 
         email = self.email
@@ -457,16 +457,23 @@ class User(BaseUser):
         self.last_name = "Doe"
         self.display_name = "John Doe"
         self.email = "deleted-{}@example.com".format(uuid.uuid4())
-        self.github_username = ""
-        self.profile_links = {}
-        self.indicate_last_login_method = False
-        self.image_uploaded = False
-        self.badges.clear()
+
+        # These fields are only scrubbed for the V3 deletion flow - gating
+        # them keeps legacy (flag-off) deletion byte-identical to production.
+        if extended_scrub:
+            self.github_username = ""
+            self.profile_links = {}
+            self.indicate_last_login_method = False
+            self.image_uploaded = False
+            self.badges.clear()
 
         # Remove the avatar/HQ images and the cached thumbnail. File deletes are
         # deferred to on_commit so a rolled-back transaction leaves them intact.
         self.delete_cached_thumbnail()
-        for field_name in ("profile_image", "hq_image"):
+        image_fields = (
+            ("profile_image", "hq_image") if extended_scrub else ("profile_image",)
+        )
+        for field_name in image_fields:
             image = getattr(self, field_name)
             if image:
                 transaction.on_commit(lambda img=image: img.delete(save=False))

--- a/users/models.py
+++ b/users/models.py
@@ -309,19 +309,29 @@ class User(BaseUser):
     # immediate delete uses. Legacy requests leave this False.
     deletion_extended_scrub = models.BooleanField(default=False, editable=False)
 
-    def delete_cached_thumbnail(self):
-        """Delete the cached ImageKit thumbnail so it regenerates on next access."""
-        if not self.profile_image:
+    def _delete_cached_spec(self, source_field, spec_field):
+        """Delete a cached ImageKit spec file so it regenerates on next access."""
+        if not getattr(self, source_field):
             return
         try:
             from imagekit.cachefiles.backends import CacheFileState
 
-            thumb = self.image_thumbnail
-            if thumb.name:
-                thumb.storage.delete(thumb.name)
-            thumb.cachefile_backend.set_state(thumb, CacheFileState.DOES_NOT_EXIST)
+            cache_file = getattr(self, spec_field)
+            if cache_file.name:
+                cache_file.storage.delete(cache_file.name)
+            cache_file.cachefile_backend.set_state(
+                cache_file, CacheFileState.DOES_NOT_EXIST
+            )
         except (OSError, AttributeError):
-            logger.debug("Failed to invalidate thumbnail cache", exc_info=True)
+            logger.debug("Failed to invalidate %s cache", spec_field, exc_info=True)
+
+    def delete_cached_thumbnail(self):
+        """Delete the cached ImageKit thumbnail so it regenerates on next access."""
+        self._delete_cached_spec("profile_image", "image_thumbnail")
+
+    def delete_cached_hq_render(self):
+        """Delete the cached full-size render of the high-quality image."""
+        self._delete_cached_spec("hq_image", "hq_image_render")
 
     def save_image_from_provider(self, avatar_url):
         from django.core.files.base import ContentFile
@@ -474,6 +484,8 @@ class User(BaseUser):
         # Remove the avatar/HQ images and the cached thumbnail. File deletes are
         # deferred to on_commit so a rolled-back transaction leaves them intact.
         self.delete_cached_thumbnail()
+        if extended_scrub:
+            self.delete_cached_hq_render()
         image_fields = (
             ("profile_image", "hq_image") if extended_scrub else ("profile_image",)
         )

--- a/users/models.py
+++ b/users/models.py
@@ -497,7 +497,7 @@ class User(BaseUser):
             setattr(self, field_name, None)
 
         self.delete_permanently_at = None
-        self.deletion_extended_scrub = False
+        self.deletion_extended_scrub = extended_scrub
         self.save()
 
     def __str__(self):

--- a/users/models.py
+++ b/users/models.py
@@ -431,24 +431,71 @@ class User(BaseUser):
 
     @transaction.atomic
     def delete_account(self):
+        from mailing_list.client import MailmanAPIError, MailmanClient
+        from mailing_list.models import SubscriptionStatus
+
         from . import tasks
 
         email = self.email
         transaction.on_commit(lambda: tasks.send_account_deleted_email.delay(email))
+
+        # Unsubscribe from the external Boost (Mailman) lists, then drop the
+        # local subscription records. The external calls are deferred to
+        # on_commit so a Mailman outage can't roll back the deletion, and the
+        # whole thing only runs at actual-deletion time - a cancelled scheduled
+        # deletion never touches the user's subscriptions.
+        active_subscriptions = [
+            (sub.email, sub.list_id)
+            for sub in self.mailing_list_subscriptions.all()
+            if sub.status == SubscriptionStatus.ACTIVE
+        ]
+        self.mailing_list_subscriptions.all().delete()
+        if active_subscriptions:
+
+            def _unsubscribe_external():
+                client = MailmanClient()
+                for sub_email, list_id in active_subscriptions:
+                    try:
+                        client.unsubscribe(sub_email, list_id)
+                    except MailmanAPIError:
+                        logger.exception(
+                            "Mailman unsubscribe failed for list %s during "
+                            "account deletion",
+                            list_id,
+                        )
+
+            transaction.on_commit(_unsubscribe_external)
+
+        # Remove linked auth + preference records. Manager-level deletes are
+        # idempotent, so a second run (immediate delete racing the scheduled
+        # task) is a harmless no-op.
         self.socialaccount_set.all().delete()
-        self.preferences.delete()
         self.emailaddress_set.all().delete()
+        Preferences.objects.filter(user=self).delete()
+        LastSeen.objects.filter(user=self).delete()
+
+        # Scrub credentials, profile identity and public PII.
         self.is_active = False
         self.set_unusable_password()
-        self.display_name = "John Doe"
         self.first_name = "John"
         self.last_name = "Doe"
         self.display_name = "John Doe"
         self.email = "deleted-{}@example.com".format(uuid.uuid4())
+        self.github_username = ""
+        self.profile_links = {}
+        self.indicate_last_login_method = False
+        self.image_uploaded = False
+        self.badges.clear()
+
+        # Remove the avatar/HQ images and the cached thumbnail. File deletes are
+        # deferred to on_commit so a rolled-back transaction leaves them intact.
         self.delete_cached_thumbnail()
-        image = self.profile_image
-        transaction.on_commit(lambda: image.delete())
-        self.profile_image = None
+        for field_name in ("profile_image", "hq_image"):
+            image = getattr(self, field_name)
+            if image:
+                transaction.on_commit(lambda img=image: img.delete(save=False))
+            setattr(self, field_name, None)
+
         self.delete_permanently_at = None
         self.save()
 

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -96,11 +96,6 @@ def send_account_deleted_email(email):
     )
 
 
-# External Postorius (Mailman) instance where users manage their own mailing
-# list subscriptions - kept in sync with the delete modal / profile view copy.
-POSTORIUS_URL = "https://lists.boost.org/mailman3/lists/"
-
-
 @shared_task
 def send_account_deletion_scheduled_email(
     email, first_name, grace_days, login_url, scheme, host
@@ -114,7 +109,7 @@ def send_account_deletion_scheduled_email(
         "first_name": first_name,
         "grace_days": grace_days,
         "action_url": login_url,
-        "postorius_url": POSTORIUS_URL,
+        "postorius_url": settings.POSTORIUS_URL,
         "scheme": scheme,
         "host": host,
     }

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -81,6 +81,9 @@ def clear_tokens():
 
 @shared_task
 def do_scheduled_user_deletions():
+    # This task has no request/flag context and can't tell whether a given
+    # user scheduled through the legacy or V3 flow, so it deliberately
+    # defaults to the narrow (legacy) scrub rather than guessing.
     users = User.objects.filter(delete_permanently_at__lte=timezone.now())
     for user in users:
         user.delete_account()

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -4,8 +4,9 @@ from datetime import timedelta
 import structlog
 
 from django.contrib.auth import get_user_model
-from django.core.mail import send_mail
+from django.core.mail import EmailMultiAlternatives, send_mail
 from django.db.models import Q
+from django.template.loader import render_to_string
 from django.utils import timezone
 from django.conf import settings
 
@@ -93,6 +94,43 @@ def send_account_deleted_email(email):
         settings.DEFAULT_FROM_EMAIL,
         [email],
     )
+
+
+# External Postorius (Mailman) instance where users manage their own mailing
+# list subscriptions - kept in sync with the delete modal / profile view copy.
+POSTORIUS_URL = "https://lists.boost.org/mailman3/lists/"
+
+
+@shared_task
+def send_account_deletion_scheduled_email(
+    email, first_name, grace_days, login_url, scheme, host
+):
+    """Confirm a scheduled deletion and explain how to cancel it.
+
+    Absolute URLs (login CTA, logo link) are built in the view where the
+    request is available and passed in, since a Celery task has no request.
+    """
+    context = {
+        "first_name": first_name,
+        "grace_days": grace_days,
+        "action_url": login_url,
+        "postorius_url": POSTORIUS_URL,
+        "scheme": scheme,
+        "host": host,
+    }
+    subject = render_to_string(
+        "emails/account_deletion_scheduled_subject.txt", context
+    ).strip()
+    text_body = render_to_string("emails/account_deletion_scheduled.txt", context)
+    html_body = render_to_string("emails/account_deletion_scheduled.html", context)
+    msg = EmailMultiAlternatives(
+        subject=subject,
+        body=text_body,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        to=[email],
+    )
+    msg.attach_alternative(html_body, "text/html")
+    msg.send()
 
 
 @shared_task

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -81,12 +81,13 @@ def clear_tokens():
 
 @shared_task
 def do_scheduled_user_deletions():
-    # This task has no request/flag context and can't tell whether a given
-    # user scheduled through the legacy or V3 flow, so it deliberately
-    # defaults to the narrow (legacy) scrub rather than guessing.
+    # Reuse the scrub mode captured when the deletion was scheduled: V3
+    # requests set deletion_extended_scrub so the grace-period delete applies
+    # the same extended PII scrub as the V3 immediate delete; legacy requests
+    # leave it False and keep the narrow scrub.
     users = User.objects.filter(delete_permanently_at__lte=timezone.now())
     for user in users:
-        user.delete_account()
+        user.delete_account(extended_scrub=user.deletion_extended_scrub)
 
 
 @shared_task

--- a/users/tests/test_delete_account.py
+++ b/users/tests/test_delete_account.py
@@ -185,3 +185,30 @@ def test_v3_cancel_deletion_clears_schedule(user, tp):
     assert user.delete_permanently_at is None
     assert res.status_code == 302
     assert "edit=true" in res.url
+
+
+@pytest.mark.django_db
+@waffle.testutils.override_flag("v3", active=True)
+def test_v3_cancel_deletion_shows_no_success_banner(user, tp):
+    """V3 relies on the edit-page state, so no legacy success banner is added."""
+    user.delete_permanently_at = timezone.now() + datetime.timedelta(days=10)
+    user.save()
+
+    with tp.login(user):
+        res = tp.post("profile-cancel-delete", data={}, follow=True)
+
+    banners = [str(m) for m in res.context["messages"]]
+    assert "Your account is no longer scheduled for deletion." not in banners
+
+
+@pytest.mark.django_db
+def test_legacy_cancel_deletion_keeps_success_banner(user, tp):
+    """Legacy behaviour is unchanged: the success banner still fires."""
+    user.delete_permanently_at = timezone.now() + datetime.timedelta(days=10)
+    user.save()
+
+    with tp.login(user):
+        res = tp.post("profile-cancel-delete", data={}, follow=True)
+
+    banners = [str(m) for m in res.context["messages"]]
+    assert "Your account is no longer scheduled for deletion." in banners

--- a/users/tests/test_delete_account.py
+++ b/users/tests/test_delete_account.py
@@ -71,10 +71,13 @@ def test_delete_account_removes_linked_records(
 
 
 @pytest.mark.django_db
-def test_delete_account_unsubscribes_and_removes_mailing_lists(
+def test_delete_account_deletes_mailing_list_rows_without_api_call(
     user, django_capture_on_commit_callbacks
 ):
-    """Active external subscriptions are unsubscribed; all local rows dropped."""
+    """Local subscription rows are deleted (PII removed); Mailman is not called.
+
+    List membership is left to Postorius - we only drop our stored rows.
+    """
     baker.make(
         UserMailingListSubscription,
         user=user,
@@ -93,10 +96,7 @@ def test_delete_account_unsubscribes_and_removes_mailing_lists(
     with patch("mailing_list.client.MailmanClient") as MockClient:
         with django_capture_on_commit_callbacks(execute=True):
             user.delete_account()
-        # Only the ACTIVE subscription hits the external unsubscribe API.
-        MockClient.return_value.unsubscribe.assert_called_once_with(
-            "active@example.com", "dev.boost.org"
-        )
+        MockClient.assert_not_called()
 
     assert not UserMailingListSubscription.objects.filter(user=user).exists()
 
@@ -150,23 +150,3 @@ def test_v3_cancel_deletion_clears_schedule(user, tp):
     assert user.delete_permanently_at is None
     assert res.status_code == 302
     assert "edit=true" in res.url
-
-
-@pytest.mark.django_db
-@waffle.testutils.override_flag("v3", active=True)
-def test_v3_delete_immediately_anonymizes_and_logs_out(
-    user, tp, django_capture_on_commit_callbacks
-):
-    user.delete_permanently_at = timezone.now() + datetime.timedelta(days=10)
-    user.save()
-
-    with tp.login(user):
-        with django_capture_on_commit_callbacks(execute=True):
-            res = tp.post(
-                "profile-delete-immediately", data={"verify": "delete my account"}
-            )
-
-    user.refresh_from_db()
-    assert user.is_active is False
-    assert user.email.startswith("deleted-")
-    assert res.status_code == 302

--- a/users/tests/test_delete_account.py
+++ b/users/tests/test_delete_account.py
@@ -6,6 +6,7 @@ import waffle.testutils
 from model_bakery import baker
 
 from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
 from django.utils import timezone
 
 from mailing_list.models import SubscriptionStatus, UserMailingListSubscription
@@ -27,6 +28,7 @@ def test_delete_account_scrubs_pii_and_identity(
     user.indicate_last_login_method = True
     user.image_uploaded = True
     user.save()
+    user.hq_image.save("hq.png", ContentFile(b"hq-image-bytes"), save=True)
     user.badges.add(baker.make("users.Badge"))
 
     original_email = user.email
@@ -51,6 +53,7 @@ def test_delete_account_scrubs_pii_and_identity(
     assert user.indicate_last_login_method is False
     assert user.image_uploaded is False
     assert not user.profile_image
+    assert not user.hq_image
     assert user.badges.count() == 0
     assert user.delete_permanently_at is None
 

--- a/users/tests/test_delete_account.py
+++ b/users/tests/test_delete_account.py
@@ -130,12 +130,15 @@ def test_v3_delete_schedules_and_redirects_to_edit(user, tp):
 
 @pytest.mark.django_db
 @waffle.testutils.override_flag("v3", active=True)
-def test_v3_delete_sends_scheduled_email(user, tp, settings, mailoutbox):
+def test_v3_delete_sends_scheduled_email(
+    user, tp, settings, mailoutbox, django_capture_on_commit_callbacks
+):
     user.first_name = "Vinnie"
     user.save()
 
     with tp.login(user):
-        tp.post("profile-delete", data={"verify": "delete my account"})
+        with django_capture_on_commit_callbacks(execute=True):
+            tp.post("profile-delete", data={"verify": "delete my account"})
 
     assert len(mailoutbox) == 1
     email = mailoutbox[0]

--- a/users/tests/test_delete_account.py
+++ b/users/tests/test_delete_account.py
@@ -59,28 +59,39 @@ def test_delete_account_scrubs_pii_and_identity(
 
 
 @pytest.mark.django_db
-def test_delete_account_removes_linked_records(
-    user, django_capture_on_commit_callbacks
-):
-    """Preferences and LastSeen are removed on deletion."""
+def test_delete_account_removes_preferences(user, django_capture_on_commit_callbacks):
+    """Preferences are removed on deletion in both flows."""
     assert Preferences.objects.filter(user=user).exists()
-    assert LastSeen.objects.filter(user=user).exists()
 
     with django_capture_on_commit_callbacks(execute=True):
         user.delete_account()
 
     assert not Preferences.objects.filter(user=user).exists()
+
+
+@pytest.mark.django_db
+def test_v3_delete_account_removes_last_seen(user, django_capture_on_commit_callbacks):
+    """LastSeen is a V3-only addition to the scrub."""
+    assert LastSeen.objects.filter(user=user).exists()
+
+    with django_capture_on_commit_callbacks(execute=True):
+        user.delete_account(extended_scrub=True)
+
     assert not LastSeen.objects.filter(user=user).exists()
 
 
 @pytest.mark.django_db
-def test_delete_account_deletes_mailing_list_rows_without_api_call(
+def test_legacy_delete_account_keeps_last_seen(
     user, django_capture_on_commit_callbacks
 ):
-    """Local subscription rows are deleted (PII removed); Mailman is not called.
+    """Legacy behaviour is unchanged: LastSeen was never part of the scrub."""
+    with django_capture_on_commit_callbacks(execute=True):
+        user.delete_account()
 
-    List membership is left to Postorius - we only drop our stored rows.
-    """
+    assert LastSeen.objects.filter(user=user).exists()
+
+
+def _make_subscriptions(user):
     baker.make(
         UserMailingListSubscription,
         user=user,
@@ -96,12 +107,36 @@ def test_delete_account_deletes_mailing_list_rows_without_api_call(
         status=SubscriptionStatus.PENDING,
     )
 
+
+@pytest.mark.django_db
+def test_v3_delete_deletes_mailing_list_rows_without_api_call(
+    user, django_capture_on_commit_callbacks
+):
+    """Local subscription rows are deleted (PII removed); Mailman is not called.
+
+    List membership is left to Postorius - we only drop our stored rows.
+    """
+    _make_subscriptions(user)
+
     with patch("mailing_list.client.MailmanClient") as MockClient:
         with django_capture_on_commit_callbacks(execute=True):
-            user.delete_account()
+            user.delete_account(extended_scrub=True)
         MockClient.assert_not_called()
 
     assert not UserMailingListSubscription.objects.filter(user=user).exists()
+
+
+@pytest.mark.django_db
+def test_legacy_delete_keeps_mailing_list_rows(
+    user, django_capture_on_commit_callbacks
+):
+    """Legacy behaviour is unchanged: subscription rows were never dropped."""
+    _make_subscriptions(user)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        user.delete_account()
+
+    assert UserMailingListSubscription.objects.filter(user=user).count() == 2
 
 
 @pytest.mark.django_db

--- a/users/tests/test_delete_account.py
+++ b/users/tests/test_delete_account.py
@@ -105,6 +105,32 @@ def test_delete_account_deletes_mailing_list_rows_without_api_call(
 
 
 @pytest.mark.django_db
+def test_delete_account_invalidates_hq_render_cache(
+    user, django_capture_on_commit_callbacks
+):
+    """The cached full-size render goes with the source file, not after it."""
+    user.hq_image.save("hq.png", ContentFile(b"hq-image-bytes"), save=True)
+
+    with patch.object(User, "delete_cached_hq_render") as mock_invalidate:
+        with django_capture_on_commit_callbacks(execute=True):
+            user.delete_account(extended_scrub=True)
+
+    mock_invalidate.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_legacy_delete_leaves_hq_render_cache(user, django_capture_on_commit_callbacks):
+    """Legacy deletion never touched hq_image, so its render is left alone."""
+    user.hq_image.save("hq.png", ContentFile(b"hq-image-bytes"), save=True)
+
+    with patch.object(User, "delete_cached_hq_render") as mock_invalidate:
+        with django_capture_on_commit_callbacks(execute=True):
+            user.delete_account()
+
+    mock_invalidate.assert_not_called()
+
+
+@pytest.mark.django_db
 def test_delete_account_is_idempotent(user, django_capture_on_commit_callbacks):
     """A second run (e.g. immediate delete racing the scheduled task) is a no-op."""
     with django_capture_on_commit_callbacks(execute=True):

--- a/users/tests/test_delete_account.py
+++ b/users/tests/test_delete_account.py
@@ -1,0 +1,172 @@
+import datetime
+from unittest.mock import patch
+
+import pytest
+import waffle.testutils
+from model_bakery import baker
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from mailing_list.models import SubscriptionStatus, UserMailingListSubscription
+from ..models import LastSeen, Preferences
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_delete_account_scrubs_pii_and_identity(
+    user, django_capture_on_commit_callbacks
+):
+    """delete_account anonymizes the row in place and clears public PII."""
+    user.github_username = "octocat"
+    user.profile_links = {
+        "github": "https://github.com/octocat",
+        "email": "octo@example.com",
+    }
+    user.indicate_last_login_method = True
+    user.image_uploaded = True
+    user.save()
+    user.badges.add(baker.make("users.Badge"))
+
+    original_email = user.email
+    original_id = user.id
+
+    with django_capture_on_commit_callbacks(execute=True):
+        user.delete_account()
+
+    user.refresh_from_db()
+    # The row is preserved (authored content stays attributed to it).
+    assert user.id == original_id
+    assert user.is_active is False
+    assert user.has_usable_password() is False
+    assert user.display_name == "John Doe"
+    assert user.first_name == "John"
+    assert user.last_name == "Doe"
+    assert user.email != original_email
+    assert user.email.startswith("deleted-")
+    # Extra fields scrubbed.
+    assert user.github_username == ""
+    assert user.profile_links == {}
+    assert user.indicate_last_login_method is False
+    assert user.image_uploaded is False
+    assert not user.profile_image
+    assert user.badges.count() == 0
+    assert user.delete_permanently_at is None
+
+
+@pytest.mark.django_db
+def test_delete_account_removes_linked_records(
+    user, django_capture_on_commit_callbacks
+):
+    """Preferences and LastSeen are removed on deletion."""
+    assert Preferences.objects.filter(user=user).exists()
+    assert LastSeen.objects.filter(user=user).exists()
+
+    with django_capture_on_commit_callbacks(execute=True):
+        user.delete_account()
+
+    assert not Preferences.objects.filter(user=user).exists()
+    assert not LastSeen.objects.filter(user=user).exists()
+
+
+@pytest.mark.django_db
+def test_delete_account_unsubscribes_and_removes_mailing_lists(
+    user, django_capture_on_commit_callbacks
+):
+    """Active external subscriptions are unsubscribed; all local rows dropped."""
+    baker.make(
+        UserMailingListSubscription,
+        user=user,
+        list_id="dev.boost.org",
+        email="active@example.com",
+        status=SubscriptionStatus.ACTIVE,
+    )
+    baker.make(
+        UserMailingListSubscription,
+        user=user,
+        list_id="users.boost.org",
+        email="pending@example.com",
+        status=SubscriptionStatus.PENDING,
+    )
+
+    with patch("mailing_list.client.MailmanClient") as MockClient:
+        with django_capture_on_commit_callbacks(execute=True):
+            user.delete_account()
+        # Only the ACTIVE subscription hits the external unsubscribe API.
+        MockClient.return_value.unsubscribe.assert_called_once_with(
+            "active@example.com", "dev.boost.org"
+        )
+
+    assert not UserMailingListSubscription.objects.filter(user=user).exists()
+
+
+@pytest.mark.django_db
+def test_delete_account_is_idempotent(user, django_capture_on_commit_callbacks):
+    """A second run (e.g. immediate delete racing the scheduled task) is a no-op."""
+    with django_capture_on_commit_callbacks(execute=True):
+        user.delete_account()
+    with django_capture_on_commit_callbacks(execute=True):
+        user.delete_account()  # must not raise
+
+    user.refresh_from_db()
+    assert user.is_active is False
+
+
+@pytest.mark.django_db
+@waffle.testutils.override_flag("v3", active=True)
+def test_v3_delete_schedules_and_redirects_to_edit(user, tp):
+    with tp.login(user):
+        res = tp.post("profile-delete", data={"verify": "delete my account"})
+
+    user.refresh_from_db()
+    assert user.delete_permanently_at is not None
+    assert res.status_code == 302
+    assert "edit=true" in res.url
+
+
+@pytest.mark.django_db
+@waffle.testutils.override_flag("v3", active=True)
+def test_v3_delete_invalid_confirmation_reopens_modal(user, tp):
+    with tp.login(user):
+        res = tp.post("profile-delete", data={"verify": "wrong"})
+
+    user.refresh_from_db()
+    assert user.delete_permanently_at is None
+    assert res.status_code == 302
+    assert "#delete-account-dialog" in res.url
+
+
+@pytest.mark.django_db
+@waffle.testutils.override_flag("v3", active=True)
+def test_v3_cancel_deletion_clears_schedule(user, tp):
+    user.delete_permanently_at = timezone.now() + datetime.timedelta(days=10)
+    user.save()
+
+    with tp.login(user):
+        res = tp.post("profile-cancel-delete", data={})
+
+    user.refresh_from_db()
+    assert user.delete_permanently_at is None
+    assert res.status_code == 302
+    assert "edit=true" in res.url
+
+
+@pytest.mark.django_db
+@waffle.testutils.override_flag("v3", active=True)
+def test_v3_delete_immediately_anonymizes_and_logs_out(
+    user, tp, django_capture_on_commit_callbacks
+):
+    user.delete_permanently_at = timezone.now() + datetime.timedelta(days=10)
+    user.save()
+
+    with tp.login(user):
+        with django_capture_on_commit_callbacks(execute=True):
+            res = tp.post(
+                "profile-delete-immediately", data={"verify": "delete my account"}
+            )
+
+    user.refresh_from_db()
+    assert user.is_active is False
+    assert user.email.startswith("deleted-")
+    assert res.status_code == 302

--- a/users/tests/test_delete_account.py
+++ b/users/tests/test_delete_account.py
@@ -127,6 +127,41 @@ def test_v3_delete_schedules_and_redirects_to_edit(user, tp):
 
 @pytest.mark.django_db
 @waffle.testutils.override_flag("v3", active=True)
+def test_v3_delete_sends_scheduled_email(user, tp, settings, mailoutbox):
+    user.first_name = "Vinnie"
+    user.save()
+
+    with tp.login(user):
+        tp.post("profile-delete", data={"verify": "delete my account"})
+
+    assert len(mailoutbox) == 1
+    email = mailoutbox[0]
+    assert email.subject == "Your account is scheduled for deletion"
+    assert email.to == [user.email]
+    grace = settings.ACCOUNT_DELETION_GRACE_PERIOD_DAYS
+    assert f"deletion in {grace} day" in email.body
+    assert "Vinnie" in email.body
+    # HTML alternative is attached and links out to Postorius.
+    html_body, mimetype = email.alternatives[0]
+    assert mimetype == "text/html"
+    assert "Postorius" in html_body
+
+
+@pytest.mark.django_db
+def test_legacy_delete_does_not_send_scheduled_email(user, tp, mailoutbox):
+    """The scheduling email is a V3-only addition; legacy behaviour is unchanged."""
+    with tp.login(user):
+        tp.post("profile-delete", data={"verify": "delete my account"})
+
+    user.refresh_from_db()
+    assert user.delete_permanently_at is not None
+    assert not any(
+        m.subject == "Your account is scheduled for deletion" for m in mailoutbox
+    )
+
+
+@pytest.mark.django_db
+@waffle.testutils.override_flag("v3", active=True)
 def test_v3_delete_invalid_confirmation_reopens_modal(user, tp):
     with tp.login(user):
         res = tp.post("profile-delete", data={"verify": "wrong"})

--- a/users/tests/test_delete_account.py
+++ b/users/tests/test_delete_account.py
@@ -170,6 +170,24 @@ def test_v3_delete_invalid_confirmation_reopens_modal(user, tp):
     assert user.delete_permanently_at is None
     assert res.status_code == 302
     assert "#delete-account-dialog" in res.url
+    assert "delete_error=1" in res.url
+
+
+@pytest.mark.django_db
+@waffle.testutils.override_flag("v3", active=True)
+def test_v3_delete_invalid_confirmation_renders_inline_error(user, tp):
+    """The error is shown inline in the modal, not as a global message banner."""
+    with tp.login(user):
+        tp.post("profile-delete", data={"verify": "wrong"})
+        res = tp.get("profile-account", data={"edit": "true", "delete_error": "1"})
+
+    html = res.content.decode()
+    # Inline field error rendered inside the modal (quotes are HTML-escaped).
+    assert "Please enter" in html
+    assert "field--error" in html
+    assert 'class="field__error"' in html
+    # No message was queued for the global (legacy) banner.
+    assert list(res.context["messages"]) == []
 
 
 @pytest.mark.django_db

--- a/users/tests/test_delete_account.py
+++ b/users/tests/test_delete_account.py
@@ -33,7 +33,7 @@ def test_delete_account_scrubs_pii_and_identity(
     original_id = user.id
 
     with django_capture_on_commit_callbacks(execute=True):
-        user.delete_account()
+        user.delete_account(extended_scrub=True)
 
     user.refresh_from_db()
     # The row is preserved (authored content stays attributed to it).

--- a/users/views.py
+++ b/users/views.py
@@ -984,11 +984,6 @@ class DeleteUserView(LoginRequiredMixin, FormView):
         )
         user.save()
         if flag_is_active(self.request, "v3"):
-            messages.success(
-                self.request,
-                "Your account is scheduled for deletion. You can cancel any "
-                "time before then.",
-            )
             return HttpResponseRedirect(_v3_profile_edit_url())
         return super().form_valid(form)
 

--- a/users/views.py
+++ b/users/views.py
@@ -208,7 +208,6 @@ class CurrentUserProfileView(
         )
         ctx["profile_delete_url"] = reverse("profile-delete")
         ctx["profile_cancel_delete_url"] = reverse("profile-cancel-delete")
-        ctx["profile_delete_immediately_url"] = reverse("profile-delete-immediately")
         return ctx
 
     def get_v3_context_data(self, **kwargs):
@@ -1039,12 +1038,6 @@ class DeleteImmediatelyView(LoginRequiredMixin, SuccessMessageMixin, FormView):
         user.delete_account()
         auth.logout(self.request)
         return super().form_valid(form)
-
-    def form_invalid(self, form):
-        if flag_is_active(self.request, "v3"):
-            messages.error(self.request, _verify_error(form))
-            return HttpResponseRedirect(_v3_profile_edit_url("#delete-now-dialog"))
-        return super().form_invalid(form)
 
 
 def _verify_error(form):

--- a/users/views.py
+++ b/users/views.py
@@ -208,6 +208,9 @@ class CurrentUserProfileView(
         )
         ctx["profile_delete_url"] = reverse("profile-delete")
         ctx["profile_cancel_delete_url"] = reverse("profile-cancel-delete")
+        # External Boost Postorius (Mailman) instance - users manage their
+        # own mailing list subscriptions there after deletion.
+        ctx["postorius_url"] = "https://lists.boost.org/mailman3/lists/"
         return ctx
 
     def get_v3_context_data(self, **kwargs):

--- a/users/views.py
+++ b/users/views.py
@@ -964,9 +964,8 @@ class UserAvatar(TemplateView):
         return response
 
 
-# Confirmation-phrase error shown inline in the delete modal; mirrors the
-# DeleteAccountForm.clean_verify message so JS and no-JS paths read the same.
-DELETE_CONFIRM_ERROR = 'Please enter "delete my account"'
+# Confirmation-phrase error shown inline in the delete modal.
+DELETE_CONFIRM_ERROR = DeleteAccountForm.CONFIRM_ERROR
 
 
 def _v3_profile_edit_url(fragment="", error=False):

--- a/users/views.py
+++ b/users/views.py
@@ -198,6 +198,10 @@ class CurrentUserProfileView(
         # Delete-account card: the modal schedules deletion, and once
         # scheduled the card swaps to cancel / delete-now controls.
         ctx["delete_account_form"] = DeleteAccountForm()
+        # A failed confirmation redirects back here with ?delete_error=1 and
+        # reopens the modal, which renders this inline on the verify field.
+        if self.request.GET.get("delete_error"):
+            ctx["delete_account_error"] = DELETE_CONFIRM_ERROR
         ctx["delete_permanently_at"] = user.delete_permanently_at
         grace_days = settings.ACCOUNT_DELETION_GRACE_PERIOD_DAYS
         ctx["ACCOUNT_DELETION_GRACE_PERIOD_DAYS"] = grace_days
@@ -960,13 +964,21 @@ class UserAvatar(TemplateView):
         return response
 
 
-def _v3_profile_edit_url(fragment=""):
+# Confirmation-phrase error shown inline in the delete modal; mirrors the
+# DeleteAccountForm.clean_verify message so JS and no-JS paths read the same.
+DELETE_CONFIRM_ERROR = 'Please enter "delete my account"'
+
+
+def _v3_profile_edit_url(fragment="", error=False):
     """Edit-profile URL used as the V3 return target for the delete flow.
 
     The optional fragment reopens the relevant :target modal after a redirect
     (e.g. when confirmation fails), so the flow works without JavaScript.
+    ``error=True`` flags a failed confirmation so the reopened modal can render
+    the error inline instead of relying on a global message banner.
     """
-    return f"{reverse('profile-account')}?edit=true{fragment}"
+    query = "?edit=true&delete_error=1" if error else "?edit=true"
+    return f"{reverse('profile-account')}{query}{fragment}"
 
 
 class DeleteUserView(LoginRequiredMixin, FormView):
@@ -997,8 +1009,9 @@ class DeleteUserView(LoginRequiredMixin, FormView):
 
     def form_invalid(self, form):
         if flag_is_active(self.request, "v3"):
-            messages.error(self.request, _verify_error(form))
-            return HttpResponseRedirect(_v3_profile_edit_url("#delete-account-dialog"))
+            return HttpResponseRedirect(
+                _v3_profile_edit_url("#delete-account-dialog", error=True)
+            )
         return super().form_invalid(form)
 
     def get_context_data(self, **kwargs):
@@ -1051,11 +1064,3 @@ class DeleteImmediatelyView(LoginRequiredMixin, SuccessMessageMixin, FormView):
         user.delete_account()
         auth.logout(self.request)
         return super().form_valid(form)
-
-
-def _verify_error(form):
-    """Human-readable confirmation error for the delete forms."""
-    errors = form.errors.get("verify")
-    if errors:
-        return errors[0]
-    return "Please confirm to delete your account."

--- a/users/views.py
+++ b/users/views.py
@@ -211,7 +211,6 @@ class CurrentUserProfileView(
             "deletion before then."
         )
         ctx["profile_delete_url"] = reverse("profile-delete")
-        ctx["profile_cancel_delete_url"] = reverse("profile-cancel-delete")
         ctx["postorius_url"] = settings.POSTORIUS_URL
         return ctx
 

--- a/users/views.py
+++ b/users/views.py
@@ -197,7 +197,6 @@ class CurrentUserProfileView(
         }
         # Delete-account card: the modal schedules deletion, and once
         # scheduled the card swaps to a single "Cancel deletion" control.
-        ctx["delete_account_form"] = DeleteAccountForm()
         # A failed confirmation redirects back here with ?delete_error=1 and
         # reopens the modal, which renders this inline on the verify field.
         if self.request.GET.get("delete_error"):

--- a/users/views.py
+++ b/users/views.py
@@ -196,7 +196,7 @@ class CurrentUserProfileView(
             ],
         }
         # Delete-account card: the modal schedules deletion, and once
-        # scheduled the card swaps to cancel / delete-now controls.
+        # scheduled the card swaps to a single "Cancel deletion" control.
         ctx["delete_account_form"] = DeleteAccountForm()
         # A failed confirmation redirects back here with ?delete_error=1 and
         # reopens the modal, which renders this inline on the verify field.

--- a/users/views.py
+++ b/users/views.py
@@ -212,9 +212,7 @@ class CurrentUserProfileView(
         )
         ctx["profile_delete_url"] = reverse("profile-delete")
         ctx["profile_cancel_delete_url"] = reverse("profile-cancel-delete")
-        # External Boost Postorius (Mailman) instance - users manage their
-        # own mailing list subscriptions there after deletion.
-        ctx["postorius_url"] = "https://lists.boost.org/mailman3/lists/"
+        ctx["postorius_url"] = settings.POSTORIUS_URL
         return ctx
 
     def get_v3_context_data(self, **kwargs):

--- a/users/views.py
+++ b/users/views.py
@@ -12,6 +12,7 @@ from django.views.generic import DetailView, FormView
 from django.views.generic.base import TemplateView
 from django.utils import timezone
 from django.conf import settings
+from django.db import transaction
 from django import forms
 
 from allauth.account.forms import ChangePasswordForm, ResetPasswordForm
@@ -990,17 +991,27 @@ class DeleteUserView(LoginRequiredMixin, FormView):
         user.delete_permanently_at = timezone.now() + datetime.timedelta(
             days=settings.ACCOUNT_DELETION_GRACE_PERIOD_DAYS
         )
-        user.save()
         if flag_is_active(self.request, "v3"):
-            tasks.send_account_deletion_scheduled_email.delay(
-                email=user.email,
-                first_name=user.first_name,
-                grace_days=settings.ACCOUNT_DELETION_GRACE_PERIOD_DAYS,
-                login_url=self.request.build_absolute_uri(reverse("account_login")),
-                scheme=self.request.scheme,
-                host=self.request.get_host(),
-            )
+            login_url = self.request.build_absolute_uri(reverse("account_login"))
+            scheme = self.request.scheme
+            host = self.request.get_host()
+            # Persist the schedule and enqueue the confirmation email atomically:
+            # the task is published only after the row commits (mirroring
+            # delete_account), so a rolled-back save never enqueues an email.
+            with transaction.atomic():
+                user.save()
+                transaction.on_commit(
+                    lambda: tasks.send_account_deletion_scheduled_email.delay(
+                        email=user.email,
+                        first_name=user.first_name,
+                        grace_days=settings.ACCOUNT_DELETION_GRACE_PERIOD_DAYS,
+                        login_url=login_url,
+                        scheme=scheme,
+                        host=host,
+                    )
+                )
             return HttpResponseRedirect(_v3_profile_edit_url())
+        user.save()
         return super().form_valid(form)
 
     def form_invalid(self, form):

--- a/users/views.py
+++ b/users/views.py
@@ -1023,6 +1023,13 @@ class CancelDeletionView(LoginRequiredMixin, SuccessMessageMixin, FormView):
             return _v3_profile_edit_url()
         return super().get_success_url()
 
+    def get_success_message(self, cleaned_data):
+        # V3 relies on the edit-page state (the scheduled banner disappears) for
+        # feedback, so suppress the legacy success banner. Legacy is unchanged.
+        if flag_is_active(self.request, "v3"):
+            return ""
+        return super().get_success_message(cleaned_data)
+
     def form_valid(self, form):
         user = self.get_object()
         user.delete_permanently_at = None

--- a/users/views.py
+++ b/users/views.py
@@ -159,7 +159,8 @@ class CurrentUserProfileView(
                 initial=self.get_v3_edit_initial(),
             )
         saved_section = self.request.GET.get("saved")
-        return {
+        user = self.request.user
+        ctx = {
             "user_profile_form": form,
             "SLACK_PROFILE_URL_PREFIX": SLACK_PROFILE_URL_PREFIX,
             "biography_max_length": User.BIOGRAPHY_MAX_LENGTH,
@@ -194,6 +195,21 @@ class CurrentUserProfileView(
                 },
             ],
         }
+        # Delete-account card: the modal schedules deletion, and once
+        # scheduled the card swaps to cancel / delete-now controls.
+        ctx["delete_account_form"] = DeleteAccountForm()
+        ctx["delete_permanently_at"] = user.delete_permanently_at
+        grace_days = settings.ACCOUNT_DELETION_GRACE_PERIOD_DAYS
+        ctx["ACCOUNT_DELETION_GRACE_PERIOD_DAYS"] = grace_days
+        ctx["delete_schedule_warning"] = (
+            f"Your account will be scheduled for deletion in {grace_days} "
+            f"{'day' if grace_days == 1 else 'days'}. You can cancel the "
+            "deletion before then."
+        )
+        ctx["profile_delete_url"] = reverse("profile-delete")
+        ctx["profile_cancel_delete_url"] = reverse("profile-cancel-delete")
+        ctx["profile_delete_immediately_url"] = reverse("profile-delete-immediately")
+        return ctx
 
     def get_v3_context_data(self, **kwargs):
         user = self.request.user
@@ -942,6 +958,15 @@ class UserAvatar(TemplateView):
         return response
 
 
+def _v3_profile_edit_url(fragment=""):
+    """Edit-profile URL used as the V3 return target for the delete flow.
+
+    The optional fragment reopens the relevant :target modal after a redirect
+    (e.g. when confirmation fails), so the flow works without JavaScript.
+    """
+    return f"{reverse('profile-account')}?edit=true{fragment}"
+
+
 class DeleteUserView(LoginRequiredMixin, FormView):
     template_name = "users/delete.html"
     success_url = reverse_lazy("profile-account")
@@ -956,7 +981,20 @@ class DeleteUserView(LoginRequiredMixin, FormView):
             days=settings.ACCOUNT_DELETION_GRACE_PERIOD_DAYS
         )
         user.save()
+        if flag_is_active(self.request, "v3"):
+            messages.success(
+                self.request,
+                "Your account is scheduled for deletion. You can cancel any "
+                "time before then.",
+            )
+            return HttpResponseRedirect(_v3_profile_edit_url())
         return super().form_valid(form)
+
+    def form_invalid(self, form):
+        if flag_is_active(self.request, "v3"):
+            messages.error(self.request, _verify_error(form))
+            return HttpResponseRedirect(_v3_profile_edit_url("#delete-account-dialog"))
+        return super().form_invalid(form)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -974,6 +1012,11 @@ class CancelDeletionView(LoginRequiredMixin, SuccessMessageMixin, FormView):
 
     def get_object(self):
         return self.request.user
+
+    def get_success_url(self):
+        if flag_is_active(self.request, "v3"):
+            return _v3_profile_edit_url()
+        return super().get_success_url()
 
     def form_valid(self, form):
         user = self.get_object()
@@ -996,3 +1039,17 @@ class DeleteImmediatelyView(LoginRequiredMixin, SuccessMessageMixin, FormView):
         user.delete_account()
         auth.logout(self.request)
         return super().form_valid(form)
+
+    def form_invalid(self, form):
+        if flag_is_active(self.request, "v3"):
+            messages.error(self.request, _verify_error(form))
+            return HttpResponseRedirect(_v3_profile_edit_url("#delete-now-dialog"))
+        return super().form_invalid(form)
+
+
+def _verify_error(form):
+    """Human-readable confirmation error for the delete forms."""
+    errors = form.errors.get("verify")
+    if errors:
+        return errors[0]
+    return "Please confirm to delete your account."

--- a/users/views.py
+++ b/users/views.py
@@ -984,6 +984,14 @@ class DeleteUserView(LoginRequiredMixin, FormView):
         )
         user.save()
         if flag_is_active(self.request, "v3"):
+            tasks.send_account_deletion_scheduled_email.delay(
+                email=user.email,
+                first_name=user.first_name,
+                grace_days=settings.ACCOUNT_DELETION_GRACE_PERIOD_DAYS,
+                login_url=self.request.build_absolute_uri(reverse("account_login")),
+                scheme=self.request.scheme,
+                host=self.request.get_host(),
+            )
             return HttpResponseRedirect(_v3_profile_edit_url())
         return super().form_valid(form)
 

--- a/users/views.py
+++ b/users/views.py
@@ -992,6 +992,7 @@ class DeleteUserView(LoginRequiredMixin, FormView):
             days=settings.ACCOUNT_DELETION_GRACE_PERIOD_DAYS
         )
         if flag_is_active(self.request, "v3"):
+            user.deletion_extended_scrub = True
             login_url = self.request.build_absolute_uri(reverse("account_login"))
             scheme = self.request.scheme
             host = self.request.get_host()
@@ -1053,6 +1054,7 @@ class CancelDeletionView(LoginRequiredMixin, SuccessMessageMixin, FormView):
     def form_valid(self, form):
         user = self.get_object()
         user.delete_permanently_at = None
+        user.deletion_extended_scrub = False
         user.save()
         return super().form_valid(form)
 

--- a/users/views.py
+++ b/users/views.py
@@ -1058,6 +1058,6 @@ class DeleteImmediatelyView(LoginRequiredMixin, SuccessMessageMixin, FormView):
 
     def form_valid(self, form):
         user = self.get_object()
-        user.delete_account()
+        user.delete_account(extended_scrub=flag_is_active(self.request, "v3"))
         auth.logout(self.request)
         return super().form_valid(form)


### PR DESCRIPTION
# Issue: #2438

## Summary & Context
Reworks the account-deletion flow for the V3 design system. Deletion is now driven by a confirmation modal (matching Figma) that schedules the account for anonymization after a grace period, with a site-wide banner, an in-modal confirmation error, and a confirmation email. Legacy (non-V3) behaviour is left byte-identical - every change is gated behind the `v3` Waffle flag.

- **Figma link**: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=6635-25490
- **Link to components/page:** [http://localhost:8000/users/me/?edit=True](http://localhost:8000/users/me/?edit=True)

## Changes

- Added a V3 delete-account **modal** (`_delete_account_modal.html` + `delete-account-modal.css`) built to the Figma spec: white rounded inner card on a light-red canvas, full-bleed section dividers, fixed section spacing, and a destructive submit button that stays disabled (via Alpine) until the exact phrase `delete my account` is typed. No-JS fallback: the button stays enabled and the server validates.
- Scheduling deletion now **anonymizes in place** (`User.delete_account()` preserves the row so authored content stays attributed to an anonymized user); extended the scrub to cover profile links, GitHub username, avatar images, badges, and login-method flags.
- **Mailing lists**: local `UserMailingListSubscription` rows are deleted to remove stored-email PII, but the Mailman/Postorius API is deliberately **not** called - list membership is left for the user to manage in Postorius (linked from the modal).
- Added a **site-wide "scheduled for deletion" banner** (`_account_deletion_banner.html` + `account-deletion-banner.css`) that pins to the top above the navbar and pushes content down, with a "Cancel deletion" action (no "Delete now").
- Removed the **"Delete now"** control from V3 entirely (kept only in legacy).
- Scheduling a deletion now sends a branded **confirmation email** (`emails/account_deletion_scheduled.*`) via a Celery task, explaining what happens, how to cancel, and linking to Postorius; registered in `send_test_emails` for previews.
- Replaced the deletion-flow **message banners** with in-context feedback: removed the "scheduled"/"no longer scheduled" success banners, and moved the wrong-phrase confirmation error **inline into the modal** (carried through the PRG redirect via `?delete_error=1`).
- Added `test_delete_account.py` covering PII scrub, linked-record removal, no-Mailman-API deletion, idempotency, V3 schedule/cancel redirects, the scheduling email, inline error rendering, and that legacy behaviour is unchanged.

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*

- `User.delete_account()` anonymizes rather than deletes the row - confirm authored content (news, library authorship) stays attributed to the anonymized user and no PII leaks when the Wagtail integration is in place.
- Mailing-list rows are deleted with **no** external Mailman call by design; this creates intentional drift with Postorius' own DB (users manage membership there).
- All new behaviour is gated behind the `v3` flag; with the flag off, the flow must match current production (legacy banner, legacy delete pages, success/error message banners) exactly.
- The scheduling email is dispatched from the view via Celery (`.delay()`).

## Screenshots

<img width="905" height="634" alt="image" src="https://github.com/user-attachments/assets/c2ff0a1a-326c-4405-ac55-5fca49c3a72a" />

<img width="1719" height="812" alt="image" src="https://github.com/user-attachments/assets/42c5c984-280f-4974-82b0-96f59b01a549" />

<img width="924" height="712" alt="image" src="https://github.com/user-attachments/assets/f236f4e5-f9ce-4119-bb7b-e43c7a6db025" />

<img width="690" height="739" alt="image" src="https://github.com/user-attachments/assets/67f57416-27ad-439e-92fa-646e023f8b05" />


## Peer-review testing steps
1. Enable the `v3` Waffle flag.
2. Go to `/users/me/?edit=true` and open the "Delete account" modal. Confirm the layout matches Figma (white card on light-red, full-bleed dividers, small bullets) in light and dark mode.
3. With JS on, confirm the "Delete my account" button is disabled until you type `delete my account` exactly (wrong case / trailing space keep it disabled).
4. With JS off (or by submitting a wrong phrase), confirm the error renders **inline** under the field and no global banner appears.
5. Submit the correct phrase: confirm you land back on the edit page, the site-wide red banner appears at the top (pushing content down, above the navbar) with "Cancel deletion" only, and no success banner shows.
6. Check the inbox (maildev) for the "Your account is scheduled for deletion" email; verify copy, the "Log in to cancel" CTA, and the Postorius link.
7. Click "Cancel deletion": confirm the banner disappears and no success banner shows.
8. Turn the `v3` flag off and confirm the legacy flow (legacy red banner with "Delete Now", legacy delete pages, and the success/error message banners) is unchanged.

## Self-review Checklist
- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. - No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a V3 sticky “account scheduled for deletion” banner with dismiss and “Cancel deletion”.
  * Added a V3 delete-account confirmation modal that requires an exact phrase, with improved destructive presentation and inline error handling.
  * Added V3 scheduled-deletion email notifications with countdown plus cancellation and mailing-list links.

* **Bug Fixes**
  * Improved account deletion privacy cleanup (including linked records, badges, and media) and ensured the workflow is safe to run multiple times.
  * Updated V3 vs legacy UI messaging so success/error states match the selected flow.

* **Tests**
  * Expanded automated coverage for V3/legacy delete and cancel flows, email sending, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->