### PR TITLE
Story #2439: Manage Mailing Lists in the Profile Edit UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,11 @@ services:
   #   volumes:
   #     - ./mailman/core:/opt/mailman/
   #   networks:
-  #     - backend
+  #     backend:
+  #       # Dotted alias so MAILMAN_REST_API_URL can use it as both the reachable
+  #       # host and the list mail domain - see docs/mailman/README.md.
+  #       aliases:
+  #         - lists.local.test
   #   env_file:
   #     - .env
   #   depends_on:

--- a/docs/mailman/README.md
+++ b/docs/mailman/README.md
@@ -2,3 +2,5 @@
 ## Mailman
 
 Information about mailman3 server instances is covered in https://github.com/cppalliance/website-v2-operations
+
+For local development and testing instructions, see [local-testing.md](local-testing.md).

--- a/docs/mailman/local-testing.md
+++ b/docs/mailman/local-testing.md
@@ -1,0 +1,110 @@
+# Mailman - local development & testing
+
+This walks through everything needed to stand up Mailman locally and manually test the
+subscribe/confirm flow end to end.
+
+## Part 1 - One-time infrastructure setup
+
+1. **Uncomment `mailman-core` and `mailman-web`** in `docker-compose.yml` (commented out by
+   default - they add weight to `docker compose up` that most devs don't need day to day).
+2. **Confirm `MAILMAN_REST_API_URL`** in `.env` is set to:
+   ```
+   MAILMAN_REST_API_URL=http://lists.local.test:8001
+   ```
+   This is the default in `env.template`. `lists.local.test` is a network alias defined on the
+   `mailman-core` service in `docker-compose.yml`, resolvable by `web`/`celery-worker`/
+   `celery-beat` over Docker's internal network - no other setup is needed for it to work.
+3. **Bring the stack up / restart it** so `web`, `celery-worker`, and `celery-beat` pick up the new
+   env value - `.env` changes are not hot-reloaded:
+   ```bash
+   docker compose up -d
+   ```
+4. **Create the mailing lists** on your local Mailman instance:
+   ```bash
+   ./scripts/dev-mailman-helpers
+   ```
+   Pick `list lists` first - it should print nothing yet. Then run it again and pick
+   `create lists`. Run `list lists` once more to confirm the three lists now exist
+   (`boost.lists.local.test`, `boost-announce.lists.local.test`, `boost-users.lists.local.test`).
+
+At this point your local Mailman is ready to accept subscriptions - infrastructure setup is done.
+
+## Part 2 - Testing the subscribe → confirm flow
+
+1. **Turn on the `v3` feature flag** so the V3 mailing-list card renders;
+2. **Open a page with the mailing-list card** - either:
+   - `http://localhost:8000/community/`, or
+   - `http://localhost:8000/users/me/?edit=True` (logged in).
+3. **Enter an email address in the card's subscribe field and submit it.** You should land back
+   on the same page with a "pending confirmation" state shown on the card.
+4. **Open Maildev** at `http://localhost:1080` - this is where local outgoing email lands instead
+   of a real inbox. You should see a new "Confirm your Boost mailing list subscription"-style email
+   addressed to the email you entered.
+5. **Open the email and click the confirmation link** (or copy the `/mailing-list/confirm/<token>/`
+   URL into your browser). You should land on a page reading **"Subscription confirmed"** listing
+   the list(s) you subscribed to. If instead you see **"Could not subscribe - please try again
+   later"**, see [Troubleshooting](#troubleshooting) below.
+6. **Verify the subscription actually landed in Mailman**, independent of what the confirm page
+   claims:
+   ```bash
+   ./scripts/dev-mailman-helpers   # pick "list members", then the list you subscribed to
+   ```
+   Your email address should appear in the roster.
+7. **If you tested while logged in**, also check the same page again
+   (`/users/me/?edit=True`) - the mailing-list card should now show the "already subscribed" /
+   manage state instead of the subscribe form, confirming `UserMailingListSubscription` was
+   updated to `ACTIVE`.
+
+## Troubleshooting
+
+- **Confirm page shows "Could not subscribe - please try again later" for every list** - almost
+  always means `MailmanClient.subscribe()` couldn't reach Mailman. Check, in order:
+  - Does `docker compose exec web python3 -c "import socket;
+    print(socket.gethostbyname('lists.local.test'))"` resolve to an IP? If it errors, `web` isn't
+    on the same network as `mailman-core`, or `mailman-core` wasn't recreated after you uncommented
+    it - run `docker compose up -d mailman-core` again.
+  - Did you restart `web`/`celery-worker`/`celery-beat` after changing `MAILMAN_REST_API_URL`?
+  - Did you actually run `create lists` (Part 1, step 4)? If the lists don't exist yet on Mailman,
+    every subscribe attempt fails the same way.
+- **No email shows up in Maildev** - check `docker compose logs celery-worker` for a failed task;
+  the confirmation email is sent via Celery, so the worker needs to be running.
+
+## How list IDs are derived
+
+- The app does **not** read list IDs from an env var. `mailing_list/constants.py` derives a
+  `MAILMAN_DOMAIN` from the host of `MAILMAN_REST_API_URL`, then builds three list IDs from it:
+  `boost.<domain>`, `boost-announce.<domain>`, `boost-users.<domain>`.
+- Every consumer in the app (`mailing_list/mixins.py`, `mailing_list/views.py` - subscribe,
+  confirm, manage, `managed_lists` filtering, etc.) uses this computed list.
+- **Bottom line:** whatever host is in `MAILMAN_REST_API_URL` is the domain your local lists must
+  actually exist under in Mailman.
+- `scripts/dev-mailman-helpers`'s `create lists` action mirrors this same derivation in bash
+  (`_mailman_domain()`), so there's nothing to keep in sync by hand - no `MAILMAN_LISTS` env var
+  exists. The three prefixes live in a `LIST_PREFIXES` array at the top of the script; add more
+  there if you need extra lists locally.
+
+## Why `MAILMAN_REST_API_URL` needs a dotted domain, not `localhost`
+
+- The host in `MAILMAN_REST_API_URL` doubles as the mail domain for every list (see above). A
+  bare, single-label host like `localhost` or the Docker service name `mailman-core` gets past
+  Mailman's *domain* creation, but list creation under it then fails with `"Invalid list posting
+  address"` - Mailman requires the address to have at least two labels (a dot) to look like a
+  real domain.
+- It does **not** need to actually resolve over the public internet or be a real, owned domain -
+  only the local network needs to resolve it, which is exactly what the `lists.local.test` network
+  alias on `mailman-core` provides.
+- If you need a different alias name (e.g. it collides with something on your machine), change it
+  in both `docker-compose.yml`'s `mailman-core.networks.backend.aliases` and
+  `MAILMAN_REST_API_URL` in `.env` - they must match.
+
+## Why the email confirmation doesn't need Mailman's mail transport
+
+- Mailman's own double opt-in is bypassed - `MailmanClient.subscribe()` sends
+  `pre_verified`/`pre_confirmed`/`pre_approved: True`, so membership is created directly via the
+  REST call.
+- The confirmation email you see in Part 2 is this app's own signed token, sent through `maildev` -
+  not through Mailman. Mailman's mail transport (LMTP/SMTP) doesn't need to work locally, only its
+  REST API.
+- `scripts/dev-mailman-helpers` also has `confirm pending` (accept pending Mailman-side
+  subscription requests) - not normally needed given `pre_confirmed` above, but useful if a list
+  isn't using it.

--- a/docs/mailman/local-testing.md
+++ b/docs/mailman/local-testing.md
@@ -8,7 +8,7 @@ subscribe/confirm flow end to end.
 1. **Uncomment `mailman-core` and `mailman-web`** in `docker-compose.yml` (commented out by
    default - they add weight to `docker compose up` that most devs don't need day to day).
 2. **Confirm `MAILMAN_REST_API_URL`** in `.env` is set to:
-   ```
+   ```dotenv
    MAILMAN_REST_API_URL=http://lists.local.test:8001
    ```
    This is the default in `env.template`. `lists.local.test` is a network alias defined on the
@@ -23,7 +23,8 @@ subscribe/confirm flow end to end.
    ```bash
    ./scripts/dev-mailman-helpers
    ```
-   Pick `list lists` first - it should print nothing yet. Then run it again and pick
+   Pick `list lists` first - on an empty instance it should print `No lists found at $URL`
+   to stderr and exit non-zero. Then run it again and pick
    `create lists`. Run `list lists` once more to confirm the three lists now exist
    (`boost.lists.local.test`, `boost-announce.lists.local.test`, `boost-users.lists.local.test`).
 
@@ -57,8 +58,8 @@ At this point your local Mailman is ready to accept subscriptions - infrastructu
 
 ## Troubleshooting
 
-- **Confirm page shows "Could not subscribe - please try again later" for every list** - almost
-  always means `MailmanClient.subscribe()` couldn't reach Mailman. Check, in order:
+- **Confirm page shows "Could not subscribe - please try again later" for every list** - means
+  `MailmanClient.subscribe()` failed against Mailman's REST API. Check, in order:
   - Does `docker compose exec web python3 -c "import socket;
     print(socket.gethostbyname('lists.local.test'))"` resolve to an IP? If it errors, `web` isn't
     on the same network as `mailman-core`, or `mailman-core` wasn't recreated after you uncommented
@@ -66,6 +67,10 @@ At this point your local Mailman is ready to accept subscriptions - infrastructu
   - Did you restart `web`/`celery-worker`/`celery-beat` after changing `MAILMAN_REST_API_URL`?
   - Did you actually run `create lists` (Part 1, step 4)? If the lists don't exist yet on Mailman,
     every subscribe attempt fails the same way.
+  - Does the domain in `MAILMAN_REST_API_URL` match the domain the lists were actually created
+    under in Mailman? If you changed `MAILMAN_REST_API_URL` after running `create lists`, the app
+    will request a list under the new domain while Mailman only has one under the old domain -
+    run `list lists` (Part 1, step 4) to check which domain your lists currently exist under.
 - **No email shows up in Maildev** - check `docker compose logs celery-worker` for a failed task;
   the confirmation email is sent via Celery, so the worker needs to be running.
 

--- a/env.template
+++ b/env.template
@@ -87,11 +87,13 @@ ALGOLIA_ANALYTICS_API_KEY=
 
 OPENROUTER_API_KEY=
 
-# Used by Django inside Docker — hostname resolves within the container network
-MAILMAN_REST_API_URL=http://mailman-core:8001
+# Used by Django inside Docker — this host's domain also becomes the mail domain
+# for every locally-created list, so it must be dotted (see docs/mailman/README.md).
+# The "lists.local.test" alias is defined on the mailman-core service in
+# docker-compose.yml once you uncomment it.
+MAILMAN_REST_API_URL=http://lists.local.test:8001
 # Used by scripts/dev-mailman-helpers on the host — maps to the published port
 MAILMAN_DEV_API_URL=http://localhost:8001
-MAILMAN_LISTS=boost-users.lists.boost.org,boost-announce.lists.boost.org,boost.lists.boost.org
 
 POPULAR_SEARCH_TERMS_MIN_SEARCH_COUNT=
 

--- a/mailing_list/mixins.py
+++ b/mailing_list/mixins.py
@@ -60,16 +60,29 @@ class MailingListCardMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        request = self.request
+        context.update(self.get_mailing_list_card_context())
+        return context
 
-        context["mailing_list_card_subscribe_url"] = reverse(
-            "mailing-list-quick-subscribe"
-        )
-        context["mailing_list_card_modal_subscribe_url"] = reverse(
-            "mailing-list-modal-subscribe"
-        )
-        context["mailing_list_card_list_id"] = _DEFAULT_LIST_ID
-        context["mailing_list_card_lists"] = constants.MAILING_LIST_LABELS.values()
+    def get_mailing_list_card_context(self) -> dict:
+        """Build the card context once per request.
+
+        V3Mixin.get_context_data() re-enters self.get_context_data(), so any view
+        combining both mixins would otherwise run these queries twice per request.
+        """
+        if not hasattr(self, "_mailing_list_card_context"):
+            self._mailing_list_card_context = self._build_mailing_list_card_context()
+        return self._mailing_list_card_context
+
+    def _build_mailing_list_card_context(self) -> dict:
+        request = self.request
+        context = {
+            "mailing_list_card_subscribe_url": reverse("mailing-list-quick-subscribe"),
+            "mailing_list_card_modal_subscribe_url": reverse(
+                "mailing-list-modal-subscribe"
+            ),
+            "mailing_list_card_list_id": _DEFAULT_LIST_ID,
+            "mailing_list_card_lists": constants.MAILING_LIST_LABELS.values(),
+        }
 
         if request.user.is_authenticated:
             managed_lists = set(constants.MAILMAN_LISTS)

--- a/mailing_list/mixins.py
+++ b/mailing_list/mixins.py
@@ -51,7 +51,9 @@ class MailingListCardMixin:
       mailing_list_card_list_id
       mailing_list_card_state              ("pending", "active", "error", or None)
       mailing_list_card_error_message      (set on error state, used by no-JS PRG flow)
-      mailing_list_card_user_email         (authenticated users only, or from PRG params)
+      mailing_list_card_user_email         (the subscription email if one exists, else the
+                                            account email; authenticated users only, or
+                                            from PRG params)
       mailing_list_card_manage_url         (authenticated users only)
       mailing_list_card_subscription_count (authenticated users only — ACTIVE count only)
     """
@@ -75,7 +77,7 @@ class MailingListCardMixin:
 
             context["mailing_list_card_state"] = state.state
             context["mailing_list_card_subscription_count"] = state.count
-            context["mailing_list_card_user_email"] = state.email
+            context["mailing_list_card_user_email"] = state.email or request.user.email
             context["mailing_list_card_manage_url"] = reverse("profile-account")
             context["mailing_list_card_subscribed_ids"] = set(
                 UserMailingListSubscription.objects.filter(

--- a/mailing_list/tests/test_mixins.py
+++ b/mailing_list/tests/test_mixins.py
@@ -1,0 +1,65 @@
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.views.generic import TemplateView
+from model_bakery import baker
+
+from mailing_list.constants import MAILMAN_LISTS
+from mailing_list.mixins import MailingListCardMixin
+from mailing_list.models import SubscriptionStatus, UserMailingListSubscription
+
+LIST_ID = MAILMAN_LISTS[0]
+
+
+class _CardView(MailingListCardMixin, TemplateView):
+    template_name = "v3/includes/_mailing_list_card.html"
+
+
+def _context(rf, user, path="/"):
+    request = rf.get(path)
+    request.user = user
+    view = _CardView()
+    view.setup(request)
+    return view.get_context_data()
+
+
+@pytest.fixture
+def user(db):
+    return baker.make("users.User", email="user@example.com")
+
+
+@pytest.mark.django_db
+def test_card_email_falls_back_to_account_email(rf, user):
+    """No subscription: the card pre-fills with the user's registered account email."""
+    context = _context(rf, user)
+    assert context["mailing_list_card_user_email"] == "user@example.com"
+
+
+@pytest.mark.django_db
+def test_card_email_prefers_subscription_email(rf, user):
+    """An existing subscription's email wins over the account email."""
+    baker.make(
+        UserMailingListSubscription,
+        user=user,
+        list_id=LIST_ID,
+        email="subscriber@example.com",
+        status=SubscriptionStatus.ACTIVE,
+    )
+    context = _context(rf, user)
+    assert context["mailing_list_card_user_email"] == "subscriber@example.com"
+
+
+@pytest.mark.django_db
+def test_card_email_empty_for_anonymous(rf):
+    """Anonymous users get no pre-filled email."""
+    context = _context(rf, AnonymousUser())
+    assert context.get("mailing_list_card_user_email") is None
+
+
+@pytest.mark.django_db
+def test_prg_error_param_overrides_account_email(rf, user):
+    """The no-JS error PRG echoes back the submitted address, not the account email."""
+    context = _context(
+        rf, user, "/?ml_state=error&ml_error=Nope&ml_email=typed@example.com"
+    )
+    assert context["mailing_list_card_state"] == "error"
+    assert context["mailing_list_card_user_email"] == "typed@example.com"

--- a/mailing_list/tests/test_mixins.py
+++ b/mailing_list/tests/test_mixins.py
@@ -56,6 +56,31 @@ def test_card_email_empty_for_anonymous(rf):
 
 
 @pytest.mark.django_db
+def test_card_context_built_once_per_request(rf, user, django_assert_num_queries):
+    """Repeated get_context_data() calls reuse the first result.
+
+    V3Mixin.get_context_data() re-enters self.get_context_data(), so without the
+    memo every v3 page paying for this mixin runs its queries twice.
+    """
+    request = rf.get("/")
+    request.user = user
+    view = _CardView()
+    view.setup(request)
+
+    first = view.get_context_data()
+    with django_assert_num_queries(0):
+        second = view.get_context_data()
+
+    assert (
+        first["mailing_list_card_user_email"] == second["mailing_list_card_user_email"]
+    )
+    assert (
+        first["mailing_list_card_subscribed_ids"]
+        == second["mailing_list_card_subscribed_ids"]
+    )
+
+
+@pytest.mark.django_db
 def test_prg_error_param_overrides_account_email(rf, user):
     """The no-JS error PRG echoes back the submitted address, not the account email."""
     context = _context(

--- a/mailing_list/tests/test_views.py
+++ b/mailing_list/tests/test_views.py
@@ -293,3 +293,60 @@ def test_confirm_anonymous_token_subscribes_without_db_record(client):
         response = client.get(url)
     assert response.status_code == 200
     MockClient.return_value.subscribe.assert_called_once_with(EMAIL, LIST_ID)
+
+
+# ---------------------------------------------------------------------------
+# _prg_redirect — no-JS fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_no_js_quick_subscribe_keeps_referer_query_string(client, user):
+    """POST /mailing-list/quick-subscribe/ — no-JS: the referer's query string survives the PRG.
+
+    The edit profile page carries its state in ?edit=true, so dropping the query
+    would bounce the user back to the read-only profile.
+    """
+    client.force_login(user)
+    url = reverse("mailing-list-quick-subscribe")
+    with patch("mailing_list.views._send_confirmation_email"):
+        response = client.post(
+            url,
+            {"email": EMAIL, "list_id": LIST_ID},
+            HTTP_REFERER="http://testserver/users/me/?edit=true",
+        )
+    assert response.status_code == 302
+    assert response["Location"] == "/users/me/?edit=true"
+
+
+@pytest.mark.django_db
+def test_no_js_quick_subscribe_drops_stale_ml_params(client, user):
+    """POST /mailing-list/quick-subscribe/ — no-JS: ml_* params on the referer are replaced, not appended."""
+    client.force_login(user)
+    url = reverse("mailing-list-quick-subscribe")
+    response = client.post(
+        url,
+        {"email": "", "list_id": LIST_ID},
+        HTTP_REFERER="http://testserver/users/me/?edit=true&ml_state=pending&ml_email=old@example.com",
+    )
+    assert response.status_code == 302
+    location = response["Location"]
+    assert location.startswith("/users/me/?edit=true&")
+    assert "ml_state=error" in location
+    assert "ml_state=pending" not in location
+    assert "old%40example.com" not in location
+
+
+@pytest.mark.django_db
+def test_no_js_quick_subscribe_strips_referer_host(client, user):
+    """POST /mailing-list/quick-subscribe/ — no-JS: an off-site referer can't drive the redirect."""
+    client.force_login(user)
+    url = reverse("mailing-list-quick-subscribe")
+    with patch("mailing_list.views._send_confirmation_email"):
+        response = client.post(
+            url,
+            {"email": EMAIL, "list_id": LIST_ID},
+            HTTP_REFERER="https://evil.example.com/community/?edit=true",
+        )
+    assert response.status_code == 302
+    assert response["Location"] == "/community/?edit=true"

--- a/mailing_list/views.py
+++ b/mailing_list/views.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from urllib.parse import urlencode, urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -41,11 +41,21 @@ def _is_htmx(request) -> bool:
 def _prg_redirect(request, **params) -> HttpResponseRedirect:
     """Redirect back to the referring page, with optional query params for card state.
 
-    Strips the referer to path-only to prevent open-redirect issues.
+    Drops the scheme and host from the referer to prevent open-redirect issues, but
+    keeps its query string: on pages where a param carries page state (e.g. the edit
+    profile page's ?edit=true) dropping it would bounce the user out of that state.
+    Any ml_* params already on the referer are discarded so repeated no-JS submits
+    don't accumulate stale card state.
     """
-    referer = request.headers.get("referer", "/")
-    path = urlparse(referer).path or "/"
-    qs = urlencode({k: v for k, v in params.items() if v})
+    referer = urlparse(request.headers.get("referer", "/"))
+    path = referer.path or "/"
+    query = [
+        (k, v)
+        for k, v in parse_qsl(referer.query, keep_blank_values=True)
+        if not k.startswith("ml_")
+    ]
+    query += [(k, v) for k, v in params.items() if v]
+    qs = urlencode(query)
     return HttpResponseRedirect(f"{path}?{qs}" if qs else path)
 
 

--- a/scripts/dev-mailman-helpers
+++ b/scripts/dev-mailman-helpers
@@ -5,16 +5,23 @@
 #
 #   list lists    — print all mailing lists on the server
 #   list members  — pick a mailing list and print its member roster (JSON)
-#   create lists  — create the lists defined in MAILMAN_LISTS (from .env)
+#   create lists  — create the default lists (see LIST_PREFIXES below), under
+#                   the domain derived from MAILMAN_REST_API_URL (from .env)
 #   delete lists  — pick one or more lists to delete (fzf multi-select)
 #
 # Environment variables (loaded from ../.env if present):
 #   MAILMAN_DEV_API_URL    Host-side URL of the Mailman Core REST API
 #                          (default: http://localhost:8001 — the mapped container port)
+#   MAILMAN_REST_API_URL   Used by Django inside Docker to reach Mailman Core; its
+#                          host is also the mail domain every list is created under
+#                          here, mirroring mailing_list/constants.py's derivation.
 #   MAILMAN_REST_API_USER  REST API username  (default: restadmin)
 #   MAILMAN_REST_API_PASS  REST API password  (default: restpass)
-#   MAILMAN_LISTS          Comma-separated list IDs to create
-#                          e.g. boost-users.lists.boost.org,boost.lists.boost.org
+#
+# LIST_PREFIXES below are the three lists the app manages (see
+# mailing_list/constants.py::MailingLists). To create extra lists locally, add
+# more prefixes to that array — there is no env var for this.
+LIST_PREFIXES=(boost boost-announce boost-users)
 
 set -euo pipefail
 
@@ -51,6 +58,19 @@ _list_id_to_fqdn() {
   echo "$1" | sed 's/\./@/'
 }
 
+# Mirrors mailing_list/constants.py::get_domain_with_subdomains — strip scheme,
+# path, and port from MAILMAN_REST_API_URL, leaving just the host.
+_mailman_domain() {
+  if [[ -z "${MAILMAN_REST_API_URL:-}" ]]; then
+    echo "MAILMAN_REST_API_URL is not set in .env — cannot derive the list domain." >&2
+    return 1
+  fi
+  local host="${MAILMAN_REST_API_URL#*://}"
+  host="${host%%/*}"
+  host="${host%%:*}"
+  echo "$host"
+}
+
 # ---------------------------------------------------------------------------
 # Actions
 # ---------------------------------------------------------------------------
@@ -79,15 +99,11 @@ action_list_members() {
 }
 
 action_create_lists() {
-  if [[ -z "${MAILMAN_LISTS:-}" ]]; then
-    echo "MAILMAN_LISTS is not set in .env — nothing to create." >&2
-    exit 1
-  fi
+  domain=$(_mailman_domain) || exit 1
 
-  IFS=',' read -ra list_ids <<< "$MAILMAN_LISTS"
-  for list_id in "${list_ids[@]}"; do
+  for prefix in "${LIST_PREFIXES[@]}"; do
+    list_id="${prefix}.${domain}"
     fqdn=$(_list_id_to_fqdn "$list_id")
-    domain="${list_id#*.}" # Extracts the domain (everything after the first dot)
 
     echo "Ensuring domain $domain exists..."
     domain_http_code=$(curl -s -o /dev/null -w "%{http_code}" \

--- a/static/css/v3/user-profile-page.css
+++ b/static/css/v3/user-profile-page.css
@@ -390,8 +390,12 @@
         order: 5;
     }
 
-    .user-profile__delete-account {
+    .user-profile-edit__mailing-list-card {
         order: 6;
+    }
+
+    .user-profile__delete-account {
+        order: 7;
     }
 }
 

--- a/templates/v3/includes/_mailing_list_card.html
+++ b/templates/v3/includes/_mailing_list_card.html
@@ -96,20 +96,20 @@ and HTMX swaps [data-ml-block] in place; x-init then clears the URL hash so the 
   {% if modal_subscribe_url and mailing_lists %}
     <div class="dialog-modal" id="mailing-list-modal"
          x-data="{
-                 totalLists: {{ mailing_lists|length }},
-                 checkedCount: 0,
-                 updateCount() {
-                 this.checkedCount = this.$refs.checkboxContainer.querySelectorAll('[name=list_id]:checked').length;
-                 },
-                 unselectAll() {
-                 this.$refs.checkboxContainer.querySelectorAll('[name=list_id]').forEach(cb => { cb.checked = false; });
-                 this.checkedCount = 0;
-                 },
-                 selectAll() {
-                 this.$refs.checkboxContainer.querySelectorAll('[name=list_id]').forEach(cb => { cb.checked = true; });
-                 this.checkedCount = this.totalLists;
-                 }
-                 }"
+           totalLists: {{ mailing_lists|length }},
+           checkedCount: 0,
+           updateCount() {
+             this.checkedCount = this.$refs.checkboxContainer.querySelectorAll('[name=list_id]:checked').length;
+           },
+           unselectAll() {
+             this.$refs.checkboxContainer.querySelectorAll('[name=list_id]').forEach(cb => { cb.checked = false; });
+             this.checkedCount = 0;
+           },
+           selectAll() {
+             this.$refs.checkboxContainer.querySelectorAll('[name=list_id]').forEach(cb => { cb.checked = true; });
+             this.checkedCount = this.totalLists;
+           }
+         }"
          x-init="updateCount()">
       <a class="dialog-modal__backdrop" href="#_" tabindex="-1"></a>
       <div class="dialog-modal__container"

--- a/templates/v3/includes/_mailing_list_card.html
+++ b/templates/v3/includes/_mailing_list_card.html
@@ -94,7 +94,23 @@ and HTMX swaps [data-ml-block] in place; x-init then clears the URL hash so the 
   {% endif %}
 
   {% if modal_subscribe_url and mailing_lists %}
-    <div class="dialog-modal" id="mailing-list-modal">
+    <div class="dialog-modal" id="mailing-list-modal"
+         x-data="{
+                 totalLists: {{ mailing_lists|length }},
+                 checkedCount: 0,
+                 updateCount() {
+                 this.checkedCount = this.$refs.checkboxContainer.querySelectorAll('[name=list_id]:checked').length;
+                 },
+                 unselectAll() {
+                 this.$refs.checkboxContainer.querySelectorAll('[name=list_id]').forEach(cb => { cb.checked = false; });
+                 this.checkedCount = 0;
+                 },
+                 selectAll() {
+                 this.$refs.checkboxContainer.querySelectorAll('[name=list_id]').forEach(cb => { cb.checked = true; });
+                 this.checkedCount = this.totalLists;
+                 }
+                 }"
+         x-init="updateCount()">
       <a class="dialog-modal__backdrop" href="#_" tabindex="-1"></a>
       <div class="dialog-modal__container"
            role="dialog"
@@ -114,7 +130,8 @@ and HTMX swaps [data-ml-block] in place; x-init then clears the URL hash so the 
           <p>Pick the lists you want to subscribe to. You can change these any time.</p>
           <button type="button"
                   class="mailing-list-modal__select-all"
-                  @click="$el.closest('.dialog-modal__container').querySelector('form').querySelectorAll('[name=list_id]').forEach(cb => cb.checked = true)">Select All</button>
+                  @click="checkedCount === totalLists ? unselectAll() : selectAll()"
+                  x-text="checkedCount === totalLists ? 'Unselect All' : 'Select All'"></button>
         </div>
         <form method="post"
               action="{{ modal_subscribe_url }}"
@@ -124,26 +141,27 @@ and HTMX swaps [data-ml-block] in place; x-init then clears the URL hash so the 
           {% csrf_token %}
           <input type="hidden" name="email" value="{{ user_email|default:'' }}" :value="mlEmail">
           <div class="mailing-list-modal__list-card">
-          <ul class="mailing-list-modal__list" role="list">
-            {% for ml in mailing_lists %}
-              <li class="mailing-list-modal__item">
-                <label class="mailing-list-modal__label">
-                  <input class="mailing-list-modal__checkbox"
-                         type="checkbox"
-                         name="list_id"
-                         value="{{ ml.id }}"
-                         {% if subscribed_ids %}{% if ml.id in subscribed_ids %}checked{% endif %}{% else %}checked{% endif %}>
-                  <span class="mailing-list-modal__checkbox-box" aria-hidden="true">
-                    {% include "includes/icon.html" with icon_name="check" icon_class="mailing-list-modal__checkbox-check" icon_size=16 %}
-                  </span>
-                  <div class="mailing-list-modal__item-content">
-                    <span class="mailing-list-modal__item-name">{{ ml.name }}</span>
-                    <span class="mailing-list-modal__item-description">{{ ml.description }}</span>
-                  </div>
-                </label>
-              </li>
-            {% endfor %}
-          </ul>
+            <ul class="mailing-list-modal__list" role="list" x-ref="checkboxContainer">
+              {% for ml in mailing_lists %}
+                <li class="mailing-list-modal__item">
+                  <label class="mailing-list-modal__label">
+                    <input class="mailing-list-modal__checkbox"
+                           type="checkbox"
+                           name="list_id"
+                           value="{{ ml.id }}"
+                           {% if subscribed_ids %}{% if ml.id in subscribed_ids %}checked{% endif %}{% else %}checked{% endif %}
+                           @change="updateCount()">
+                    <span class="mailing-list-modal__checkbox-box" aria-hidden="true">
+                      {% include "includes/icon.html" with icon_name="check" icon_class="mailing-list-modal__checkbox-check" icon_size=16 %}
+                    </span>
+                    <div class="mailing-list-modal__item-content">
+                      <span class="mailing-list-modal__item-name">{{ ml.name }}</span>
+                      <span class="mailing-list-modal__item-description">{{ ml.description }}</span>
+                    </div>
+                  </label>
+                </li>
+              {% endfor %}
+            </ul>
           </div>
           <div class="dialog-modal__buttons">
             <a href="#_" class="btn btn-secondary btn-flex">Cancel</a>

--- a/templates/v3/user_profile_edit.html
+++ b/templates/v3/user_profile_edit.html
@@ -182,6 +182,7 @@ flushed rather than leaking onto the next page. {% endcomment %}
           </div>
           </form>
         </div>
+        {% include "v3/includes/_mailing_list_card.html" with subscribe_url=mailing_list_card_subscribe_url modal_subscribe_url=mailing_list_card_modal_subscribe_url list_id=mailing_list_card_list_id state=mailing_list_card_state user_email=mailing_list_card_user_email manage_url=mailing_list_card_manage_url subscription_count=mailing_list_card_subscription_count error_message=mailing_list_card_error_message mailing_lists=mailing_list_card_lists subscribed_ids=mailing_list_card_subscribed_ids %}
         <div class="basic-card card user-profile__delete-account">
           <div class="card__header">
             <span class="card__title">Delete account</span>
@@ -271,6 +272,22 @@ flushed rather than leaking onto the next page. {% endcomment %}
         </div>
         <div class="user-profile-edit__connections-card">
           {% include 'v3/includes/_account_connections_card.html' with connections=account_connections_mixed %}
+        </div>
+        <div class="basic-card card user-profile__delete-account">
+          <div class="card__header">
+            <span class="card__title">Delete account</span>
+          </div>
+          <hr class="card__hr" aria-hidden="true" />
+          <div class="card__column px-large">
+            <div>
+              <div class="user-profile__small-section-heading">Remove your account from our system</div>
+              <div class="user-profile__small-section-subheading">This will remove your information and account from Boost completely and is not reversible.</div>
+            </div>
+          </div>
+          <hr class="card__hr" aria-hidden="true" />
+          <div class="card__cta_section">
+            {% include 'v3/includes/_button.html' with style='error' type='submit' label='Delete Account' only %}
+          </div>
         </div>
       </div>
     </div>

--- a/templates/v3/user_profile_edit.html
+++ b/templates/v3/user_profile_edit.html
@@ -182,40 +182,9 @@ flushed rather than leaking onto the next page. {% endcomment %}
           </div>
           </form>
         </div>
-        {% include "v3/includes/_mailing_list_card.html" with subscribe_url=mailing_list_card_subscribe_url modal_subscribe_url=mailing_list_card_modal_subscribe_url list_id=mailing_list_card_list_id state=mailing_list_card_state user_email=mailing_list_card_user_email manage_url=mailing_list_card_manage_url subscription_count=mailing_list_card_subscription_count error_message=mailing_list_card_error_message mailing_lists=mailing_list_card_lists subscribed_ids=mailing_list_card_subscribed_ids %}
-        <div class="basic-card card user-profile__delete-account">
-          <div class="card__header">
-            <span class="card__title">Delete account</span>
-          </div>
-          <hr class="card__hr" aria-hidden="true" />
-          <div class="card__column px-large">
-            {% if delete_permanently_at %}
-              <div>
-                <div class="user-profile__small-section-heading">Account scheduled for deletion</div>
-                <div class="user-profile__small-section-subheading">Your account is scheduled for deletion on {{ delete_permanently_at|date:'N j, Y, P e' }}. You can cancel the deletion before then.</div>
-              </div>
-            {% else %}
-              <div>
-                <div class="user-profile__small-section-heading">Remove your account from our system</div>
-                <div class="user-profile__small-section-subheading">This action will permanently erase all your information and account from Boost, and it cannot be undone.</div>
-              </div>
-            {% endif %}
-          </div>
-          <hr class="card__hr" aria-hidden="true" />
-          <div class="card__cta_section user-profile__delete-account-actions">
-            {% if delete_permanently_at %}
-              <form method="post" action="{{ profile_cancel_delete_url }}" class="user-profile__delete-inline-form">
-                {% csrf_token %}
-                <button type="submit" class="btn btn-secondary btn-flex">Cancel deletion</button>
-              </form>
-            {% else %}
-              <a href="#delete-account-dialog" class="btn btn-error btn-flex" role="button">Delete Account</a>
-            {% endif %}
-          </div>
+        <div class="user-profile-edit__mailing-list-card">
+          {% include "v3/includes/_mailing_list_card.html" with subscribe_url=mailing_list_card_subscribe_url modal_subscribe_url=mailing_list_card_modal_subscribe_url list_id=mailing_list_card_list_id state=mailing_list_card_state user_email=mailing_list_card_user_email manage_url=mailing_list_card_manage_url subscription_count=mailing_list_card_subscription_count error_message=mailing_list_card_error_message mailing_lists=mailing_list_card_lists subscribed_ids=mailing_list_card_subscribed_ids %}
         </div>
-        {% if not delete_permanently_at %}
-          {% include "v3/users/_delete_account_modal.html" with dialog_id="delete-account-dialog" title="Delete your account" warning=delete_schedule_warning action_url=profile_delete_url submit_label="Delete my account" postorius_url=postorius_url error=delete_account_error %}
-        {% endif %}
       </div>
       <div class="user-profile__col">
         <div class="basic-card card user-profile__update-details">
@@ -279,16 +248,33 @@ flushed rather than leaking onto the next page. {% endcomment %}
           </div>
           <hr class="card__hr" aria-hidden="true" />
           <div class="card__column px-large">
-            <div>
-              <div class="user-profile__small-section-heading">Remove your account from our system</div>
-              <div class="user-profile__small-section-subheading">This will remove your information and account from Boost completely and is not reversible.</div>
-            </div>
+            {% if delete_permanently_at %}
+              <div>
+                <div class="user-profile__small-section-heading">Account scheduled for deletion</div>
+                <div class="user-profile__small-section-subheading">Your account is scheduled for deletion on {{ delete_permanently_at|date:'N j, Y, P e' }}. You can cancel the deletion before then.</div>
+              </div>
+            {% else %}
+              <div>
+                <div class="user-profile__small-section-heading">Remove your account from our system</div>
+                <div class="user-profile__small-section-subheading">This action will permanently erase all your information and account from Boost, and it cannot be undone.</div>
+              </div>
+            {% endif %}
           </div>
           <hr class="card__hr" aria-hidden="true" />
-          <div class="card__cta_section">
-            {% include 'v3/includes/_button.html' with style='error' type='submit' label='Delete Account' only %}
+          <div class="card__cta_section user-profile__delete-account-actions">
+            {% if delete_permanently_at %}
+              <form method="post" action="{{ profile_cancel_delete_url }}" class="user-profile__delete-inline-form">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-secondary btn-flex">Cancel deletion</button>
+              </form>
+            {% else %}
+              <a href="#delete-account-dialog" class="btn btn-error btn-flex" role="button">Delete Account</a>
+            {% endif %}
           </div>
         </div>
+        {% if not delete_permanently_at %}
+          {% include "v3/users/_delete_account_modal.html" with dialog_id="delete-account-dialog" title="Delete your account" warning=delete_schedule_warning action_url=profile_delete_url submit_label="Delete my account" postorius_url=postorius_url error=delete_account_error %}
+        {% endif %}
       </div>
     </div>
   </div>

--- a/users/views.py
+++ b/users/views.py
@@ -39,6 +39,7 @@ from libraries.constants import (
 )
 from libraries.forms import V3CommitAuthorEmailForm
 from libraries.models import CommitAuthorEmail
+from mailing_list.mixins import MailingListCardMixin
 from .forms import (
     PreferencesForm,
     UserProfileForm,
@@ -121,6 +122,7 @@ class PublicUserProfileView(V3UserProfileContextMixin, V3Mixin, DetailView):
 
 class CurrentUserProfileView(
     V3UserProfileContextMixin,
+    MailingListCardMixin,
     V3Mixin,
     LoginRequiredMixin,
     SuccessMessageMixin,


### PR DESCRIPTION
# Issue: #2439

## Summary & Context
Adds mailing list management to the edit profile page. The existing subscribe/manage card (already used on the community, learn, library, and release pages) is reused as-is at the bottom of the left column, and the "Delete account" card moves to the bottom of the right column to make room for it. 
⚠️ This implementation drifts from the Figma specification, but this is intentional and confirmed/accepted by Rob in [this thread](https://github.com/boostorg/website-v2/issues/2439#issuecomment-4617057657).

- **Figma link**: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=6735-9993&m=dev → but you should actually look at [this](https://github.com/boostorg/website-v2/issues/2439#issuecomment-4617057657) thread first.
- **Link to components/page:** [http://localhost:8000/users/me/?edit=true](http://localhost:8000/users/me/?edit=true)

## Changes

- `CurrentUserProfileView` now includes `MailingListCardMixin` (`users/views.py`), so the edit page gets the same `mailing_list_card_*` context (subscribe/modal URLs, subscription state, list options) as every other page that embeds the card.
- `templates/v3/user_profile_edit.html`: the mailing-list card (`_mailing_list_card.html`) is now rendered at the bottom of the left column, right after the Profile card. No new markup, CSS, or JS - it's the exact same include and behavior (quick-subscribe form, "Manage your lists" modal, HTMX swap, no-JS PRG fallback) used elsewhere.
- The "Delete account" card moved to the bottom of the right column, after the account-connections card.
- No new CSS was needed - `mailing-list-card.css` is already loaded globally via `css/v3/components.css` in `base.html`.

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*

- Purely a placement/wiring change - no changes to the mailing list card's markup, styles, or view logic, so its existing behavior (states, HTMX, no-JS fallback) carries over unchanged.
- `manage_url` for this card resolves to `profile-account` (this same edit page), so "Manage your lists" from other pages and the card's own state on this page both point back here - confirmed this doesn't create a redirect loop.
- Noticed a pre-existing, unrelated console error (`autoInit is not defined`) coming from the Biography WYSIWYG editor init script on this page - present before this change and not touched by it.

## Screenshots
<img width="1718" height="944" alt="image" src="https://github.com/user-attachments/assets/e1457861-d231-47b8-aecc-dd428fdbb006" />

<img width="1675" height="952" alt="image" src="https://github.com/user-attachments/assets/aafbe3e2-1a88-46fc-af8e-e3b42c91a60f" />

<img width="1717" height="943" alt="image" src="https://github.com/user-attachments/assets/96a112a1-decb-4b53-a75f-8c9022affc21" />

## Peer-review testing steps

First of all, checkout the new doc file in `docs/mailman/local-testing.md`. After reading through that and settings things up, come back to the steps below (skipping what you've already done).


1. Enable the `v3` Waffle flag and log in.
2. Go to `/users/me/?edit=true`. Confirm the "Join the Boost Developers Mailing List" card renders at the bottom of the **left** column, right after the Profile card.
3. Confirm "Delete account" now renders at the bottom of the **right** column, after Account connections.
4. Enter an email and submit the quick-subscribe form - confirm the "Join the Boost Developer Mailing List" modal opens with the list checkboxes, same as on `/community/`.
5. Confirm/select lists and hit Confirm - verify the card swaps in place (HTMX) to reflect the new subscription state.
6. If your test user already has an active/pending subscription, confirm the card shows the "Subscribed"/"Pending" state with a "Manage your lists" button that reopens the modal.
7. Toggle dark mode and confirm both the mailing-list card and the relocated Delete account card render correctly.
8. With JS disabled, confirm the quick-subscribe form still submits (PRG) and the page reloads with the correct card state.

## Self-review Checklist
- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. - No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a mailing list preferences card to the user profile page.

* **UI Changes**
  * Improved mailing list selection with checkbox counting and Select All controls.
  * Reordered profile sections and updated the Delete Account area with a static warning and shared error styling.

* **Documentation**
  * Expanded Mailman local end-to-end testing instructions and updated references.

* **Chores**
  * Updated local Mailman configuration and helper scripts to derive list domains automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->