### PR TITLE
Fix 2546: display two lines instead of three in header wraps

### DIFF
--- a/static/css/v3/learn-page.css
+++ b/static/css/v3/learn-page.css
@@ -1,128 +1,126 @@
 .learn-page-container .card {
-    max-width: 100%;
+  max-width: 100%;
 }
 
 .learn-page-header {
-    width: 100%;
-    max-width: calc(50% - .5 * var(--space-card));
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-xl);
-    align-items: flex-start;
-    color: var(--text-primary);
+  width: 100%;
+  max-width: calc(50% - 0.5 * var(--space-card));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+  align-items: flex-start;
+  color: var(--text-primary);
 }
 
 .learn-page-header h1 {
-    /* Sans/Desktop/Regular/3XL */
-    font-size: var(--font-size-3xl);
-    font-weight: var(--font-weight-regular);
-    line-height: var(--line-height-tight);
-    color: var(--color-text-primary);
-    /* 64px */
-    letter-spacing: -0.64px;
-    margin: 0;
-    align-self: stretch;
+  /* Sans/Desktop/Regular/3XL */
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-tight);
+  color: var(--color-text-primary);
+  /* 64px */
+  letter-spacing: -0.64px;
+  margin: 0;
+  align-self: stretch;
+  font-variation-settings: "wdth" 84;
 }
 
 .learn-page-header p {
-    padding: 0;
-    color: var(--color-text-secondary);
+  padding: 0;
+  color: var(--color-text-secondary);
 
-    /* Sans/Desktop/Regular/Large/Loose */
-    font-size: var(--font-size-large);
+  /* Sans/Desktop/Regular/Large/Loose */
+  font-size: var(--font-size-large);
 
-    font-weight: var(--font-weight-regular);
-    line-height: var(--line-height-loose-alt);
-    /* 31.92px */
-    letter-spacing: -0.24px;
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-loose-alt);
+  /* 31.92px */
+  letter-spacing: -0.24px;
 }
 
 .card-row {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: var(--space-card);
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-card);
 }
 
 .three-column .why-boost-cards__grid {
-    grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, 1fr);
 }
 
 .three-column .content-detail-icon {
-    height: 100%;
+  height: 100%;
 }
 
 .card-masonry {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-template-areas:
-        "a b c"
-        "a b e"
-        "a d e"
-    ;
-    row-gap: var(--space-card);
-    column-gap: var(--space-card);
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-areas:
+    "a b c"
+    "a b e"
+    "a d e";
+  row-gap: var(--space-card);
+  column-gap: var(--space-card);
 }
 
 .card-masonry .item-a {
-    grid-area: a;
+  grid-area: a;
 }
 
 .card-masonry .item-b {
-    grid-area: b;
+  grid-area: b;
 }
 
 .card-masonry .item-c {
-    grid-area: c;
+  grid-area: c;
 }
 
 .card-masonry .item-d {
-    grid-area: d;
+  grid-area: d;
 }
 
 .card-masonry .item-e {
-    grid-area: e;
+  grid-area: e;
 }
 
-
 @media (max-width: 1280px) {
-    .card-masonry {
-        grid-template-columns: repeat(2, 1fr);
-        grid-template-areas:
-            "a b"
-            "a d"
-            "c d"
-            "c d"
-            "c e"
-            "c ."
-        ;
-    }
+  .card-masonry {
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-areas:
+      "a b"
+      "a d"
+      "c d"
+      "c d"
+      "c e"
+      "c .";
+  }
 
-    .card, .card-group {
-        max-width: 100%;
-    }
+  .card,
+  .card-group {
+    max-width: 100%;
+  }
 }
 
 @media (max-width: 768px) {
-    .card-row {
-        grid-template-columns: repeat(1, 1fr);
-    }
+  .card-row {
+    grid-template-columns: repeat(1, 1fr);
+  }
 
-    .three-column .why-boost-cards__grid {
-        grid-template-columns: repeat(1, 1fr);
-    }
+  .three-column .why-boost-cards__grid {
+    grid-template-columns: repeat(1, 1fr);
+  }
 
-    .card-masonry {
-        grid-template-columns: 1fr;
-        grid-template-areas:
-            "a"
-            "b"
-            "c"
-            "d"
-            "e"
-        ;
-    }
+  .card-masonry {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "a"
+      "b"
+      "c"
+      "d"
+      "e";
+  }
 
-    .learn-page-header {
-        max-width: none;
-    }
+  .learn-page-header {
+    max-width: none;
+  }
 }

--- a/static/css/v3/learn-page.css
+++ b/static/css/v3/learn-page.css
@@ -19,7 +19,7 @@
   line-height: var(--line-height-tight);
   color: var(--color-text-primary);
   /* 64px */
-  letter-spacing: -0.64px;
+  letter-spacing: var(--letter-spacing-tight);
   margin: 0;
   align-self: stretch;
   font-variation-settings: "wdth" 84;


### PR DESCRIPTION
# Issue: #2546

## Summary & Context
Fixes the Learn page heading wrapping to three lines on desktop instead of the two-line layout in the Figma design, while keeping the header aligned with the card row below it.

- **Figma link**: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1849-49687
- **Link to components/page:** localhost:8000/learn/

## Changes

- Applied the intended condensed font width to the Learn page heading via `font-variation-settings: "wdth" 84` in `static/css/v3/learn-page.css`.
- Kept the header column at `calc(50% - .5 * var(--space-card))` so it stays aligned with the card row below.

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*

- The browser renders Mona Sans wider than the Figma mock (which shows a condensed rendering), so the two-line layout relies on the condensed `wdth 84` width. This holds across the desktop range (header column ~604px at 1280px up to 684px at 1440px+).
- Below the 1280px breakpoint (tablet), the 50% column keeps shrinking and the heading reflows to three lines. Out of scope for this desktop-focused fix.

## Screenshots

### 1280 px Width
<img width="1287" height="447" alt="width1280" src="https://github.com/user-attachments/assets/707b5fa1-bbb3-4482-ab69-0b5e627a58e2" />

### 1440 px Width
<img width="1440" height="448" alt="width1440" src="https://github.com/user-attachments/assets/7c3de45b-b740-42e9-82dc-c5db523ecb5d" />


## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [X] Tag at least one team member from each team to review this PR
- [X] Link this PR to the related GitHub Project ticket

### Frontend
- [X] UI implementation matches Figma design
- [X] Tested in light and dark mode
- [X] Responsive / mobile verified
- [X] Accessibility checked (keyboard navigation, etc.)
- [X] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [X] Test without JavaScript (if applicable)
- [X] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reformatted and normalized Learn page layout styles for improved consistency.
  * Updated spacing and typography values to use standardized variables (including tighter header letter spacing).
  * Preserved existing responsive behavior and overall visual styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->