### PR TITLE
Story 2551: Improve Library Subpage Layout

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2033,6 +2033,8 @@ class V3ComponentDemoView(V3Mixin, TemplateView):
                         {"label": "Boost.Example", "value": 1200},
                         {"label": "Alternative A", "value": 800},
                         {"label": "Alternative B", "value": 450},
+                        {"label": "Alternative C", "value": 300},
+                        {"label": "Alternative D", "value": 150},
                     ],
                 },
                 {
@@ -2041,6 +2043,8 @@ class V3ComponentDemoView(V3Mixin, TemplateView):
                     "data": [
                         {"label": "Boost.Example", "value": 12},
                         {"label": "Alternative A", "value": 30},
+                        {"label": "Alternative B", "value": 45},
+                        {"label": "Alternative C", "value": 60},
                     ],
                 },
             ]

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -41,7 +41,7 @@ def test_build_quick_start_links_validates_and_falls_back():
             "label": "Common use cases",
             "url": "https://www.boost.org/doc/libs/x/use.html",
         },
-        {"label": "Code examples", "url": docs},
+        {"label": "Code Examples", "url": docs},
     ]
 
 
@@ -99,7 +99,7 @@ def test_build_quick_start_links_no_adoc_links_uses_docs():
     docs = "/doc/libs/1_90_0/libs/x/index.html"
     assert _build_quick_start_links(docs, None) == [
         {"label": "Common use cases", "url": docs},
-        {"label": "Code examples", "url": docs},
+        {"label": "Code Examples", "url": docs},
     ]
 
 

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -85,7 +85,7 @@ def _is_boost_url(url):
 def _build_quick_start_links(documentation_url, links):
     """Build the Quick Start card links from website.adoc's [#links] section.
 
-    "Common use cases" and "Code examples" come from the maintainer's
+    "Common use cases" and "Code Examples" come from the maintainer's
     :common-use-case-url: / :code-example-url:. Each is used only if it is a
     valid Boost URL; otherwise it falls back to the documentation link.
     """

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -98,7 +98,7 @@ def _build_quick_start_links(documentation_url, links):
     if common_url:
         result.append({"label": "Common use cases", "url": common_url})
     if example_url:
-        result.append({"label": "Code examples", "url": example_url})
+        result.append({"label": "Code Examples", "url": example_url})
     return result
 
 

--- a/static/css/v3/card-group.css
+++ b/static/css/v3/card-group.css
@@ -26,27 +26,22 @@
 
 .card-group--default {
   background: var(--color-surface-weak);
-  border-color: var(--color-stroke-weak);
 }
 
 .card-group--card.card-group--default {
   background: var(--color-surface-mid);
-  border-color: var(--color-stroke-weak);
 }
 
 .card-group--yellow {
   background: var(--color-surface-weak-accent-yellow);
-  border-color: var(--color-accent-strong-yellow);
 }
 
 .card-group--green {
   background: var(--color-surface-weak-accent-green);
-  border-color: var(--color-accent-strong-green);
 }
 
 .card-group--teal {
   background: var(--color-surface-weak-accent-teal);
-  border-color: var(--color-accent-strong-teal);
 }
 
 /* ── Heading ───────────────────────────────── */
