### PR TITLE
Story #2576 :: Task: Wire the Library Authoring achievement to library authors

### DIFF
--- a/badges/sources.py
+++ b/badges/sources.py
@@ -21,6 +21,15 @@ All three can still be granted by hand in the admin.
 from badges.enums import AchievementSlug
 
 
+def _iter_library_authoring():
+    """Yield (user, library) for every library authorship."""
+    from libraries.models import Library
+
+    for library in Library.objects.prefetch_related("authors").iterator(chunk_size=500):
+        for user in library.authors.all():
+            yield user, library
+
+
 def _iter_code_commits():
     """Yield (user, commit) for every attributed commit."""
     from libraries.models import Commit
@@ -35,6 +44,7 @@ def _iter_code_commits():
 
 
 BACKFILL_ITERATORS = {
+    AchievementSlug.LIBRARY_AUTHORING: _iter_library_authoring,
     AchievementSlug.CODE_COMMITS: _iter_code_commits,
 }
 

--- a/badges/sources.py
+++ b/badges/sources.py
@@ -16,16 +16,26 @@ per-record, per-user source for them here:
   against the current models would not survive it.
 
 All three can still be granted by hand in the admin.
+
+Sub-libraries (``math/quaternion``, ``functional/hash``, and the rest of
+``SUB_LIBRARIES``) are excluded from every library-shaped source. They are
+subdivisions of a parent library's documentation rather than libraries of their
+own, so only the parent counts, and authorship of a sub-library alone earns
+nothing here. Recognising that work would take a badge of its own.
 """
 
 from badges.enums import AchievementSlug
+from libraries.constants import SUB_LIBRARIES
 
 
 def _iter_library_authoring():
-    """Yield (user, library) for every library authorship."""
+    """Yield (user, library) for every authorship of a parent library."""
     from libraries.models import Library
 
-    for library in Library.objects.prefetch_related("authors").iterator(chunk_size=500):
+    libraries = Library.objects.exclude(key__in=SUB_LIBRARIES).prefetch_related(
+        "authors"
+    )
+    for library in libraries.iterator(chunk_size=500):
         for user in library.authors.all():
             yield user, library
 

--- a/badges/tests/test_commands.py
+++ b/badges/tests/test_commands.py
@@ -73,12 +73,38 @@ def test_backfill_skips_recalculation_without_new_rows(plain_user):
     assert not UserBadge.objects.exists()
 
 
+def test_backfill_library_authoring(plain_user):
+    """Backfill grants the authoring achievement from Library authors."""
+    library = baker.make("libraries.Library")
+    library.authors.add(plain_user)  # M2M only - no live signal grants it
+
+    call_command("backfill_achievements", "--source", "library-authoring")
+
+    assert UserBadge.objects.filter(
+        user=plain_user, badge__achievement__slug="library-authoring"
+    ).exists()
+
+
 def test_backfill_fails_loudly_on_an_explicit_unseeded_source(plain_user):
     """A named source with no Achievement row is a deploy bug, not a skip."""
     Achievement.objects.filter(slug=AchievementSlug.CODE_COMMITS).delete()
 
     with pytest.raises(CommandError, match="code-commits"):
         call_command("backfill_achievements", "--source", "code-commits")
+
+
+def test_backfill_skips_an_unseeded_source_on_a_full_run(plain_user, capsys):
+    """A scheduled sweep must not lose every other source to one missing row."""
+    library = baker.make("libraries.Library")
+    library.authors.add(plain_user)
+    Achievement.objects.filter(slug=AchievementSlug.CODE_COMMITS).delete()
+
+    call_command("backfill_achievements")
+
+    assert "code-commits" in capsys.readouterr().err
+    assert UserBadge.objects.filter(
+        user=plain_user, badge__achievement__slug="library-authoring"
+    ).exists()
 
 
 def test_backfill_fails_when_no_source_is_seeded(plain_user):
@@ -293,6 +319,25 @@ def test_reconcile_rejects_an_unknown_member(plain_user):
     """A typo in ``--user`` must not silently widen the run to everybody."""
     with pytest.raises(CommandError, match=re.escape("nobody@example.com")):
         call_command("reconcile_achievements", "--user", "nobody@example.com")
+
+
+def test_reconcile_scopes_to_the_named_source(
+    plain_user, commit_by_someone_else, stale_commit_grant
+):
+    """``--source`` must not walk, or prune, a source it was not given."""
+    library = baker.make("libraries.Library")
+    library.authors.add(plain_user)
+    call_command("backfill_achievements", "--source", "library-authoring")
+    library.authors.remove(plain_user)
+
+    call_command("reconcile_achievements", "--source", "code-commits")
+
+    assert not UserAchievement.objects.filter(
+        user=plain_user, achievement__slug="code-commits"
+    ).exists()
+    assert UserAchievement.objects.filter(
+        user=plain_user, achievement__slug="library-authoring"
+    ).exists()
 
 
 def test_reconcile_refuses_a_source_that_yields_nothing(

--- a/badges/tests/test_sources.py
+++ b/badges/tests/test_sources.py
@@ -46,6 +46,14 @@ def test_an_automatic_grant_is_idempotent(plain_user):
     )
 
 
+def test_iter_library_authoring(plain_user):
+    """The authoring iterator yields each (author, library) pair."""
+    library = baker.make("libraries.Library")
+    library.authors.add(plain_user)
+    pairs = list(sources._iter_library_authoring())
+    assert (plain_user, library) in pairs
+
+
 def test_iter_code_commits_skips_unlinked(plain_user):
     """Only commits whose author has a linked user are yielded."""
     linked = baker.make("libraries.CommitAuthor", user=plain_user)

--- a/badges/tests/test_sources.py
+++ b/badges/tests/test_sources.py
@@ -54,6 +54,18 @@ def test_iter_library_authoring(plain_user):
     assert (plain_user, library) in pairs
 
 
+def test_iter_library_authoring_skips_sub_libraries(plain_user):
+    """A sub-library is its parent's, so authoring one alone counts for nothing.
+
+    ``math/quaternion`` and the rest of ``SUB_LIBRARIES`` are subdivisions of a
+    parent library's documentation, and the badge counts parent libraries.
+    """
+    sub = baker.make("libraries.Library", key="math/quaternion")
+    sub.authors.add(plain_user)
+
+    assert list(sources._iter_library_authoring()) == []
+
+
 def test_iter_code_commits_skips_unlinked(plain_user):
     """Only commits whose author has a linked user are yielded."""
     linked = baker.make("libraries.CommitAuthor", user=plain_user)

--- a/badges/tests/test_tasks.py
+++ b/badges/tests/test_tasks.py
@@ -18,6 +18,19 @@ def test_backfill_task_sweeps_every_source_by_default(catalogue, capsys):
         assert f"{slug}:" in output
 
 
+def test_backfill_task_scopes_to_one_source(catalogue, capsys):
+    """A slug reaches the command as ``--source`` rather than being ignored.
+
+    The task passes it by the argument's ``dest``, a different word from the
+    option, so the only proof it landed is one source running and the others not.
+    """
+    backfill_achievements_task(slug="library-authoring")
+
+    output = capsys.readouterr().out
+    assert "library-authoring:" in output
+    assert "code-commits:" not in output
+
+
 def test_reconcile_task_scopes_its_run_to_one_member(
     stale_commit_grant, commit_by_someone_else, plain_user, super_user
 ):

--- a/core/tests/test_admin_buttons.py
+++ b/core/tests/test_admin_buttons.py
@@ -457,4 +457,4 @@ def test_scoped_lock_is_per_argument(client, super_user):
         client.post(reverse(BACKFILL_URL), {"slug": "library-authoring"})
 
     assert "not starting another one" in refused.content.decode()
-    delay.assert_called_once_with(slug="library-authoring")
+    delay.assert_called_once_with(slug="library-authoring", actor_id=super_user.pk)

--- a/core/tests/test_admin_buttons.py
+++ b/core/tests/test_admin_buttons.py
@@ -438,3 +438,23 @@ def test_status_names_the_source_of_a_scoped_run(client, super_user):
         body = client.get(reverse(CHANGELIST_URL)).content.decode()
 
     assert "Backfill achievements (Code Commits): <strong>Running</strong>" in body
+
+
+def test_scoped_lock_is_per_argument(client, super_user):
+    """One source running does not refuse a run for another.
+
+    They are different jobs; they only share a button.
+    """
+    client.force_login(super_user)
+    cache.set(
+        f"{LAST_RUN_KEY}:job:code-commits", "running-task", TASK_BUTTON_COOLDOWN_SECONDS
+    )
+
+    with _state("STARTED"), patch(TASK_PATH, return_value=_result()) as delay:
+        refused = client.post(
+            reverse(BACKFILL_URL), {"slug": "code-commits"}, follow=True
+        )
+        client.post(reverse(BACKFILL_URL), {"slug": "library-authoring"})
+
+    assert "not starting another one" in refused.content.decode()
+    delay.assert_called_once_with(slug="library-authoring")


### PR DESCRIPTION
# Issue: #2576 

## Summary & Context

Wires the **Library Authoring** achievement to its source: `Library.authors`. One grant per
library a member authored, which is what the badge's thresholds (1 / 2 / 4 / 7 / 14) count.

First of four one-source-per-PR changes. This PR assumes the engine is already reviewed in #2573.

- **Figma link**: n/a
- **Link to components/page:** n/a

## Changes

- `_iter_library_authoring` yields `(user, library)` for every authorship, prefetching authors so
  the walk is one query per 500 libraries rather than one per library.
- Registered in `BACKFILL_ITERATORS`, which is also what adds `library-authoring` to the
  `--source` choices.
- `test_iter_library_authoring` (the iterator) and `test_backfill_library_authoring` (end to end:
  source data in, badge out).
- Two engine tests that only become meaningful with a **second** source arrive here:
  `test_backfill_skips_an_unseeded_source_on_a_full_run` (one missing catalogue row must not cost
  the other sources their backfill) and `test_reconcile_scopes_to_the_named_source` (`--source`
  must not prune a source it was not given).

## ‼️ Risks & Considerations ‼️

- The grain is **per library**, not per version - `library-versioning` is the per-version
  one. A library with 40 releases is one authoring grant.
- Authorship comes from the upstream `libraries.json`, which is known to be dirty: 78
  `LibraryVersion` rows carry a placeholder `'various '` author. That is an upstream data problem
  tracked separately; reconciliation will move the grants once it is fixed, which is exactly what
  the two-way sync exists for.
- Nothing runs automatically yet: the scheduled sweep is the release-pipeline PR.

## Screenshots

n/a - no UI.

## Peer-review & QA testing steps

All of it is doable from the admin. 
**Setup for local dev only**  (@kattyode, you may ignore this) `just load_production_data`, `just migrate`, and `docker compose up` so a worker is there to pick the buttons up.

1. **The source is wired.** `/admin/badges/badge/` - the **Library Author** row's *Automatic* column
   is now a tick and its ladder reads `1 / 2 / 4 / 7 / 14`. On the base branch that tick is a cross.

2. **Give yourself an authorship.** `/admin/libraries/library/` -> pick a library with a long release
   history -> add your own user to **Authors** -> Save.

3. **Backfill from the admin.** `/admin/badges/userachievement/` -> **Backfill achievements**, with
   *Source* set to **Library Authoring**. The status line finishes in place; no reload needed.

4. **The grant points at the right row.** Filter that changelist by *Achievement: Library Authoring*.
   Your row's **Source** column links to the library you edited - click through and confirm you are in
   its Authors list. `/admin/badges/userbadge/` now shows you holding **Library Author / Bronze**,
   because the ladder starts at 1.

5. **The grain is per library, not per version.** `/admin/libraries/libraryversion/`, filtered to that
   same library, lists many versions. You still have exactly **one** Library Authoring grant. Click
   your name from either badge changelist for the per-member page: it should read one valid grant and
   *1 to go* to Silver.

6. **Re-running adds nothing.** Press **Backfill achievements** on the same source again, then open
   `/admin/badges/achievementsyncrun/`: two `library-authoring` rows, the second with **Added 0**, both
   naming you under *Triggered by*.

7. **A backfill cannot take it away.** Remove yourself from the library's Authors and press
   **Backfill** again - the grant and the badge are still there. That is the additive command behaving
   as designed, and the reason the release pipeline is allowed to run it unattended.

8. **A reconcile can.** Press **Reconcile achievements** with *Source* on **Library Authoring**. The
   preview reports one removal before anything happens; Apply, and the grant is deleted while the Bronze
   row on `/admin/badges/userbadge/` is **revoked** rather than removed - badges keep their history. Its
   *Revocation notes* name the run, its *Count at revocation* reads 0, and the run row on
   `/admin/badges/achievementsyncrun/` shows **Removed 1**.

9. **Scoping.** Redo steps 2-3, remove yourself from Authors again, then press **Reconcile** with
   *Source* left on **Code Commits**. The commit run must leave your now-unsupported authoring grant
   alone; only a run pointed at Library Authoring or *All sources* may prune it.

On a database with no other library authorship, step 8 **refuses** rather than deletes: the preview says
nothing can be removed, does not offer Apply, and explains that a source yielding nothing at all is more
likely a broken import than a genuinely empty one. Add a second authorship and it proceeds. That guard is
worth seeing once, since it is the only thing standing between a failed upstream import and a mass
revocation.

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Backend
- [x] Black + Ruff clean
- [x] No new models or migrations
- [x] Full suite green: **1334 passed / 43 skipped**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic achievement recognition for authoring parent libraries.
  * Sub-libraries are excluded from library-authoring achievements.

* **Bug Fixes**
  * Improved achievement backfill and reconciliation to operate only on the selected source.
  * Prevented unrelated sources from being skipped or modified during targeted processing.
  * Task locks now allow independent achievement jobs to run concurrently when they use different sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->