### PR TITLE
Mailing list: security check

### DIFF
--- a/mailing_list/views.py
+++ b/mailing_list/views.py
@@ -223,14 +223,14 @@ class SubscribeView(LoginRequiredMixin, View):
                 unsubscribed.append(list_id)
                 continue
             try:
-                MailmanClient().unsubscribe(email, list_id)
+                MailmanClient().unsubscribe(sub.email, list_id)
                 UserMailingListSubscription.objects.filter(
                     user=request.user, list_id=list_id
                 ).delete()
                 unsubscribed.append(list_id)
             except MailmanAPIError as exc:
                 logger.error(
-                    "Mailman unsubscribe error for %s/%s: %s", email, list_id, exc
+                    "Mailman unsubscribe error for %s/%s: %s", sub.email, list_id, exc
                 )
                 errors.append(list_id)
 


### PR DESCRIPTION
I asked Claude to run a security check on mailman features, just to be overly safe. It found one small thing, nearly trivial, but we should still update it, since even if this is part of a staff-only demo, it seems this api is publicly reachable, meaning from code inspection someone could discover it.

Fix: unsubscribe using the stored subscription email, not request input

SubscribeView computed which lists to unsubscribe from the logged-in user's own records, but then called the Mailman API with the email address taken directly from the POST body. Because Mailman removes whatever address it's given, an authenticated user with a single confirmed subscription could unsubscribe an arbitrary third party from a list by submitting someone else's email — no ownership check and no confirmation step.

This change makes the unsubscribe call use sub.email (the address stored on the user's own subscription record) instead of the request-supplied email, so a user can only ever remove their own subscription. This matches the pattern already used by ModalSubscribeView. The change is limited to the two references in the unsubscribe branch (the API call and the log line); the rest of the subscribe/confirm flow is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authenticated unsubscribe requests to consistently use the email address associated with the existing subscription.
  * Improved error reporting for unsubscribe failures by logging the correct email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->