### PR TITLE
(Story #2554) Route QA email to a shared maildev inbox

### DIFF
--- a/config/email_routing.py
+++ b/config/email_routing.py
@@ -1,0 +1,27 @@
+"""Predicates behind the email routing decisions in `config.settings`.
+
+Kept out of the settings module so they are importable and testable: the guard
+below is the only thing stopping a values-file mistake from sending QA mail to
+real recipients, and settings modules cannot be reimported under test.
+"""
+
+
+def is_production(deployment_environment: str, environment_name: str) -> bool:
+    """Report whether this environment is production, by either available signal.
+
+    `deployment_environment` is `X_DEPLOYMENT_ENV`, set from the chart's
+    `deploymentEnvironment` anchor. `environment_name` is `ENVIRONMENT_NAME`, set
+    for the admin banner. Both are set in `values-production-gke.yaml`, and
+    either one alone being unset or renamed must not read as non-production.
+    """
+    return (
+        deployment_environment == "production"
+        or environment_name == "Production Environment"
+    )
+
+
+def catch_all_conflicts_with_production(
+    catch_all_email: bool, deployment_environment: str, environment_name: str
+) -> bool:
+    """Report whether catch-all email is enabled somewhere it must never be."""
+    return catch_all_email and is_production(deployment_environment, environment_name)

--- a/config/settings.py
+++ b/config/settings.py
@@ -595,7 +595,15 @@ SERVER_EMAIL = "errors@cppalliance.org"
 CATCH_ALL_EMAIL = env.bool("CATCH_ALL_EMAIL", default=False)
 DEPLOYMENT_ENVIRONMENT = env("X_DEPLOYMENT_ENV", default="")
 
-if CATCH_ALL_EMAIL and DEPLOYMENT_ENVIRONMENT == "production":
+# Two independent signals, because neither one being unset or renamed should be
+# what lets catch-all email through in production. X_DEPLOYMENT_ENV comes from
+# the chart's deploymentEnvironment anchor, ENVIRONMENT_NAME from the admin
+# banner config; both are set in values-production-gke.yaml.
+IS_PRODUCTION = (
+    DEPLOYMENT_ENVIRONMENT == "production" or ENV_NAME == "Production Environment"
+)
+
+if CATCH_ALL_EMAIL and IS_PRODUCTION:
     raise ImproperlyConfigured("CATCH_ALL_EMAIL must not be enabled in production")
 
 if LOCAL_DEVELOPMENT or CATCH_ALL_EMAIL:

--- a/config/settings.py
+++ b/config/settings.py
@@ -593,7 +593,7 @@ SERVER_EMAIL = "errors@cppalliance.org"
 # real users without those users receiving anything. Enabled per environment in
 # the Helm values files; never valid in production.
 CATCH_ALL_EMAIL = env.bool("CATCH_ALL_EMAIL", default=False)
-DEPLOYMENT_ENVIRONMENT = env("X_DEPLOYMENT_ENV", default="production")
+DEPLOYMENT_ENVIRONMENT = env("X_DEPLOYMENT_ENV", default="")
 
 if CATCH_ALL_EMAIL and DEPLOYMENT_ENVIRONMENT == "production":
     raise ImproperlyConfigured("CATCH_ALL_EMAIL must not be enabled in production")

--- a/config/settings.py
+++ b/config/settings.py
@@ -571,8 +571,9 @@ NEWS_MODERATION_ALLOWLIST = [
 ]
 
 # EMAIL SETTINGS
-# Production sends through Mailgun (Anymail). In local development the default
-# is the maildev SMTP container, but every setting below is overridable via env
+# Production sends through Mailgun (Anymail). Local development and any
+# environment with CATCH_ALL_EMAIL enabled send to the maildev SMTP container
+# instead. See docs/email.md. Every setting below is overridable via env
 # so you can route test sends through your own email service provider -- either
 # an SMTP provider (set EMAIL_HOST/EMAIL_PORT/EMAIL_HOST_USER/
 # EMAIL_HOST_PASSWORD/EMAIL_USE_TLS) or an Anymail API backend (set
@@ -587,7 +588,17 @@ EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS", default=False)
 DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="boost@cppalliance.org")
 SERVER_EMAIL = "errors@cppalliance.org"
 
-if LOCAL_DEVELOPMENT:
+# Route every outbound message to a catch-all SMTP sink (the maildev container)
+# instead of a real email service provider, so QA can exercise flows that email
+# real users without those users receiving anything. Enabled per environment in
+# the Helm values files; never valid in production.
+CATCH_ALL_EMAIL = env.bool("CATCH_ALL_EMAIL", default=False)
+DEPLOYMENT_ENVIRONMENT = env("X_DEPLOYMENT_ENV", default="")
+
+if CATCH_ALL_EMAIL and DEPLOYMENT_ENVIRONMENT == "production":
+    raise ImproperlyConfigured("CATCH_ALL_EMAIL must not be enabled in production")
+
+if LOCAL_DEVELOPMENT or CATCH_ALL_EMAIL:
     EMAIL_BACKEND = env(
         "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"
     )