@@ -138,9 +133,6 @@
 
 /* ── Dark mode ─────────────────────────────── */
 html.dark {
-  .card-group {
-    border-color: var(--color-stroke-weak);
-  }
 
   .card-group--default {
     background: var(--color-primary-grey-850);

--- a/static/css/v3/code-block.css
+++ b/static/css/v3/code-block.css
@@ -8,10 +8,8 @@
 
 :root {
   --code-block-bg: var(--color-bg-secondary);
-  --code-block-border: var(--color-border);
   --code-block-text: var(--color-syntax-cpp-text);
   --code-block-bg-standalone: var(--color-primary-grey-100);
-  --code-block-border-standalone: var(--color-border);
   --code-block-bg-grey: var(--color-primary-grey-100);
   --code-block-copy-icon-size: var(--space-icon-copy);
   --code-block-copy-icon-color: var(--color-icon-secondary);
@@ -41,7 +39,7 @@
 
 .code-block--white-bg {
   background: var(--color-bg-secondary);
-  border: 1px solid var(--code-block-border);
+  border: 1px solid var(--color-stroke-weak);
 }
 
 .code-block--white-bg .code-block__copy {
@@ -77,6 +75,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  border: 1px solid var(--color-stroke-weak);
 }
 
 .code-block-card__body {
@@ -126,48 +125,25 @@
 
 .code-block-card--neutral {
   background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border);
 }
 
 .code-block-card--grey {
   background: var(--color-surface-mid);
-  border: 1px solid var(--color-border);
 }
 
 .code-block-card--teal {
   background: var(--color-surface-weak-accent-teal);
-  border: 1px solid var(--color-accent-strong-teal);
 }
 
 .code-block-card--yellow {
   background: var(--color-surface-weak-accent-yellow);
-  border: 1px solid var(--color-accent-strong-yellow);
 }
 
 .code-block-card--green {
   background: var(--color-surface-weak-accent-green);
-  border: 1px solid var(--color-accent-strong-green);
 }
 
-html.dark .code-block-card--teal {
-  background: var(--color-surface-weak-accent-teal);
-  border: 0;
-}
 
-html.dark .code-block-card--yellow {
-  background: var(--color-surface-weak-accent-yellow);
-  border: 0;
-}
-
-html.dark .code-block-card--green {
-  background: var(--color-surface-weak-accent-green);
-  border: 0;
-}
-
-html.dark .code-block-card--grey {
-  background: var(--color-surface-mid);
-  border: 0;
-}
 
 .code-block-card__heading {
   margin: 0;
@@ -185,7 +161,7 @@ html.dark .code-block-card--grey {
 }
 
 .code-block-card__body:has(.code-block-card__description) {
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-stroke-weak);
 }
 
 .code-block__inner {

--- a/static/css/v3/code-block.css
+++ b/static/css/v3/code-block.css
@@ -1,3 +1,11 @@
+/*
+  Code Block & Code Block Card
+
+  A code sample with copy button and syntax highlighting, plus the card that
+  wraps it: heading, then .code-block-card__body (scroll region owning the
+  divider) holding the description and code, then an optional CTA.
+*/
+
 :root {
   --code-block-bg: var(--color-bg-secondary);
   --code-block-border: var(--color-border);

--- a/static/css/v3/code-block.css
+++ b/static/css/v3/code-block.css
@@ -71,6 +71,13 @@
   flex-direction: column;
 }
 
+.code-block-card__body {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .code-block-card .code-block {
   margin: 0 var(--space-card);
   overflow: hidden;
@@ -169,7 +176,7 @@ html.dark .code-block-card--grey {
   color: var(--color-text-secondary);
 }
 
-.code-block-card .code-block-card__description {
+.code-block-card__body:has(.code-block-card__description) {
   border-top: 1px solid var(--color-border);
 }
 

--- a/static/css/v3/contributors-list.css
+++ b/static/css/v3/contributors-list.css
@@ -2,9 +2,14 @@
     margin: 0;
 }
 
+.contributors-list__body {
+    width: 100%;
+    min-height: 0;
+    overflow-y: auto;
+}
+
 .contributors-list .card__column {
     gap: var(--space-medium);
-    overflow-y: auto;
 }
 
 .contributors-list.all-contributors {
@@ -20,7 +25,6 @@
 @media (max-width: 768px) {
     .contributors-list.all-contributors .card__column {
         grid-template-columns: 1fr;
-        overflow-y: auto;
     }
 
     .contributors-list {

--- a/static/css/v3/contributors-list.css
+++ b/static/css/v3/contributors-list.css
@@ -1,3 +1,11 @@
+/*
+  Contributors List
+
+  Card listing contributors as .user-profile rows inside .contributors-list__body
+  (the scroll region). Release variant is a single column; .all-contributors is a
+  responsive grid.
+*/
+
 .contributors-list :is(h2, h3, h4, h5, h6) {
     margin: 0;
 }

--- a/static/css/v3/forms.css
+++ b/static/css/v3/forms.css
@@ -394,7 +394,7 @@
   max-height: 280px;
   overflow-y: auto;
   scrollbar-width: thin;
-  scrollbar-color: var(--color-icon-primary) var(--color-surface-strong);
+  scrollbar-color: var(--color-stroke-mid) var(--color-surface-strong);
 }
 
 .dropdown__item {

--- a/static/css/v3/foundations.css
+++ b/static/css/v3/foundations.css
@@ -20,6 +20,21 @@ body.v3 * {
   scrollbar-color: var(--color-primary-grey-500) transparent;
 }
 
+/* Scroll regions inside the page keep their scrollbar hidden until hovered or
+   focused. Only the colours change — `scrollbar-width: thin` above still
+   reserves the gutter, so revealing a scrollbar never reflows content.
+   Scoped to `body.v3 *` so the document's own scrollbar stays visible, and to
+   hover-capable pointers, since touch has no hover to reveal it with. */
+@media (hover: hover) {
+  body.v3 * {
+    scrollbar-color: transparent transparent;
+  }
+
+  body.v3 *:is(:hover, :focus, :focus-within) {
+    scrollbar-color: var(--color-primary-grey-500) transparent;
+  }
+}
+
 /* Reserve the scrollbar gutter so dialog scroll-lock doesn't reflow the page. */
 html.v3 {
   scrollbar-gutter: stable;

--- a/static/css/v3/foundations.css
+++ b/static/css/v3/foundations.css
@@ -17,7 +17,7 @@ body.v3,
 html.v3 *,
 body.v3 * {
   scrollbar-width: thin;
-  scrollbar-color: var(--color-primary-grey-500) transparent;
+  scrollbar-color: var(--color-stroke-mid) var(--color-surface-strong);
 }
 
 /* Scroll regions inside the page keep their scrollbar hidden until hovered or
@@ -31,7 +31,7 @@ body.v3 * {
   }
 
   body.v3 *:is(:hover, :focus, :focus-within) {
-    scrollbar-color: var(--color-primary-grey-500) transparent;
+    scrollbar-color: var(--color-stroke-mid) var(--color-surface-strong);
   }
 }
 

--- a/static/css/v3/header.css
+++ b/static/css/v3/header.css
@@ -366,7 +366,7 @@ html.dark .header__icon--theme-moon {
   max-height: calc(var(--dropdown-item-height) * 7); /* Show up to 7 items, then scroll */
   overflow-y: auto;
   scrollbar-width: thin;
-  scrollbar-color: var(--color-icon-primary) var(--color-surface-strong);
+  scrollbar-color: var(--color-stroke-mid) var(--color-surface-strong) !important;
 }
 
 .header__version-dropdown .header__version-option {

--- a/static/css/v3/library-intro-card.css
+++ b/static/css/v3/library-intro-card.css
@@ -69,6 +69,7 @@
   overflow-y: auto;
   /* ≈ 3 rows × 80px (48px avatar + 2 × 16px padding) + 2 × 1px hr separators */
   max-height: 242px;
+  scrollbar-color: var(--color-stroke-mid) var(--color-surface-strong);
 }
 
 .library-intro-card__authors:focus-visible {

--- a/static/css/v3/library-intro-card.css
+++ b/static/css/v3/library-intro-card.css
@@ -69,7 +69,6 @@
   overflow-y: auto;
   /* ≈ 3 rows × 80px (48px avatar + 2 × 16px padding) + 2 × 1px hr separators */
   max-height: 242px;
-  scrollbar-color: var(--color-icon-primary) var(--color-surface-strong);
 }
 
 .library-intro-card__authors:focus-visible {

--- a/static/css/v3/library-subpage.css
+++ b/static/css/v3/library-subpage.css
@@ -101,9 +101,49 @@ body:has(.is_flagship) .library-subpage-container {
   flex-direction: column;
 }
 
-.library-subpage__documentation > .markdown-card .markdown-content {
-  min-height: 0;
+/* .markdown-card__body already scrolls and shrinks (markdown-card.css). */
+
+/* About + Install cards: the body (blurb + code sample) is capped and scrolls as
+   one region, so heading, divider and CTA stay in place. */
+.card-masonry-top .item-a { --subpage-code-body-max: 450px; }  /* About */
+.card-masonry-top .item-c { --subpage-code-body-max: 214px; }  /* Install */
+
+.card-masonry-top .item-a .code-block-card__body,
+.card-masonry-top .item-c .code-block-card__body {
+  max-height: var(--subpage-code-body-max);
   overflow-y: auto;
+}
+
+.card-masonry-top .item-a .code-block,
+.card-masonry-top .item-c .code-block {
+  flex: 0 0 auto;
+}
+
+.card-masonry-top .item-a .code-block__scroll-container,
+.card-masonry-top .item-c .code-block__scroll-container {
+  max-height: none;
+  overflow: visible;
+}
+
+/* Benchmarks card */
+.card-masonry-top .item-g .stats__body {
+  max-height: 362px;
+  overflow-y: auto;
+}
+
+/* Contributors: This Release */
+.card-masonry-top .item-d .contributors-list__body {
+  max-height: 408px;
+}
+
+/* Designed for card */
+.card-masonry-top .item-f .markdown-card__body {
+  max-height: 245px;
+}
+
+/* Freeform card */
+.library-subpage__freeform > .markdown-card .markdown-card__body {
+  max-height: 143px;
 }
 
 /* ── Mobile (< 768px): tighter padding, stack the bottom row ─────────────── */

--- a/static/css/v3/library-subpage.css
+++ b/static/css/v3/library-subpage.css
@@ -1,14 +1,11 @@
 /*
   Library Subpage layout.
 
-  .card-masonry-top: CSS multi-column masonry. Cards flow and pack into as many
-  columns as fit (column-width var(--subpage-col-min)), so the layout auto-
-  rearranges 3 → 2 → 1 columns by available width — no strict breakpoints, no
-  grid row-stretching gaps. Reading order flows down each column, then across.
+  .card-masonry-top: CSS multi-column, so cards pack into as many columns as fit
+  (3 → 2 → 1 by width) with no strict breakpoints and no grid row-stretching
+  gaps. Reading order runs down each column, then across.
 
-  .card-masonry-bottom: posts 2/3 + mailing list 1/3 (grid), stacking on mobile.
-
-  All widths, gaps, and spacing derive from design tokens.
+  .card-masonry-bottom: posts 2/3 + mailing list 1/3, stacking on mobile.
 */
 
 /* ── Page wrapper ─────────────────────────────────────────────────────────── */
@@ -20,7 +17,6 @@
   width: 100%;
 }
 
-/* Outer container with page-level centering */
 .library-subpage-container {
   display: flex;
   flex-direction: column;
@@ -38,16 +34,14 @@ body:has(.is_flagship) .library-subpage-container {
 
 /* ── Top card masonry ────────────────────────────────────────────────────── */
 
-/* Multi-column masonry: cards pack into as many columns as fit at this width.
-   --subpage-col-min is the target column width — with the 1440px container and
-   16px gaps it yields 3 columns on desktop, 2 on tablet, 1 on mobile. */
+/* --subpage-col-min is hand-picked: with the 1440px container and 16px gaps it
+   yields 3 columns on desktop, 2 on tablet, 1 on mobile. */
 .card-masonry-top {
-  --subpage-col-min: 22rem; /* Hand-picked value that accommodates 3->2->1 column flow at desktop->tablet->mobile breakpoints. */
+  --subpage-col-min: 22rem;
   columns: var(--subpage-col-min);
   column-gap: var(--space-card);
 }
 
-/* Keep each card whole within a column and space stacked cards vertically. */
 .card-masonry-top > * {
   break-inside: avoid;
   margin-bottom: var(--space-card);
@@ -88,8 +82,7 @@ body:has(.is_flagship) .library-subpage-container {
   width: 100%;
 }
 
-/* Benchmark card sizes like the other cards: fill the column width, grow to
-   fit its content (override the component's fixed 460px / 420px cap). */
+/* Override the component's fixed height so it sizes like the other cards. */
 .card-masonry-top .stats--benchmarks {
   height: auto;
   max-height: none;
@@ -101,10 +94,10 @@ body:has(.is_flagship) .library-subpage-container {
   flex-direction: column;
 }
 
-/* .markdown-card__body already scrolls and shrinks (markdown-card.css). */
+/* ── Card body scroll caps ───────────────────────────────────────────────── */
 
-/* About + Install cards: the body (blurb + code sample) is capped and scrolls as
-   one region, so heading, divider and CTA stay in place. */
+/* Each card caps its body — the region below the title — so one long card can't
+   dominate a column. Titles, dividers and CTAs stay put. */
 .card-masonry-top .item-a { --subpage-code-body-max: 450px; }  /* About */
 .card-masonry-top .item-c { --subpage-code-body-max: 214px; }  /* Install */
 
@@ -114,6 +107,8 @@ body:has(.is_flagship) .library-subpage-container {
   overflow-y: auto;
 }
 
+/* Body is the only scroll region: let the code block grow to its full height
+   instead of flexing down into its own nested scroller. */
 .card-masonry-top .item-a .code-block,
 .card-masonry-top .item-c .code-block {
   flex: 0 0 auto;
@@ -125,7 +120,7 @@ body:has(.is_flagship) .library-subpage-container {
   overflow: visible;
 }
 
-/* Benchmarks card */
+/* Benchmarks */
 .card-masonry-top .item-g .stats__body {
   max-height: 362px;
   overflow-y: auto;
@@ -136,12 +131,12 @@ body:has(.is_flagship) .library-subpage-container {
   max-height: 408px;
 }
 
-/* Designed for card */
+/* Designed for */
 .card-masonry-top .item-f .markdown-card__body {
   max-height: 245px;
 }
 
-/* Freeform card */
+/* Freeform */
 .library-subpage__freeform > .markdown-card .markdown-card__body {
   max-height: 143px;
 }

--- a/static/css/v3/library-subpage.css
+++ b/static/css/v3/library-subpage.css
@@ -75,6 +75,7 @@ body:has(.is_flagship) .library-subpage-container {
 .card-masonry-bottom > div > .basic-card,
 .card-masonry-bottom > div > .card-group,
 .card-masonry-bottom > div > .post-card,
+.card-masonry-bottom > div > [data-ml-block] > .card,
 .library-subpage__documentation > .markdown-card,
 .library-subpage__freeform > .markdown-card,
 .library-subpage__all-contributors > .contributors-list {

--- a/static/css/v3/mailing-list-card.css
+++ b/static/css/v3/mailing-list-card.css
@@ -19,7 +19,7 @@
   padding: var(--space-default);
   border-radius: var(--border-radius-s);
   background-color: var(--color-surface-brand-accent-default);
-  color: var(--color-text-primary);
+  color: var(--color-text-on-accent);
   font-family: var(--font-sans);
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-regular);

--- a/static/css/v3/markdown-card.css
+++ b/static/css/v3/markdown-card.css
@@ -1,3 +1,11 @@
+/*
+  Markdown Card
+
+  Card for rendered markdown or HTML: title, then .markdown-card__body — the
+  scroll region owning the top divider — wrapping the .markdown-content text
+  area, then an optional CTA. Pages cap the body to bound the card's height.
+*/
+
 .card__column.markdown-content {
     gap: var(--space-medium);
     line-height: var(--line-height-code);

--- a/static/css/v3/markdown-card.css
+++ b/static/css/v3/markdown-card.css
@@ -36,13 +36,19 @@
     text-underline-position: from-font;
 }
 
+.markdown-card__body {
+    width: 100%;
+    min-height: 0;
+    overflow-y: auto;
+    border-top: 1px solid var(--color-stroke-weak);
+}
+
 .markdown-content {
     color: var(--color-text-secondary);
-    padding: 0 var(--space-large);
+    padding: var(--space-card) var(--space-large) 0;
     font-size: var(--font-size-small);
     font-weight: var(--font-weight-regular);
     letter-spacing: var(--letter-spacing-tight);
-    overflow-y: auto;
     overflow-wrap: anywhere;
     min-width: 0;
 }

--- a/static/css/v3/stats.css
+++ b/static/css/v3/stats.css
@@ -1,3 +1,11 @@
+/*
+  Stats
+
+  Bar-chart cards in two variants: .stats--benchmarks (labelled bar rows grouped
+  into .stats__set blocks inside the .stats__body scroll region) and
+  .stats--in-numbers (vertical bars sized to the container).
+*/
+
 .stats {
   --stats-space: var(--space-large);
   font-family: var(--font-sans);

--- a/static/css/v3/stats.css
+++ b/static/css/v3/stats.css
@@ -21,22 +21,18 @@
 
 .stats--default {
   background: var(--color-bg-secondary);
-  border-color: var(--color-stroke-weak);
 }
 
 .stats--yellow {
   background: var(--color-surface-weak-accent-yellow);
-  border-color: var(--color-accent-strong-yellow);
 }
 
 .stats--green {
   background: var(--color-surface-weak-accent-green);
-  border-color: var(--color-accent-strong-green);
 }
 
 .stats--teal {
   background: var(--color-surface-weak-accent-teal);
-  border-color: var(--color-accent-strong-teal);
 }
 
 .stats--yellow .stats__bar,
@@ -61,7 +57,7 @@
   font-size: var(--font-size-large);
   font-weight: var(--font-weight-medium);
   line-height: var(--line-height-tight);
-  letter-spacing: -0.24px;
+  letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
 }
 

--- a/static/css/v3/stats.css
+++ b/static/css/v3/stats.css
@@ -215,7 +215,7 @@
 }
 
 .stats__set-bar {
-  height: var(--stats-space);
+  height: 24px;
   background: var(--color-surface-strong);
   border-radius: var(--border-radius-xs);
   flex-shrink: 0;

--- a/static/css/v3/stats.css
+++ b/static/css/v3/stats.css
@@ -181,7 +181,7 @@
   font-size: var(--font-size-small);
   font-weight: var(--font-weight-medium);
   line-height: var(--line-height-relaxed);
-  letter-spacing: -0.14px;
+  letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
 }
 
@@ -205,7 +205,7 @@
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-regular);
   line-height: var(--line-height-default);
-  letter-spacing: -0.12px;
+  letter-spacing: var(--letter-spacing-tight);
   color: var(--color-text-primary);
   min-width: 0;
 }

--- a/static/css/v3/v3-examples-section.css
+++ b/static/css/v3/v3-examples-section.css
@@ -292,6 +292,11 @@ html.dark .v3-examples-section__toc {
   overflow-x: auto;
 }
 
+/* Fixed-width benchmark cards must scroll, not shrink, in the row above. */
+.v3-examples-section-horizontal-container .stats--benchmarks {
+  flex-shrink: 0;
+}
+
 /* ── V3 Paths Registry table ──────────────────── */
 
 .v3-examples-section__registry-table {

--- a/static/css/v3/v3-examples-section.css
+++ b/static/css/v3/v3-examples-section.css
@@ -60,7 +60,7 @@
 }
 
 html.dark .v3-examples-section__example-box {
-  background: var(--color-surface-mid);
+  background: transparent;
 }
 
 .v3-examples-section__tools {
@@ -255,7 +255,7 @@ html.dark .v3-examples-section__example-box {
 }
 
 html.dark .v3-examples-section__toc {
-  background: var(--color-surface-mid);
+  background: transparent;
 }
 
 .v3-examples-section__toc-heading {

--- a/templates/v3/examples/_v3_example_section.html
+++ b/templates/v3/examples/_v3_example_section.html
@@ -418,6 +418,22 @@
     {% endwith %}
   {% endif %}
 
+  {% comment %}
+    Benchmarks — the library subpage maps website.adoc's [#benchmarks] charts to
+    the _stats_benchmarks `sets` shape (bar width_pct normalized per chart).
+  {% endcomment %}
+  {% with section_title="Benchmarks Card — themes: default, teal, yellow, green" %}
+    <div class="v3-examples-section__block" id="{{ section_title|slugify }}">
+      <h3>{{ section_title }}</h3>
+      <div class="v3-examples-section__example-box v3-examples-section-horizontal-container">
+        {% include "v3/includes/_stats_benchmarks.html" with heading="Benchmarks" sets=benchmark_demo_sets %}
+        {% include "v3/includes/_stats_benchmarks.html" with heading="Benchmarks" sets=benchmark_demo_sets theme="teal" %}
+        {% include "v3/includes/_stats_benchmarks.html" with heading="Benchmarks" sets=benchmark_demo_sets theme="yellow" %}
+        {% include "v3/includes/_stats_benchmarks.html" with heading="Benchmarks" sets=benchmark_demo_sets theme="green" %}
+      </div>
+    </div>
+  {% endwith %}
+
   {% include "v3/examples/_v3_example_section_wysiwyg.html" %}
 
   {% with section_title="Badges Card (empty with CTA)" %}
@@ -648,17 +664,6 @@
     <div class="v3-examples-section__block" id="{{ section_title|slugify }}">
       <h3>{{ section_title }}</h3>
       <div class="v3-examples-section__example-box">{% include "v3/includes/_markdown_card.html" with title="This library is designed for" html=designed_for_demo_html %}</div>
-    </div>
-  {% endwith %}
-
-  {% comment %}
-    Benchmarks — the library subpage maps website.adoc's [#benchmarks] charts to
-    the _stats_benchmarks `sets` shape (bar width_pct normalized per chart).
-  {% endcomment %}
-  {% with section_title="Benchmarks Card" %}
-    <div class="v3-examples-section__block" id="{{ section_title|slugify }}">
-      <h3>{{ section_title }}</h3>
-      <div class="v3-examples-section__example-box">{% include "v3/includes/_stats_benchmarks.html" with heading="Benchmarks" sets=benchmark_demo_sets theme="green" %}</div>
     </div>
   {% endwith %}
 

--- a/templates/v3/includes/_code_block_card.html
+++ b/templates/v3/includes/_code_block_card.html
@@ -15,8 +15,10 @@
 {% endcomment %}
 <div class="code-block-card code-block-card--{{ card_variant|default:'neutral' }}">
   <h2 class="card__title code-block-card__heading">{{ heading }}</h2>
-  {% if description %}<p class="code-block-card__description">{{ description }}</p>{% endif %}
-  {% if code or code_html %}{% include "v3/includes/_code_block.html" with code=code code_html=code_html language=language variant=block_variant|default:"grey-bg" %}{% endif %}
+  <div class="code-block-card__body">
+    {% if description %}<p class="code-block-card__description">{{ description }}</p>{% endif %}
+    {% if code or code_html %}{% include "v3/includes/_code_block.html" with code=code code_html=code_html language=language variant=block_variant|default:"grey-bg" %}{% endif %}
+  </div>
   {% if button_text %}
     <div class="card__cta_section">
       {% include "v3/includes/_button.html" with label=button_text url=button_url|default:'#' aria_label=button_aria_label|default:button_text style=button_style %}

--- a/templates/v3/includes/_contributors_list.html
+++ b/templates/v3/includes/_contributors_list.html
@@ -27,9 +27,11 @@
     {% endif %}
   </div>
   <hr class="card__hr" />
-  <div class="card__column px-large">
-    {% for contributor in contributors %}
-        {% include "v3/includes/_user_profile.html" with author=contributor only %}
-    {% endfor %}
+  <div class="contributors-list__body">
+    <div class="card__column px-large">
+      {% for contributor in contributors %}
+          {% include "v3/includes/_user_profile.html" with author=contributor only %}
+      {% endfor %}
+    </div>
   </div>
 </div>

--- a/templates/v3/includes/_markdown_card.html
+++ b/templates/v3/includes/_markdown_card.html
@@ -12,9 +12,10 @@
   <div class="card__header">
     <span class="card__title">{{ title }}</span>
   </div>
-  <hr class="card__hr" aria-hidden="true" />
-  <div class="card__column markdown-content">
-    {% if html %}{{ html|safe }}{% else %}{{ markdown|markdown }}{% endif %}
+  <div class="markdown-card__body">
+    <div class="card__column markdown-content">
+      {% if html %}{{ html|safe }}{% else %}{{ markdown|markdown }}{% endif %}
+    </div>
   </div>
   {% if button_url and button_label %}
   <hr class="card__hr" aria-hidden="true" />

--- a/templates/v3/includes/_stats_benchmarks.html
+++ b/templates/v3/includes/_stats_benchmarks.html
@@ -15,20 +15,22 @@
 <section class="stats stats--benchmarks {% if sized_by_parent %}stats--fill {% endif %}stats--{{ theme|default:'default' }}" aria-labelledby="stats-benchmarks-heading-{{ theme|default:'default' }}">
   <h2 id="stats-benchmarks-heading-{{ theme|default:'default' }}" class="stats__heading">{{ heading }}</h2>
   <hr class="stats__separator" aria-hidden>
-  {% for set in sets %}
-  <div class="stats__set">
-    <p class="stats__set-title">{{ set.title }}</p>
-    <div class="stats__set-rows">
-      {% for row in set.rows %}
-      <div class="stats__set-row">
-        <p class="stats__set-label">{{ row.label }}</p>
-        <div class="stats__set-bar-wrap">
-          <div class="stats__set-bar" style="width: {{ row.width_pct }}%;" role="presentation"></div>
+  <div class="stats__body">
+    {% for set in sets %}
+    <div class="stats__set">
+      <p class="stats__set-title">{{ set.title }}</p>
+      <div class="stats__set-rows">
+        {% for row in set.rows %}
+        <div class="stats__set-row">
+          <p class="stats__set-label">{{ row.label }}</p>
+          <div class="stats__set-bar-wrap">
+            <div class="stats__set-bar" style="width: {{ row.width_pct }}%;" role="presentation"></div>
+          </div>
         </div>
+        {% endfor %}
       </div>
-      {% endfor %}
     </div>
+    {% endfor %}
   </div>
-  {% endfor %}
 </section>
 {% if sized_by_parent %}</div>{% endif %}

--- a/templates/v3/libraries/library-subpage.html
+++ b/templates/v3/libraries/library-subpage.html
@@ -29,7 +29,7 @@
     <div class="card-masonry-top">
       {% if website_adoc.about %}
       <div class="item-a">
-        {% include "v3/includes/_code_block_card.html" with heading="About "|add:object.display_name description=website_adoc.about.blurb code=website_adoc.about.code.code language=website_adoc.about.code.language card_variant="neutral" button_text="Explore examples" button_url=documentation_url|default:"#" button_aria_label="Explore examples for "|add:object.display_name %}
+        {% include "v3/includes/_code_block_card.html" with heading="About "|add:object.display_name description=website_adoc.about.blurb code=website_adoc.about.code.code language=website_adoc.about.code.language|default:"cpp" %}
       </div>
       {% endif %}
 


### PR DESCRIPTION
# Issue: #2551 

⚠️ This PR is branched off from [Story 2430: Library Subpage Integration](https://github.com/boostorg/website-v2/pull/2524) ⚠️ 

## Summary & Context
This PR improves the grid layout of the Library subpage by capping the height of each card body and making the scroll region the card body rather than the text area inside it. Also settles card strokes on one neutral colour across themes and dark mode.

- **Figma link**: 
  1. [Library Subpage](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1651-41094&m=dev)
  2. [Benchmark cards](https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=411-6288&m=dev)
  3. [Event Cards](https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=55-596&m=dev)
  4. [Post Cards](https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=55-448&m=dev) 
- **Link to components/page**:
  1. Any library subpage that you choose to test – please see the Peer Reviews section below (e.g. http://localhost:8000/library/1.90.0/beast/ )
  5. http://localhost:8000/v3/demo/components/#benchmarks-card-themes-default-teal-yellow-green (newly added)
  6. http://localhost:8000/v3/demo/components/#event-cards-card-variants-with-different-themes (only border color changed)
  7. http://localhost:8000/v3/demo/components/#post-cards-card-variant-with-different-themes-default-teal-yellow-green (only border color changed)

## Changes
**Card body height and scroll region**
- Add a body wrapper with `overflow-y: auto` to each card so everything below the title scrolls as one region, leaving the title, divider and CTA fixed
- Cap each body: About 450px, Contributors 440px, Benchmarks 362px, Designed for 245px, Install 214px, Freeform 143px
- Keep the About and Install code blocks at full height so they don't become nested scrollers
- Fix the mailing list card so it fills its column – its root sits under an extra `[data-ml-block]` Alpine wrapper the max-width override list didn't reach

**Benchmark Cards**
- Add more colored variants to the V3 Demo page

**Card strokes**
- Every themed card now uses the neutral `--color-stroke-weak` (`code-block.css`, `card-group.css`, `stats.css`); removes the redundant `html.dark` rules and the unused `--code-block-border` tokens
- Dark mode: transparent example box and TOC backgrounds in `v3-examples-section.css`; mailing list badge text switched to `--color-text-on-accent`

**Tokens and docs**
- Top-of-file docs added to four CSS files
- `--letter-spacing-tight` replaces hardcoded values in `stats.css`; 

## ‼️ Risks & Considerations ‼️
- **The four card components are shared**, so this reaches the Documentation card, the Release notes card in `release-detail.css`, markdown cards with a CTA on user profiles, and the components demo page
- The mailing list override depends on `[data-ml-block]` staying on the Alpine wrapper

## Peer Testing Review

1. Please follow the set up as in [Story 2430: Library Subpage Integration](https://github.com/boostorg/website-v2/pull/2524)
2. Once loaded the `website-adoc` demo content into a library, you can visit Admin Panel to update the content to test how the UI respond when there are more or less content (and how the card will handle overflow) 
<img width="936" height="354" alt="Screenshot 2026-07-28 at 5 03 20 PM" src="https://github.com/user-attachments/assets/140295f0-d1c6-41ab-bf58-5da8e73c4b2e" />

## Screenshots

Before | After | Notes
-- | -- | --
<img width="3818" height="8204" alt="page before" src="https://github.com/user-attachments/assets/2d29ece0-43d6-4f78-ae02-17c4ca281bc0" /> | <img width="3818" height="7668" alt="page after" src="https://github.com/user-attachments/assets/f70287b9-18a3-41a4-83e2-fa82837ccb13" /> | Full page comparison, main difference is with the new max-height restrictions
<img width="492" height="234" alt="Screenshot 2026-07-28 at 4 51 52 PM" src="https://github.com/user-attachments/assets/b2508e7a-66e1-4fdc-bb98-4fb753a87230" /> | <img width="974" height="476" alt="image" src="https://github.com/user-attachments/assets/2da340cd-3993-40fe-8896-314eba1d1707" /> | Text color token used in the badge was updated so that the dark mode is correctly applied. This component is also now full-width on mobile view.
<img width="478" height="465" alt="Screenshot 2026-07-28 at 4 53 20 PM" src="https://github.com/user-attachments/assets/4fcb766d-2453-42f6-94f7-7d75b0f246b8" /> |<img width="478" height="444" alt="Screenshot 2026-07-28 at 4 52 47 PM" src="https://github.com/user-attachments/assets/c5cb5e64-db2b-49c9-b8fa-ad323f832959" /> | For all of the cards that have accent colors, the border is now `--stroke-weak` (instead of yellow, green, etc) to correctly match Figma


## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added benchmark examples for default, teal, yellow, and green themes.
  - Expanded demo benchmark data for throughput and latency.
  - Improved scrolling behavior for contributor, Markdown, code, and card content areas.

- **Bug Fixes**
  - Standardized scrollbar appearance and visibility across supported components and modes.
  - Improved card borders, spacing, sizing, and dark-mode presentation.
  - Corrected mailing-list badge contrast and benchmark layout behavior.

- **Documentation**
  - Updated Quick Start link text to “Code Examples.”
  - Improved component layout documentation and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->