### PR TITLE
Fix 2382: apply correct layout to password reset

### DIFF
--- a/static/css/v3/auth-page.css
+++ b/static/css/v3/auth-page.css
@@ -246,35 +246,24 @@ body:has(.auth-page) .header {
   width: 100%;
 }
 
-/* ── Responsive (Tablet) ────────────────────────────── */
-@media (max-width: 1279px) {
+/* ── Responsive (Mobile) ────────────────────────────── */
+@media (max-width: 767px) {
   .auth-page__wrapper {
     grid-template-columns: 1fr;
     flex: none;
   }
 
   .auth-page__illustration {
-    height: 592px;
+    height: 368px;
   }
 
   .auth-page__illustration-foreground {
-    height: 500px;
+    height: 280px;
   }
 
   .auth-page__content {
     padding: var(--space-medium);
     align-items: flex-start;
     margin-top: 0;
-  }
-}
-
-/* ── Responsive (Mobile) ────────────────────────────── */
-@media (max-width: 767px) {
-  .auth-page__illustration {
-    height: 368px;
-  }
-
-  .auth-page__illustration-foreground {
-    height: 280px;
   }
 }

--- a/static/css/v3/auth-page.css
+++ b/static/css/v3/auth-page.css
@@ -262,7 +262,9 @@ body:has(.auth-page) .header {
   }
 
   .auth-page__content {
-    padding: var(--space-medium);
+    padding-top: 56px;
+    padding-inline: var(--space-card);
+    padding-bottom: var(--space-xxl);
     align-items: flex-start;
     margin-top: 0;
   }


### PR DESCRIPTION
# Issue: #2382

## Summary & Context
<!-- *1-2 sentences describing what this PR does and why* -->

Fixes the password-reset (auth page) layout so tablet renders the two-column desktop layout instead of the mobile stack, and tightens up mobile spacing to match Figma. Changes live entirely in the shared `auth-page.css`, so they apply to every password-reset screen (and the other auth pages that reuse the layout).

- **Figma link**:
  - Tablet: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=5760-24729
  - Mobile: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=5760-24758
- **Link to components/page:** localhost:8000/v3/accounts/password/reset/ (also `/done/`, `/key/<uidb36>-<key>/`, `/key/done/`)

## Changes

- **Tablet:** moved the single-column collapse from `max-width: 1279px` down to `max-width: 767px` so the two-column layout (illustration left, form right) persists across the tablet range instead of collapsing to the mobile stack. 
- Removed the unused intermediate tablet illustration sizing (`592px` / `500px`). The mobile sizing (`368px` / `280px`) now lives in the single `≤767px` block.
- **Mobile:** widened the content side gutters from 8px to 12px (`var(--space-card)`) and increased the illustration heading gap to 56px to match Figma (was 8px).

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*

- **Shared layout:** `auth-page.css` also backs sign-in and sign-up. The breakpoint change makes those pages two-column on tablet as well (the intended "match desktop" behavior), so please spot-check sign-in / sign-up at tablet widths, not just the password screens.
- **Breakpoint boundary:** two-column now begins at `768px` (Tailwind `md`). Widths in the 768–1279px range that previously stacked will now show two columns — verify nothing looks cramped in that range, especially the taller sign-up form.
- **One hardcoded value:** the mobile illustration→heading gap uses a literal `56px`. No spacing token matches it (56px exceeds the largest mobile token, `--space-xxl` = 48px) because the value comes from Figma's vertical centering rather than a token. Sides and bottom remain tokenized (`--space-card`, `--space-xxl`).

## Screenshots
### Mobile
<img width="666" height="611" alt="Mobile" src="https://github.com/user-attachments/assets/50105f8b-8a33-4408-a258-7b12ed00d94a" />

### Tablet
<img width="736" height="887" alt="Tablet" src="https://github.com/user-attachments/assets/47729444-c3aa-479d-8407-d9ed8d95abc2" />

## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [X] Tag at least one team member from each team to review this PR
- [X] Link this PR to the related GitHub Project ticket

### Frontend
- [X] UI implementation matches Figma design
- [X] Tested in light and dark mode
- [X] Responsive / mobile verified
- [X] Accessibility checked (keyboard navigation, etc.)
- [X] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [X] Test without JavaScript (if applicable)
- [X] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined authentication page responsive styling.
  * Improved layout behavior and content alignment on mobile screens.
  * Removed separate tablet-specific layout adjustments for a more streamlined responsive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->