--- a/config/settings.py
+++ b/config/settings.py
@@ -593,7 +593,7 @@ SERVER_EMAIL = "errors@cppalliance.org"
 # real users without those users receiving anything. Enabled per environment in
 # the Helm values files; never valid in production.
 CATCH_ALL_EMAIL = env.bool("CATCH_ALL_EMAIL", default=False)
-DEPLOYMENT_ENVIRONMENT = env("X_DEPLOYMENT_ENV", default="")
+DEPLOYMENT_ENVIRONMENT = env("X_DEPLOYMENT_ENV", default="production")
 
 if CATCH_ALL_EMAIL and DEPLOYMENT_ENVIRONMENT == "production":
     raise ImproperlyConfigured("CATCH_ALL_EMAIL must not be enabled in production")

--- a/config/settings.py
+++ b/config/settings.py
@@ -10,6 +10,8 @@ from corsheaders.defaults import default_headers
 from django.core.exceptions import ImproperlyConfigured
 from pythonjsonlogger import jsonlogger
 
+from config.email_routing import catch_all_conflicts_with_production, is_production
+
 env = environs.Env()
 
 READ_DOT_ENV_FILE = env.bool("DJANGO_READ_DOT_ENV_FILE", default=False)
@@ -595,15 +597,11 @@ SERVER_EMAIL = "errors@cppalliance.org"
 CATCH_ALL_EMAIL = env.bool("CATCH_ALL_EMAIL", default=False)
 DEPLOYMENT_ENVIRONMENT = env("X_DEPLOYMENT_ENV", default="")
 
-# Two independent signals, because neither one being unset or renamed should be
-# what lets catch-all email through in production. X_DEPLOYMENT_ENV comes from
-# the chart's deploymentEnvironment anchor, ENVIRONMENT_NAME from the admin
-# banner config; both are set in values-production-gke.yaml.
-IS_PRODUCTION = (
-    DEPLOYMENT_ENVIRONMENT == "production" or ENV_NAME == "Production Environment"
-)
+IS_PRODUCTION = is_production(DEPLOYMENT_ENVIRONMENT, ENV_NAME)
 
-if CATCH_ALL_EMAIL and IS_PRODUCTION:
+if catch_all_conflicts_with_production(
+    CATCH_ALL_EMAIL, DEPLOYMENT_ENVIRONMENT, ENV_NAME
+):
     raise ImproperlyConfigured("CATCH_ALL_EMAIL must not be enabled in production")
 
 if LOCAL_DEVELOPMENT or CATCH_ALL_EMAIL:

--- a/config/settings.py
+++ b/config/settings.py
@@ -602,6 +602,10 @@ if LOCAL_DEVELOPMENT or CATCH_ALL_EMAIL:
     EMAIL_BACKEND = env(
         "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"
     )
+    # smtplib blocks forever without this. A sink that accepts the connection but
+    # never sends a banner would otherwise stall the request thread or Celery
+    # worker that is sending, instead of raising.
+    EMAIL_TIMEOUT = env.int("EMAIL_TIMEOUT", default=10)
     # Credentials for an Anymail backend, as a JSON env var, e.g.
     # ANYMAIL='{"<PROVIDER>_API_TOKEN": "..."}'. Empty/ignored for plain SMTP.
     ANYMAIL = env.json("ANYMAIL", default={})

--- a/core/tests/test_email_routing.py
+++ b/core/tests/test_email_routing.py
@@ -1,0 +1,90 @@
+"""Tests for the email routing predicates used by `config.settings`."""
+
+import pytest
+
+from config.email_routing import catch_all_conflicts_with_production, is_production
+
+
+class TestIsProduction:
+    @pytest.mark.parametrize(
+        "deployment_environment,environment_name",
+        [
+            ("production", "Production Environment"),
+            ("production", "Development Environment"),
+            ("production", ""),
+            ("", "Production Environment"),
+            ("stage", "Production Environment"),
+        ],
+    )
+    def test_either_signal_reads_as_production(
+        self, deployment_environment, environment_name
+    ):
+        assert is_production(deployment_environment, environment_name) is True
+
+    @pytest.mark.parametrize(
+        "deployment_environment,environment_name",
+        [
+            ("stage", "Development Environment"),
+            ("dev", "Development Environment"),
+            ("", ""),
+            ("", "Unknown Environment"),
+        ],
+    )
+    def test_neither_signal_reads_as_non_production(
+        self, deployment_environment, environment_name
+    ):
+        assert is_production(deployment_environment, environment_name) is False
+
+
+class TestCatchAllConflictsWithProduction:
+    @pytest.mark.parametrize(
+        "deployment_environment,environment_name",
+        [
+            ("production", "Production Environment"),
+            ("production", "Development Environment"),
+            ("", "Production Environment"),
+        ],
+    )
+    def test_catch_all_in_production_conflicts(
+        self, deployment_environment, environment_name
+    ):
+        assert (
+            catch_all_conflicts_with_production(
+                True, deployment_environment, environment_name
+            )
+            is True
+        )
+
+    @pytest.mark.parametrize(
+        "deployment_environment,environment_name",
+        [
+            ("stage", "Development Environment"),
+            ("dev", "Development Environment"),
+        ],
+    )
+    def test_catch_all_outside_production_is_allowed(
+        self, deployment_environment, environment_name
+    ):
+        assert (
+            catch_all_conflicts_with_production(
+                True, deployment_environment, environment_name
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize(
+        "deployment_environment,environment_name",
+        [
+            ("production", "Production Environment"),
+            ("stage", "Development Environment"),
+        ],
+    )
+    def test_no_conflict_when_catch_all_is_disabled(
+        self, deployment_environment, environment_name
+    ):
+        assert (
+            catch_all_conflicts_with_production(
+                False, deployment_environment, environment_name
+            )
+            is False
+        )

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Caching and the `RenderedContent` model](./caching_rendered_content.md)
 - [Dependency Management](./dependencies.md)
 - [Development Setup Notes](development_setup_notes_native.md)
+- [Email Routing and the QA Inbox](./email.md) - Where email goes in each environment, and how to reach the QA inbox
 - [Environment Variables](./env_vars.md)
 - [Events Calendar](./calendar.md)
 - [Example Files](./examples/README.md) - Contains samples of `libraries.json`. `.gitmodules`, and other files that Boost data depends on

--- a/docs/email.md
+++ b/docs/email.md
@@ -14,9 +14,9 @@ Non-production environments deliberately send nothing to real recipients. This m
 
 Mailman is not affected by any of this. It is driven through `MAILMAN_REST_API_URL`, not Django's email backend.
 
-## `CATCH_ALL_EMAIL`
+## `CATCH_ALL_EMAIL` & `X_DEPLOYMENT_ENV`
 
-- Set to `true` in `kube/boost/values-stage-gke.yaml` and `kube/boost/values-cppal-dev-gke.yaml`.
+- Set `CATCH_ALL_EMAIL=true` and `X_DEPLOYMENT_ENV=<env's label>` in `kube/boost/values-stage-gke.yaml` and `kube/boost/values-cppal-dev-gke.yaml`.
 - When enabled, `EMAIL_BACKEND` defaults to Django's SMTP backend pointed at `EMAIL_HOST` / `EMAIL_PORT` (`maildev:1025`) instead of Mailgun. The `MAILGUN_*` values in those files stay present but become inert.
 - Django raises `ImproperlyConfigured` at startup if this is enabled while `X_DEPLOYMENT_ENV` is `production`. Mis-routing production email should be loud, not silent.
 - Default is `false`, so an environment only changes behavior if its values file opts in. Enable it only where a `maildev` pod is also deployed (`maildevInstall: true`), otherwise sends will fail with a connection error.

--- a/docs/email.md
+++ b/docs/email.md
@@ -1,0 +1,61 @@
+# Email Routing and the QA Inbox
+
+## How email is routed per environment
+
+| Environment | Backend | Where messages go |
+| --- | --- | --- |
+| Local development | SMTP | The `maildev` container in `docker-compose.yml`, inbox at http://localhost:1080 |
+| `cppal-dev` | SMTP | The in-cluster `maildev` pod, inbox at https://www.cppal-dev.boost.org/maildev/ |
+| `stage` | SMTP | The in-cluster `maildev` pod, inbox at https://www.stage.boost.org/maildev/ |
+| `production` | Mailgun (Anymail) | Real recipients |
+| Tests | `locmem` | `django.core.mail.outbox`, see `config/test_settings.py` |
+
+Non-production environments deliberately send nothing to real recipients. This makes it safe to test flows against real user accounts (sign-in verification, moderation notices, subscription confirmations) without those users receiving anything, and it keeps QA traffic off the Mailgun sender domain.
+
+Mailman is not affected by any of this. It is driven through `MAILMAN_REST_API_URL`, not Django's email backend.
+
+## `CATCH_ALL_EMAIL`
+
+- Set to `true` in `kube/boost/values-stage-gke.yaml` and `kube/boost/values-cppal-dev-gke.yaml`.
+- When enabled, `EMAIL_BACKEND` defaults to Django's SMTP backend pointed at `EMAIL_HOST` / `EMAIL_PORT` (`maildev:1025`) instead of Mailgun. The `MAILGUN_*` values in those files stay present but become inert.
+- Django raises `ImproperlyConfigured` at startup if this is enabled while `X_DEPLOYMENT_ENV` is `production`. Mis-routing production email should be loud, not silent.
+- Default is `false`, so an environment only changes behavior if its values file opts in. Enable it only where a `maildev` pod is also deployed (`maildevInstall: true`), otherwise sends will fail with a connection error.
+
+## Reaching the QA inbox
+
+Open the URL for the environment and enter the basic-auth credentials:
+
+- `stage`: https://www.stage.boost.org/maildev/
+- `cppal-dev`: https://www.cppal-dev.boost.org/maildev/
+
+Credentials come from the `maildev-auth` Secret in that namespace, which is created by hand and is not in this repository:
+
+```bash
+kubectl -n stage create secret generic maildev-auth \
+  --from-literal=web_user='<user>' \
+  --from-literal=web_pass='<password>'
+```
+
+The pod will not start until that Secret exists. Ask an operator for the credentials rather than reading them out of the cluster.
+
+Things worth knowing before someone reports them as bugs:
+
+- **The inbox is ephemeral.** maildev holds messages in memory, so a pod restart (including every deploy that rolls it) empties the inbox. There is no retention by design.
+- **The inbox updates live.** New messages appear without refreshing, over a websocket.
+- **Do not publish the URL.** maildev applies basic auth as Express middleware, but its socket.io channel is attached to the raw HTTP server and bypasses that middleware, so the live message feed is readable by anyone who can reach the path. The password gate deters casual access; it is not a security boundary. The inbox contains real user addresses and working sign-in links for the QA database.
+
+## How it is wired
+
+- `kube/boost/templates/maildev.yaml` holds everything, behind `maildevInstall`: the `Deployment`, a `ClusterIP` `Service`, and (for Gateway environments) an `HTTPRoute`, a `HealthCheckPolicy` and a `GCPBackendPolicy`.
+- Django reaches SMTP at `maildev:1025` over cluster DNS. That port is never exposed outside the cluster.
+- The inbox is published as a `/maildev` path on the environment's `mainFqdn`, via a second `HTTPRoute` on the existing Gateway. It reuses the existing static IP and certificate, so no DNS record or certificate is involved, and the traffic never reaches Django or the app pods.
+- `MAILDEV_BASE_PATHNAME=/maildev` makes maildev serve itself under that prefix, so no URL rewriting is needed at the edge. The socket.io endpoint moves under the same prefix and is covered by the same route.
+- The `HealthCheckPolicy` targets `/maildev/healthz`, the only path maildev exempts from basic auth. A health check against `/` would get a 401, which the load balancer reads as an unhealthy backend.
+- The `GCPBackendPolicy` raises `timeoutSec`. On Google load balancers the backend timeout is the maximum *lifetime* of a websocket connection rather than an idle timeout, and the 30 second default would sever the live-update socket every 30 seconds.
+- `replicas` must stay at 1. Messages live in the pod's memory, so a second replica would split the inbox.
+
+## Enabling it in another environment
+
+1. In that environment's values file, set `maildevInstall: true` and add `CATCH_ALL_EMAIL: "true"` (plus `EMAIL_HOST: maildev` and `EMAIL_PORT: "1025"`) to the `Env` list.
+2. Create the `maildev-auth` Secret in that namespace before deploying.
+3. The route is only rendered for environments using the GKE Gateway (`gatewayType: "gce"`). Elsewhere you get the pod and the SMTP sink, and the inbox is reachable with `kubectl -n <ns> port-forward svc/maildev 1080:1080`.

--- a/docs/email.md
+++ b/docs/email.md
@@ -18,7 +18,7 @@ Mailman is not affected by any of this. It is driven through `MAILMAN_REST_API_U
 
 - Set `CATCH_ALL_EMAIL=true` and `X_DEPLOYMENT_ENV=<env's label>` in `kube/boost/values-stage-gke.yaml` and `kube/boost/values-cppal-dev-gke.yaml`.
 - When enabled, `EMAIL_BACKEND` defaults to Django's SMTP backend pointed at `EMAIL_HOST` / `EMAIL_PORT` (`maildev:1025`) instead of Mailgun. The `MAILGUN_*` values in those files stay present but become inert.
-- Django raises `ImproperlyConfigured` at startup if this is enabled while `X_DEPLOYMENT_ENV` is `production`. Mis-routing production email should be loud, not silent.
+- Django raises `ImproperlyConfigured` at startup if this is enabled while the environment looks like production, by either signal: `X_DEPLOYMENT_ENV` is `production`, or `ENVIRONMENT_NAME` is `Production Environment`. Two signals, so neither one being unset or renamed is on its own enough to let catch-all through. Mis-routing production email should be loud, not silent.
 - Default is `false`, so an environment only changes behavior if its values file opts in. Enable it only where a `maildev` pod is also deployed (`maildevInstall: true`), otherwise sends will fail with a connection error.
 
 ## Reaching the QA inbox

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -107,3 +107,20 @@ This project uses environment variables to configure certain aspects of the appl
 - Controls the decay rate of the posts ranking algorithm (`score = views / (age_hours + 2) ^ gravity`).
 - Higher values cause recent posts to decay faster and drop in ranking sooner.
 - Defaults to `2.0` if not set.
+
+## Email settings
+
+See [Email Routing and the QA Inbox](./email.md) for how messages are routed in each environment.
+
+### `CATCH_ALL_EMAIL`
+
+- Routes every outbound message to the `maildev` SMTP sink instead of a real email service provider, so testing against real user accounts does not email real people.
+- For **local development**, not needed: `LOCAL_DEVELOPMENT` already sends to the `maildev` container.
+- In **deployed environments**, set to `true` in `kube/boost/values-stage-gke.yaml` and `kube/boost/values-cppal-dev-gke.yaml`. Defaults to `false`, and Django refuses to start if it is enabled while `X_DEPLOYMENT_ENV` is `production`.
+- Only enable it where `maildevInstall: true` is also set, otherwise sends fail with a connection error.
+
+### `EMAIL_BACKEND`, `EMAIL_HOST`, `EMAIL_PORT`
+
+- `EMAIL_HOST` / `EMAIL_PORT` are where SMTP is delivered; they default to `maildev` and `1025`.
+- `EMAIL_BACKEND` is only read when local development or `CATCH_ALL_EMAIL` is active, and defaults to Django's SMTP backend. Everywhere else the Mailgun Anymail backend is used unconditionally.
+- Set `EMAIL_HOST_USER`, `EMAIL_HOST_PASSWORD` and `EMAIL_USE_TLS` if you point these at a real SMTP provider instead.

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -116,11 +116,12 @@ See [Email Routing and the QA Inbox](./email.md) for how messages are routed in 
 
 - Routes every outbound message to the `maildev` SMTP sink instead of a real email service provider, so testing against real user accounts does not email real people.
 - For **local development**, not needed: `LOCAL_DEVELOPMENT` already sends to the `maildev` container.
-- In **deployed environments**, set to `true` in `kube/boost/values-stage-gke.yaml` and `kube/boost/values-cppal-dev-gke.yaml`. Defaults to `false`, and Django refuses to start if it is enabled while `X_DEPLOYMENT_ENV` is `production`.
+- In **deployed environments**, set to `true` in `kube/boost/values-stage-gke.yaml` and `kube/boost/values-cppal-dev-gke.yaml`. Defaults to `false`, and Django refuses to start if it is enabled while the environment looks like production (`X_DEPLOYMENT_ENV` is `production`, or `ENVIRONMENT_NAME` is `Production Environment`).
 - Only enable it where `maildevInstall: true` is also set, otherwise sends fail with a connection error.
 
-### `EMAIL_BACKEND`, `EMAIL_HOST`, `EMAIL_PORT`
+### `EMAIL_BACKEND`, `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_TIMEOUT`
 
 - `EMAIL_HOST` / `EMAIL_PORT` are where SMTP is delivered; they default to `maildev` and `1025`.
+- `EMAIL_TIMEOUT` is the per-send socket timeout in seconds, defaulting to `10`. Without it `smtplib` blocks indefinitely, so a sink that accepts the connection but never answers would stall the request thread or Celery worker sending the message rather than raising. Only read on the SMTP path, so the Mailgun backend is unaffected.
 - `EMAIL_BACKEND` is only read when local development or `CATCH_ALL_EMAIL` is active, and defaults to Django's SMTP backend. Everywhere else the Mailgun Anymail backend is used unconditionally.
 - Set `EMAIL_HOST_USER`, `EMAIL_HOST_PASSWORD` and `EMAIL_USE_TLS` if you point these at a real SMTP provider instead.

--- a/env.template
+++ b/env.template
@@ -94,3 +94,12 @@ MAILMAN_DEV_API_URL=http://localhost:8001
 MAILMAN_LISTS=boost-users.lists.boost.org,boost-announce.lists.boost.org,boost.lists.boost.org
 
 POPULAR_SEARCH_TERMS_MIN_SEARCH_COUNT=
+
+# Routes all outbound mail to the maildev SMTP sink instead of Mailgun. Not
+# needed locally, LOCAL_DEVELOPMENT already does this; set in the stage and
+# cppal-dev values files. Never valid in production. See docs/email.md
+# CATCH_ALL_EMAIL=false
+# Where the SMTP backend delivers, and how long a send waits before failing.
+# EMAIL_HOST=maildev
+# EMAIL_PORT=1025
+# EMAIL_TIMEOUT=10

--- a/kube/boost/templates/maildev.yaml
+++ b/kube/boost/templates/maildev.yaml
@@ -1,0 +1,146 @@
+# vim: ft=sls nolist
+#
+# Catch-all inbox for non-production environments. maildev accepts SMTP on 1025
+# and serves a web inbox on 1080. Django sends to maildev:1025 over cluster DNS;
+# the inbox is published as /maildev/ on the environment's main hostname via the
+# existing Gateway, protected by maildev's own HTTP basic auth.
+#
+# Every object below must stay inside the maildevInstall conditional, otherwise
+# environments without maildev get a route pointing at a Service that does not
+# exist.
+
+{{- if .Values.maildevInstall }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maildev
+  labels:
+    app: maildev
+    env: {{ .Values.deploymentEnvironment }}
+spec:
+  # Must stay at 1: messages are held in the pod's memory, so a second replica
+  # would split the inbox and socket.io polling would need session affinity.
+  replicas: 1
+  selector:
+    matchLabels:
+      app: maildev
+      env: {{ .Values.deploymentEnvironment }}
+  template:
+    metadata:
+      labels:
+        app: maildev
+        env: {{ .Values.deploymentEnvironment }}
+    spec:
+      containers:
+        - name: maildev
+          image: maildev/maildev:{{ .Values.maildevImageTag }}
+          env:
+            - name: MAILDEV_BASE_PATHNAME
+              value: /maildev
+            - name: MAILDEV_WEB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: maildev-auth
+                  key: web_user
+            - name: MAILDEV_WEB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: maildev-auth
+                  key: web_pass
+          resources:
+            limits:
+              cpu: 250m
+              ephemeral-storage: 1Gi
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              ephemeral-storage: 1Gi
+              memory: 512Mi
+          ports:
+            - name: smtp
+              containerPort: 1025
+            - name: http
+              containerPort: 1080
+          readinessProbe:
+            httpGet:
+              # /healthz is the only path maildev exempts from basic auth, and
+              # it moves with MAILDEV_BASE_PATHNAME. Probing / returns 401.
+              path: /maildev/healthz
+              port: 1080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: maildev
+  labels:
+    app: maildev
+    env: {{ .Values.deploymentEnvironment }}
+spec:
+  ports:
+    - name: smtp
+      port: 1025
+      targetPort: 1025
+    - name: http
+      port: 1080
+      targetPort: 1080
+  selector:
+    app: maildev
+    env: {{ .Values.deploymentEnvironment }}
+{{- if eq .Values.gatewayType "gce" }}
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: maildev
+spec:
+  parentRefs:
+    - kind: Gateway
+      name: www-boost-{{ .Values.deploymentEnvironment }}
+      sectionName: https
+  hostnames:
+    - {{ .Values.mainFqdn }}
+  rules:
+    # More specific than the site's "/" rule, so it wins by path length. Also
+    # covers /maildev/socket.io/... which is how the inbox live-updates.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /maildev
+      backendRefs:
+        - name: maildev
+          port: 1080
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: maildev
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        port: 1080
+        requestPath: /maildev/healthz
+  targetRef:
+    group: ""
+    kind: Service
+    name: maildev
+---
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  name: maildev
+spec:
+  default:
+    # On Google load balancers this is the maximum lifetime of a WebSocket
+    # connection, not an idle timeout. The 30s default would sever the inbox's
+    # live-update socket every 30s, causing constant reconnects.
+    timeoutSec: 3600
+  targetRef:
+    group: ""
+    kind: Service
+    name: maildev
+{{- end }}
+
+{{ end }}

--- a/kube/boost/templates/maildev.yaml
+++ b/kube/boost/templates/maildev.yaml
@@ -19,6 +19,11 @@ metadata:
     app: maildev
     env: {{ .Values.deploymentEnvironment }}
 spec:
+  # Holds the replicas: 1 invariant during rollouts too. The default
+  # RollingUpdate surges to a second pod before terminating the first, which is
+  # the split inbox described below, time-boxed to the rollout.
+  strategy:
+    type: Recreate
   # Must stay at 1: messages are held in the pod's memory, so a second replica
   # would split the inbox and socket.io polling would need session affinity.
   replicas: 1

--- a/kube/boost/templates/maildev.yaml
+++ b/kube/boost/templates/maildev.yaml
@@ -73,6 +73,13 @@ spec:
               # it moves with MAILDEV_BASE_PATHNAME. Probing / returns 401.
               path: /maildev/healthz
               port: 1080
+          # Readiness alone would leave a wedged pod out of the Service
+          # endpoints indefinitely, failing every send in the environment until
+          # someone restarts it by hand.
+          livenessProbe:
+            httpGet:
+              path: /maildev/healthz
+              port: 1080
 ---
 apiVersion: v1
 kind: Service

--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -146,6 +146,15 @@ Env:
         key: key
   - name: MAILGUN_SENDER_DOMAIN
     value: cppal-dev.boost.cppalliance.org
+  # Send every outbound message to the in-cluster maildev inbox instead of
+  # Mailgun, so testing with real user accounts does not email real people.
+  # The MAILGUN_* values above are inert while this is enabled. See docs/email.md
+  - name: CATCH_ALL_EMAIL
+    value: "true"
+  - name: EMAIL_HOST
+    value: maildev
+  - name: EMAIL_PORT
+    value: "1025"
   - name: MAILMAN_REST_API_URL
     valueFrom:
       secretKeyRef:
@@ -285,4 +294,5 @@ gatewayStaticIp: cppal-dev-ingress1
 gatewayStaticIpv6: cppal-dev-gateway-ipv6
 redisInstall: false
 celeryInstall: true
+maildevInstall: true
 hpaMinReplicas: 2

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -146,6 +146,15 @@ Env:
         key: key
   - name: MAILGUN_SENDER_DOMAIN
     value: stage.boost.cppalliance.org
+  # Send every outbound message to the in-cluster maildev inbox instead of
+  # Mailgun, so testing with real user accounts does not email real people.
+  # The MAILGUN_* values above are inert while this is enabled. See docs/email.md
+  - name: CATCH_ALL_EMAIL
+    value: "true"
+  - name: EMAIL_HOST
+    value: maildev
+  - name: EMAIL_PORT
+    value: "1025"
   - name: MAILMAN_REST_API_URL
     valueFrom:
       secretKeyRef:
@@ -283,4 +292,5 @@ gatewayStaticIp: boost-stage-ingress1
 gatewayStaticIpv6: stage-gateway-ipv6
 redisInstall: false
 celeryInstall: true
+maildevInstall: true
 hpaMinReplicas: 2

--- a/kube/boost/values.yaml
+++ b/kube/boost/values.yaml
@@ -212,3 +212,7 @@ gatewayType: "none"
 certmap: "revsys-certmap"
 redisInstall: false
 celeryInstall: false
+# Catch-all email inbox. Enable only alongside CATCH_ALL_EMAIL in the same
+# values file, and never in production. See docs/email.md
+maildevInstall: false
+maildevImageTag: "2.2.1"


### PR DESCRIPTION
Ref #2554

## Why

Non-production deployments send real email to real recipients. `config/settings.py` hardcoded `EMAIL_BACKEND` to the Mailgun Anymail backend for every environment except `LOCAL_DEVELOPMENT`, and both `values-stage-gke.yaml` and `values-cppal-dev-gke.yaml` supply live Mailgun credentials and a verified sender domain.

That blocks QA work which needs to sign in as existing users with real contribution history, because the sign-in verification email is delivered to that user's actual inbox. More broadly, any transactional email triggered while testing reaches real recipients, consumes email quota, and generates bounces and spam signals against the sender domain.

Local development already solves this with the `maildev` container in `docker-compose.yml`. This brings the same catch-all inbox to `stage` and `cppal-dev`, reachable in a browser so QA does not need cluster credentials.

## What changed

**`config/settings.py`** - a new `CATCH_ALL_EMAIL` flag (default `false`) makes an environment send through Django's SMTP backend to `EMAIL_HOST`/`EMAIL_PORT` instead of Mailgun. Django raises `ImproperlyConfigured` at startup if the flag is ever enabled while `X_DEPLOYMENT_ENV` is `production`.

The flag is opt-in per values file rather than derived from the environment name. Deriving it (from `X_DEPLOYMENT_ENV`, or by pattern-matching `DJANGO_FQDN`) would silently switch environments that have no maildev pod, turning working mail into connection errors, and would re-enable real sending if a hostname were ever renamed.

**`kube/boost/templates/maildev.yaml`** (new) - everything behind a `maildevInstall` flag, following the existing `redisInstall` / `celeryInstall` convention so production cannot pick it up:

- `Deployment` (pinned `maildev/maildev:2.2.1`, `replicas: 1`) and a `ClusterIP` `Service` exposing SMTP `1025` and HTTP `1080`.
- For Gateway environments only: an `HTTPRoute` publishing the inbox at `/maildev/` on the environment's `mainFqdn`, plus a `HealthCheckPolicy` and a `GCPBackendPolicy`.

**Values files** - `maildevInstall: true` and `CATCH_ALL_EMAIL: "true"` in the two QA files; `maildevInstall: false` plus `maildevImageTag` as chart defaults. Production is untouched. The `MAILGUN_*` entries stay in the QA files but are inert, so reverting is a one-line change.

**Docs** - new `docs/email.md` (routing per environment, how to reach the inbox, how it is wired), plus `CATCH_ALL_EMAIL` / `EMAIL_*` entries in `docs/env_vars.md` and an index line in `docs/README.md`.

## How the inbox is exposed

The route is added at the existing GKE Gateway, so the Google load balancer that already fronts the site gains one URL-map rule. It reuses the existing static IP and certificate: no new hostname, no DNS record, no certificate, no LoadBalancer, and no change to the app's nginx config. Traffic to `/maildev/` never reaches Django, gunicorn or the app pods.

- `stage`: https://www.stage.boost.org/maildev/
- `cppal-dev`: https://www.cppal-dev.boost.org/maildev/

Access is gated by maildev's own HTTP basic auth (`MAILDEV_WEB_USER` / `MAILDEV_WEB_PASS`).

Three details that are load-bearing, all verified against `maildev/maildev:2.2.1`:

- `MAILDEV_BASE_PATHNAME=/maildev` makes maildev serve itself under the prefix, so no URL rewriting is needed at the edge, and the socket.io endpoint moves under the same prefix where the `PathPrefix` rule already covers it.
- The `HealthCheckPolicy` targets `/maildev/healthz`, the only path maildev exempts from basic auth. A health check against `/` returns 401, which the load balancer reads as an unhealthy backend and answers with 503.
- The `GCPBackendPolicy` raises `timeoutSec`. On Google load balancers the backend timeout is the maximum *lifetime* of a WebSocket connection rather than an idle timeout, so the 30 second default would sever the inbox's live-update socket every 30 seconds.

## Deploy notes

**A `maildev-auth` Secret must exist in `stage` and in `cppal-dev` before deploying, or the maildev pod will not start.** It is not in the repo because this repository is public. It follows the same convention as the 13 secrets this chart already consumes (`pg`, `mailgun`, `django-secret-key`, and so on): created out-of-band by an operator, referenced through `secretKeyRef`. The chart ships no `kind: Secret` and CI creates none.

```bash
kubectl -n stage create secret generic maildev-auth \
  --from-literal=web_user='<user>' --from-literal=web_pass='<password>'

kubectl -n cppal-dev create secret generic maildev-auth \
  --from-literal=web_user='<user>' --from-literal=web_pass='<password>'
```

Name, keys and type must be exactly `maildev-auth` / `web_user` + `web_pass` / `Opaque`, because the Deployment references them verbatim. A Secret with the right name but different keys fails in exactly the same way as a missing one. Do not create it in `production`, where nothing consumes it.

Ordering matters, and the failure mode is fail-closed rather than degraded. If the Secret is absent at deploy time the pod stays in `CreateContainerConfigError`, never passes readiness, and so never joins the Service endpoints, while `CATCH_ALL_EMAIL=true` has already switched that environment's Django to SMTP. Every outbound email in that environment then fails with a connection error instead of falling back to Mailgun. Recovery is to create the Secret and `kubectl -n <ns> rollout restart deploy/maildev`.

Post-deploy checks, per namespace:

```bash
kubectl -n stage rollout status deploy/maildev --timeout=180s
kubectl -n stage get endpoints maildev          # must list a pod IP on 1025 and 1080
kubectl -n stage exec deploy/boost -c wsgi -- python -c \
  "import smtplib; smtplib.SMTP('maildev',1025).noop(); print('reachable')"
```

The `values-cppal-dev-gke.yaml` change only takes effect once the `cppalliance/website-v2-qa` fork's `cppal-dev` branch picks up this commit.

Two further things to confirm on the first deploy: that the Gateway controller auto-attached a NEG to the `maildev` Service (otherwise add a `cloud.google.com/neg` annotation), and that the `GCPBackendPolicy` CRD is present (`kubectl get crd | grep gcpbackendpolicies`; `HealthCheckPolicy` from the same GKE bundle is already used in `gateway.yaml`).

Standardizing this Secret (a chart-templated `Secret` fed from a CI secret, or External Secrets / GCP Secret Manager) is deliberately out of scope. Doing it for the 14th secret while the other 13 stay manual trades one inconsistency for a worse one; it is worth a separate ticket covering all of them at once.

## Verification

`helm template` across all four values files:

- `production`: no maildev objects at all, Mailgun backend unchanged.
- `stage` and `cppal-dev`: `Deployment`, `Service`, `HTTPRoute`, `HealthCheckPolicy` and `GCPBackendPolicy` all render; `HTTPRoute` resolves to `www-boost-stage` / `www-boost-dev` on the correct hostname; `CATCH_ALL_EMAIL`, `EMAIL_HOST` and `EMAIL_PORT` reach every container that renders `.Values.Env` - `boost/wsgi`, `boost/nginx`, `celery-worker`, `celery-beat` and the migrations `Job` - which covers all workloads that can send mail, Celery included.
- Chart defaults (`values.yaml`): no maildev objects.
- `helm lint` is clean for all three GKE values files.

Settings behavior, exercised in the project image:

| Configuration | Result |
| --- | --- |
| `LOCAL_DEVELOPMENT=true` | SMTP backend, `maildev:1025` |
| No flag, `X_DEPLOYMENT_ENV=production` | Mailgun backend with `MAILGUN_*` in `ANYMAIL` |
| Flag on, `X_DEPLOYMENT_ENV=stage` or `dev` | SMTP backend, `maildev:1025`, empty `ANYMAIL` |
| Flag on, `X_DEPLOYMENT_ENV=production` | `ImproperlyConfigured` at startup |

Also deployed on a local Kubernetes cluster, applying the chart-rendered manifest rather than a hand-written copy, which exercises the parts a bare container cannot:

- `deploy/maildev` reached `1/1` Ready, so `/maildev/healthz` genuinely answers 200 under `MAILDEV_BASE_PATHNAME`. That is the exact path the `HealthCheckPolicy` probes.
- Inbox returns 401 unauthenticated and 200 with the Secret's credentials; `/maildev/healthz` returns 200 with no credentials; every other path is gated, since maildev's basic-auth middleware runs ahead of routing.
- SMTP to the bare hostname `maildev` on 1025 over cluster DNS delivered, matching how the app pods resolve `EMAIL_HOST`.
- End to end with Django configured exactly as the chart configures it: `sendtestemail` and `send_mail(...)` to a real-looking address were captured by the pod rather than delivered, and read back through the authenticated API.

Against the pinned image directly: basic auth, the auth-exempt health path, relative asset resolution under the prefix and a real `101 Switching Protocols` upgrade at `/maildev/socket.io/` were all confirmed.

`pre-commit run` passes on all changed files.

## Not included

- A dedicated hostname for the inbox (would need a DNS record and a Certificate Manager certmap entry).
- Per-person authentication (SSO / oauth2-proxy) or IP allowlisting.
- Message retention across pod restarts; maildev holds messages in memory by design.

## Risks and considerations

Non-production email is now fail-closed. If the maildev pod is down, sends raise instead of being delivered, and Celery tasks that send mail will error or retry. That is the correct trade for QA, since nothing silently escapes to real users, but it is a behaviour change from "Mailgun always accepts".

The `maildev-auth` Secret is a manual out-of-band prerequisite that a reviewer cannot see in the diff. See Deploy notes.

## Known limitation

maildev applies basic auth as Express middleware, but its socket.io channel attaches to the raw HTTP server and bypasses that middleware, emitting full message payloads. The password gate deters casual access to the UI; it is not a security boundary for message contents. The URL should not be published. Accepted for a QA inbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional catch-all email routing for non-production environments.
  * Added Maildev deployment support for development and staging, including web and SMTP access.
  * Added configurable Maildev installation, version, and email timeout settings.
  * Added safeguards preventing catch-all email from being enabled in production.

* **Documentation**
  * Documented email routing, environment settings, Maildev usage, QA inbox access, and SMTP configuration.
  * Added guidance for enabling Maildev in additional environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->