### PR TITLE
Story #2560: implement the unavailable library page UI

### DIFF
--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -302,15 +302,47 @@ def test_library_detail_missing_version_v3_empty_state(
 def test_library_detail_missing_version_v3_cta_targets_newest_available(
     library, version, old_version, tp
 ):
-    """A library dropped from Boost sends the visitor to its last release, not latest."""
+    """A library that left Boost points at its last release, not at latest."""
     baker.make("libraries.LibraryVersion", library=library, version=old_version)
     url = tp.reverse("library-detail", version.display_name, library.slug)
     response = tp.get(url)
     tp.response_200(response)
+    tp.assertContext(
+        "library_version_missing_description",
+        "There is no version of the Boost.MultiArray library for Boost 1.79.0. "
+        "The last release which included Boost.MultiArray was 1.70.0.",
+    )
     tp.assertContext("library_version_missing_cta_label", "Switch to 1.70.0")
     tp.assertContext(
         "library_version_missing_cta_url",
         tp.reverse("library-detail", old_version.slug, library.slug),
+    )
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_library_detail_missing_version_v3_before_first_release_of_departed_library(
+    library, version, old_version, tp
+):
+    """A release older than the first still gets the "first release" sentence.
+
+    A library that has left Boost is still missing from the releases that predate
+    it, and there "the last release which included it" would answer a question the
+    visitor did not ask.
+    """
+    older_version = baker.make(
+        "versions.Version",
+        name="boost-1.60.0",
+        release_date=datetime.date.today() - datetime.timedelta(days=730),
+        fully_imported=True,
+    )
+    baker.make("libraries.LibraryVersion", library=library, version=old_version)
+    url = tp.reverse("library-detail", older_version.display_name, library.slug)
+    response = tp.get(url)
+    tp.response_200(response)
+    tp.assertContext(
+        "library_version_missing_description",
+        "There is no version of the Boost.MultiArray library for Boost 1.60.0. "
+        "The first release of Boost.MultiArray library was version 1.70.0.",
     )
 
 

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -346,6 +346,39 @@ def test_library_detail_missing_version_v3_before_first_release_of_departed_libr
     )
 
 
+@waffle.testutils.override_flag("v3", active=True)
+def test_library_detail_missing_version_v3_develop_branch_of_departed_library(
+    library, version, old_version, tp
+):
+    """A branch head gets the "last release" sentence and the branch wording.
+
+    develop carries no version number, so it cannot be placed by the numeric
+    comparison, but it is by definition ahead of every release.
+    """
+    develop = baker.make(
+        "versions.Version",
+        name="develop",
+        slug="develop",
+        release_date=datetime.date.today(),
+        full_release=False,
+        fully_imported=True,
+    )
+    baker.make("libraries.LibraryVersion", library=library, version=old_version)
+    url = tp.reverse("library-detail", develop.slug, library.slug)
+    response = tp.get(url)
+    tp.response_200(response)
+    tp.assertContext(
+        "library_version_missing_description",
+        "There is no version of the Boost.MultiArray library for the develop branch. "
+        "The last release which included Boost.MultiArray was 1.70.0.",
+    )
+    tp.assertContext("library_version_missing_cta_label", "Switch to 1.70.0")
+    tp.assertContext(
+        "library_version_missing_cta_url",
+        tp.reverse("library-detail", old_version.slug, library.slug),
+    )
+
+
 def test_library_docs_redirect(tp, library, library_version):
     """
     GET /libs/{library_slug}/

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -264,13 +264,53 @@ def test_library_detail_404(library, old_version, tp):
     tp.response_404(response)
 
 
+@waffle.testutils.override_flag("v3", active=False)
 def test_library_detail_missing_version(library, old_version, tp):
-    # custom error due to no existing version
+    # custom error due to no existing version; pinned to the legacy template now
+    # that v3 renders its own empty state
     url = tp.reverse("library-detail", old_version.display_name, library.slug)
     response = tp.get(url)
     assert (
         "There was no version of the Boost.MultiArray library in the 1.70.0 version of "
         "Boost." in response.content.decode("utf-8")
+    )
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_library_detail_missing_version_v3_empty_state(
+    library_version, old_version, tp
+):
+    """The v3 subpage swaps in the empty state, pointing at the current release."""
+    library = library_version.library
+    url = tp.reverse("library-detail", old_version.display_name, library.slug)
+    response = tp.get(url)
+    tp.response_200(response)
+    tp.assertContext("library_version_missing", True)
+    tp.assertContext(
+        "library_version_missing_description",
+        "There is no version of the Boost.MultiArray library for Boost 1.70.0. "
+        "The first release of Boost.MultiArray library was version 1.79.0.",
+    )
+    tp.assertContext("library_version_missing_cta_label", "Switch to latest (1.79.0)")
+    tp.assertContext(
+        "library_version_missing_cta_url",
+        tp.reverse("library-detail", "latest", library.slug),
+    )
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_library_detail_missing_version_v3_cta_targets_newest_available(
+    library, version, old_version, tp
+):
+    """A library dropped from Boost sends the visitor to its last release, not latest."""
+    baker.make("libraries.LibraryVersion", library=library, version=old_version)
+    url = tp.reverse("library-detail", version.display_name, library.slug)
+    response = tp.get(url)
+    tp.response_200(response)
+    tp.assertContext("library_version_missing_cta_label", "Switch to 1.70.0")
+    tp.assertContext(
+        "library_version_missing_cta_url",
+        tp.reverse("library-detail", old_version.slug, library.slug),
     )
 
 

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -547,8 +547,7 @@ class LibraryDetail(
         except LibraryVersion.DoesNotExist:
             # No LibraryVersion for the selected release (e.g. viewing a version
             # older than the library's first release). Flag it so the v3 template
-            # renders a placeholder instead of an empty subpage.
-            # TODO: replace with a designed empty-state (separate ticket).
+            # renders the empty state instead of an empty subpage.
             context["library_version_missing"] = True
             return context
 
@@ -585,6 +584,11 @@ class LibraryDetail(
 
     def get_v3_context_data(self, **kwargs):
         context = {**kwargs}
+
+        if context.get("library_version_missing"):
+            # The empty state renders a hero and nothing else, so none of the
+            # card context below applies.
+            return self.get_missing_version_context(context)
 
         version_str = context.get("version_str") or LATEST_RELEASE_URL_PATH_STR
 
@@ -656,6 +660,55 @@ class LibraryDetail(
             context["library_hero_image_url_dark"] = ""
             context["hero_image_url"] = ""
 
+        return context
+
+    def get_missing_version_context(self, context):
+        """Add the copy and CTA for the "no records for this version" empty state.
+
+        Built here rather than in the template because both the sentence and the
+        CTA branch on data: a library with no releases at all has no "first
+        release" clause and nowhere to switch to, and the newest release that
+        actually ships the library is only the current one for libraries that
+        haven't been dropped from Boost.
+        """
+        library = self.object
+        selected_version = context.get("selected_version")
+        description = (
+            f"There is no version of the {library.display_name} library for Boost "
+            f"{selected_version.display_name}."
+        )
+        first_version = library.first_boost_version
+        if first_version:
+            description += (
+                f" The first release of {library.display_name} library was version "
+                f"{first_version.display_name}."
+            )
+        context["library_version_missing_description"] = description
+
+        newest_version = (
+            Version.objects.active()
+            .filter(library_version__library=library, beta=False, full_release=True)
+            .order_by("-name")
+            .first()
+        )
+        if newest_version:
+            is_latest = newest_version == Version.objects.most_recent()
+            context["library_version_missing_cta_url"] = reverse(
+                "library-detail",
+                kwargs={
+                    "version_slug": (
+                        LATEST_RELEASE_URL_PATH_STR
+                        if is_latest
+                        else newest_version.slug
+                    ),
+                    "library_slug": library.slug,
+                },
+            )
+            context["library_version_missing_cta_label"] = (
+                f"Switch to latest ({newest_version.display_name})"
+                if is_latest
+                else f"Switch to {newest_version.display_name}"
+            )
         return context
 
     def get_dependency_diff(self, library_version):

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -4,6 +4,7 @@ from urllib.parse import urlencode, urlparse
 
 import structlog
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
@@ -672,25 +673,27 @@ class LibraryDetail(
         """
         library = self.object
         selected_version = context.get("selected_version")
+        # master and develop are branch heads, not releases: they carry no version
+        # number to compare against, and they are ahead of every release.
+        selected_is_branch = selected_version.slug in settings.BOOST_BRANCHES
+        selected_label = (
+            f"the {selected_version.display_name} branch"
+            if selected_is_branch
+            else f"Boost {selected_version.display_name}"
+        )
         description = (
-            f"There is no version of the {library.display_name} library for Boost "
-            f"{selected_version.display_name}."
+            f"There is no version of the {library.display_name} library for "
+            f"{selected_label}."
         )
 
-        # Betas are excluded rather than reusing library.first_boost_version,
-        # which spans them: a library whose first appearance was a beta would
-        # otherwise be announced as "version 1.91.0.beta1".
         released_versions = Version.objects.active().filter(
             library_version__library=library, beta=False, full_release=True
         )
         newest_version = released_versions.order_by("-name").first()
 
-        # Two different absences land here. Past the library's last release it has
-        # left Boost, so the useful fact is where it stopped. Before its first, it
-        # simply hadn't been added yet.
-        left_boost = (
-            newest_version
-            and selected_version.cleaned_version_parts_int
+        left_boost = newest_version and (
+            selected_is_branch
+            or selected_version.cleaned_version_parts_int
             > newest_version.cleaned_version_parts_int
         )
         if left_boost:

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -673,8 +673,6 @@ class LibraryDetail(
         """
         library = self.object
         selected_version = context.get("selected_version")
-        # master and develop are branch heads, not releases: they carry no version
-        # number to compare against, and they are ahead of every release.
         selected_is_branch = selected_version.slug in settings.BOOST_BRANCHES
         selected_label = (
             f"the {selected_version.display_name} branch"

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -677,12 +677,13 @@ class LibraryDetail(
             f"{selected_version.display_name}."
         )
 
-        newest_version = (
-            Version.objects.active()
-            .filter(library_version__library=library, beta=False, full_release=True)
-            .order_by("-name")
-            .first()
+        # Betas are excluded rather than reusing library.first_boost_version,
+        # which spans them: a library whose first appearance was a beta would
+        # otherwise be announced as "version 1.91.0.beta1".
+        released_versions = Version.objects.active().filter(
+            library_version__library=library, beta=False, full_release=True
         )
+        newest_version = released_versions.order_by("-name").first()
 
         # Two different absences land here. Past the library's last release it has
         # left Boost, so the useful fact is where it stopped. Before its first, it
@@ -692,20 +693,12 @@ class LibraryDetail(
             and selected_version.cleaned_version_parts_int
             > newest_version.cleaned_version_parts_int
         )
-        # Not library.first_boost_version: that spans betas, so a library whose
-        # first appearance was a beta would be announced as "version 1.91.0.beta1".
-        first_version = (
-            Version.objects.active()
-            .filter(library_version__library=library, beta=False, full_release=True)
-            .order_by("name")
-            .first()
-        )
         if left_boost:
             description += (
                 f" The last release which included {library.display_name} was "
                 f"{newest_version.display_name}."
             )
-        elif first_version:
+        elif first_version := released_versions.order_by("name").first():
             description += (
                 f" The first release of {library.display_name} library was version "
                 f"{first_version.display_name}."

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -666,10 +666,9 @@ class LibraryDetail(
         """Add the copy and CTA for the "no records for this version" empty state.
 
         Built here rather than in the template because both the sentence and the
-        CTA branch on data: a library with no releases at all has no "first
-        release" clause and nowhere to switch to, and the newest release that
-        actually ships the library is only the current one for libraries that
-        haven't been dropped from Boost.
+        CTA branch on data: a library with no releases at all has no second
+        sentence and nowhere to switch to, and a library that has left Boost
+        needs the last release that shipped it rather than the first.
         """
         library = self.object
         selected_version = context.get("selected_version")
@@ -677,13 +676,6 @@ class LibraryDetail(
             f"There is no version of the {library.display_name} library for Boost "
             f"{selected_version.display_name}."
         )
-        first_version = library.first_boost_version
-        if first_version:
-            description += (
-                f" The first release of {library.display_name} library was version "
-                f"{first_version.display_name}."
-            )
-        context["library_version_missing_description"] = description
 
         newest_version = (
             Version.objects.active()
@@ -691,6 +683,35 @@ class LibraryDetail(
             .order_by("-name")
             .first()
         )
+
+        # Two different absences land here. Past the library's last release it has
+        # left Boost, so the useful fact is where it stopped. Before its first, it
+        # simply hadn't been added yet.
+        left_boost = (
+            newest_version
+            and selected_version.cleaned_version_parts_int
+            > newest_version.cleaned_version_parts_int
+        )
+        # Not library.first_boost_version: that spans betas, so a library whose
+        # first appearance was a beta would be announced as "version 1.91.0.beta1".
+        first_version = (
+            Version.objects.active()
+            .filter(library_version__library=library, beta=False, full_release=True)
+            .order_by("name")
+            .first()
+        )
+        if left_boost:
+            description += (
+                f" The last release which included {library.display_name} was "
+                f"{newest_version.display_name}."
+            )
+        elif first_version:
+            description += (
+                f" The first release of {library.display_name} library was version "
+                f"{first_version.display_name}."
+            )
+        context["library_version_missing_description"] = description
+
         if newest_version:
             is_latest = newest_version == Version.objects.most_recent()
             context["library_version_missing_cta_url"] = reverse(

--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -487,20 +487,24 @@
   padding-top: var(--space-hero-padding-top);
 }
 
-/* The header is absolutely positioned, so the hero reserves its space. That is
-   normally .hero__block's padding, but a banner renders above the block, so the
-   clearance moves up to the section here and the block gives its own back. */
+/* Positioning context for the alert below. */
 .hero:has(> .banner) {
   /* Not var(--header-height): outside .header that resolves to an unrelated
-     legacy 2.5rem and silently under-reserves. 48px is .header's own value. */
+     legacy 2.5rem, which would tuck the alert under the header. 48px is
+     .header's own value; the rest of its footprint is its vertical padding. */
   --hero-header-footprint: calc(48px + 2 * var(--space-default));
   --hero-banner-inset: var(--space-large);
-  padding-top: var(--hero-header-footprint);
+  position: relative;
 }
 
-/* Mirror the header's box so the alert's edges line up with the nav's. */
+/* Lines up horizontally with the Nav. */
 .hero > .banner {
-  width: calc(100% - 2 * var(--hero-banner-inset));
+  position: absolute;
+  z-index: 2;
+  top: var(--hero-header-footprint);
+  left: var(--hero-banner-inset);
+  right: var(--hero-banner-inset);
+  width: auto;
   max-width: calc(1440px - 2 * var(--hero-banner-inset));
   margin-inline: auto;
 }
@@ -513,8 +517,25 @@
   }
 }
 
-.hero:has(> .banner) .hero__block {
-  padding-top: 0;
+/* Wider heroes clear the header by more than the alert is tall, so overlaying
+   costs nothing. Down here there is no such slack: the block clears the header
+   by 32px, the release hero by 16px, and the alert wraps to three lines on a
+   narrow phone. Overlaying would cover the heading, and any fixed reserve would
+   only be a guess at how long the message runs, so the alert goes back in flow
+   and takes the dismiss shift that the wider layouts avoid. */
+@media (max-width: 767px) {
+  .hero:has(> .banner) {
+    padding-top: var(--hero-header-footprint);
+  }
+
+  .hero:has(> .banner) .hero__block {
+    padding-top: 0;
+  }
+
+  .hero > .banner {
+    position: static;
+    width: calc(100% - 2 * var(--hero-banner-inset));
+  }
 }
 
 .hero--no-image .hero__block {

--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -179,6 +179,8 @@
   display: none;
 }
 
+/* Shared by the home hero and any base hero passing a cta_label/cta_url
+   (e.g. the library-unavailable variant), so the selector stays unscoped. */
 .hero__actions {
   display: flex;
   flex-direction: row;
@@ -775,6 +777,58 @@ html.dark .hero__links .btn-icon-library:hover {
    take over so the background scene shows through, same as community. */
 .hero--release.hero--no-image {
   background: var(--color-surface-weak-accent-yellow);
+}
+
+/* Library unavailable in the selected release (library subpage empty state):
+   the illustration sits on the page surface rather than the accent background
+   the other image heroes use. */
+.hero--library-unavailable,
+.dark .hero--library-unavailable {
+  background-color: var(--color-surface-page);
+}
+
+/* Raise the base hero's 662px cap so the flex split against the illustration
+   sets the text width instead (~700px at 1440px, matching Figma), which breaks
+   the 64px headline after "records" onto a second line. */
+.hero--library-unavailable .hero__content {
+  max-width: 830px;
+  gap: var(--space-xl);
+}
+
+/* Figma spaces headline, sentence and CTA evenly at 32px; the base hero packs
+   the headline and sentence tighter. */
+.hero--library-unavailable .hero__text-block {
+  gap: var(--space-xl);
+}
+
+/* Figma sits the illustration flush with the bottom of the block. The empty
+   state's copy is longer than a library hero's, so the block's fixed height
+   becomes a floor — otherwise the CTA overflows onto the version alert once the
+   headline wraps to three lines in the tablet band. */
+.hero--library-unavailable .hero__block {
+  padding-bottom: 0;
+  height: auto;
+  min-height: var(--hero-block-height);
+}
+
+/* The blend below composites against this box, not against .hero: .hero__block
+   opens a stacking context (position/z-index), which closes the blending group
+   above the section's background. Repeating the surface color here gives the
+   illustration the backdrop it needs to blend into. */
+.hero--library-unavailable .hero__image {
+  align-self: flex-end;
+  background-color: var(--color-surface-page);
+}
+
+/* The illustration ships on an opaque plate (white in the light export, black in
+   the dark one), so blend it away — otherwise its edge shows as a panel against
+   the page surface. Matches the multiply blend in Figma. */
+.hero--library-unavailable .hero__img--light {
+  mix-blend-mode: multiply;
+}
+
+.hero--library-unavailable .hero__img--dark {
+  mix-blend-mode: screen;
 }
 
 /* ----- Hero variants: tablet ----- */

--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -488,6 +488,46 @@
   padding-top: var(--space-hero-padding-top);
 }
 
+/* The header overlays the top of the page, so whatever comes first inside the
+   hero has to clear it. Normally that is .hero__block and its padding does the
+   work, but the version alert renders above the block, so the clearance moves up
+   to the section and the block gives its own back. The section's gap then spaces
+   the alert from the block. Clearance matches the reservation in header.css. */
+.hero:has(> .banner) {
+  /* 48px is .header's own --header-height. That custom property cannot be read
+     from out here: the value that reaches the hero is an unrelated legacy 2.5rem,
+     which silently under-reserves and tucks the alert under the header. The rest
+     of the footprint is the header's vertical padding. */
+  --hero-header-footprint: calc(48px + 2 * var(--space-default));
+  /* The alert lines up with the nav pill above it, so it takes the header's
+     own horizontal padding. */
+  --hero-banner-inset: var(--space-large);
+  padding-top: var(--hero-header-footprint);
+}
+
+/* Match the header's box so the alert and the nav share both edges: same 1440
+   container, same inset. Without this the banner runs the full width of the
+   section while the nav sits inset, and the two edges disagree. */
+.hero > .banner {
+  width: calc(100% - 2 * var(--hero-banner-inset));
+  max-width: calc(1440px - 2 * var(--hero-banner-inset));
+  margin-inline: auto;
+}
+
+/* Mirrors the header's own padding switch in header.css, which goes from
+   --space-default to --space-medium at this width. Without it the alert slides
+   under the taller tablet header. */
+@media (max-width: 990px) {
+  .hero:has(> .banner) {
+    --hero-header-footprint: calc(48px + 2 * var(--space-medium));
+    --hero-banner-inset: var(--space-medium);
+  }
+}
+
+.hero:has(> .banner) .hero__block {
+  padding-top: 0;
+}
+
 .hero--no-image .hero__block {
   align-items: center;
 }

--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -179,8 +179,7 @@
   display: none;
 }
 
-/* Shared by the home hero and any base hero passing a cta_label/cta_url
-   (e.g. the library-unavailable variant), so the selector stays unscoped. */
+/* Deliberately unscoped: any hero passing cta_label/cta_url renders this. */
 .hero__actions {
   display: flex;
   flex-direction: row;
@@ -488,35 +487,25 @@
   padding-top: var(--space-hero-padding-top);
 }
 
-/* The header overlays the top of the page, so whatever comes first inside the
-   hero has to clear it. Normally that is .hero__block and its padding does the
-   work, but the version alert renders above the block, so the clearance moves up
-   to the section and the block gives its own back. The section's gap then spaces
-   the alert from the block. Clearance matches the reservation in header.css. */
+/* The header is absolutely positioned, so the hero reserves its space. That is
+   normally .hero__block's padding, but a banner renders above the block, so the
+   clearance moves up to the section here and the block gives its own back. */
 .hero:has(> .banner) {
-  /* 48px is .header's own --header-height. That custom property cannot be read
-     from out here: the value that reaches the hero is an unrelated legacy 2.5rem,
-     which silently under-reserves and tucks the alert under the header. The rest
-     of the footprint is the header's vertical padding. */
+  /* Not var(--header-height): outside .header that resolves to an unrelated
+     legacy 2.5rem and silently under-reserves. 48px is .header's own value. */
   --hero-header-footprint: calc(48px + 2 * var(--space-default));
-  /* The alert lines up with the nav pill above it, so it takes the header's
-     own horizontal padding. */
   --hero-banner-inset: var(--space-large);
   padding-top: var(--hero-header-footprint);
 }
 
-/* Match the header's box so the alert and the nav share both edges: same 1440
-   container, same inset. Without this the banner runs the full width of the
-   section while the nav sits inset, and the two edges disagree. */
+/* Mirror the header's box so the alert's edges line up with the nav's. */
 .hero > .banner {
   width: calc(100% - 2 * var(--hero-banner-inset));
   max-width: calc(1440px - 2 * var(--hero-banner-inset));
   margin-inline: auto;
 }
 
-/* Mirrors the header's own padding switch in header.css, which goes from
-   --space-default to --space-medium at this width. Without it the alert slides
-   under the taller tablet header. */
+/* Tracks the header's own padding switch in header.css at this same width. */
 @media (max-width: 990px) {
   .hero:has(> .banner) {
     --hero-header-footprint: calc(48px + 2 * var(--space-medium));
@@ -819,31 +808,27 @@ html.dark .hero__links .btn-icon-library:hover {
   background: var(--color-surface-weak-accent-yellow);
 }
 
-/* Library unavailable in the selected release (library subpage empty state):
-   the illustration sits on the page surface rather than the accent background
-   the other image heroes use. */
+/* Library subpage empty state: no version of the library in this release. */
 .hero--library-unavailable,
 .dark .hero--library-unavailable {
   background-color: var(--color-surface-page);
 }
 
-/* Raise the base hero's 662px cap so the flex split against the illustration
-   sets the text width instead (~700px at 1440px, matching Figma), which breaks
-   the 64px headline after "records" onto a second line. */
+/* A ceiling, not the target width: it lifts the base hero's 662px cap so the
+   flex split against the illustration sets the width (~700px at 1440, Figma). */
 .hero--library-unavailable .hero__content {
   max-width: 830px;
   gap: var(--space-xl);
 }
 
-/* Figma spaces headline, sentence and CTA evenly at 32px; the base hero packs
-   the headline and sentence tighter. */
+/* Figma spaces headline, sentence and CTA evenly; the base hero packs the
+   headline and sentence tighter. */
 .hero--library-unavailable .hero__text-block {
   gap: var(--space-xl);
 }
 
-/* Figma sits the illustration flush with the bottom of the block. The empty
-   state's copy is longer than a library hero's, so the block's fixed height
-   becomes a floor — otherwise the CTA overflows onto the version alert once the
+/* This copy runs longer than a library hero's, so the fixed height becomes a
+   floor: at a fixed height the CTA overflows onto the version alert once the
    headline wraps to three lines in the tablet band. */
 .hero--library-unavailable .hero__block {
   padding-bottom: 0;
@@ -852,17 +837,15 @@ html.dark .hero__links .btn-icon-library:hover {
 }
 
 /* The blend below composites against this box, not against .hero: .hero__block
-   opens a stacking context (position/z-index), which closes the blending group
-   above the section's background. Repeating the surface color here gives the
-   illustration the backdrop it needs to blend into. */
+   opens a stacking context, which closes the blending group above the section's
+   background. Hence the surface color repeated here. */
 .hero--library-unavailable .hero__image {
   align-self: flex-end;
   background-color: var(--color-surface-page);
 }
 
-/* The illustration ships on an opaque plate (white in the light export, black in
-   the dark one), so blend it away — otherwise its edge shows as a panel against
-   the page surface. Matches the multiply blend in Figma. */
+/* The illustration ships on an opaque plate (white in the light export, black
+   in the dark one), so blend it away or its edge shows as a panel. */
 .hero--library-unavailable .hero__img--light {
   mix-blend-mode: multiply;
 }

--- a/templates/v3/includes/_hero_library.html
+++ b/templates/v3/includes/_hero_library.html
@@ -13,6 +13,9 @@
     source_url         (optional) — Source code link URL. Omit to hide.
     slack_url          (optional) — Discuss in Slack URL. Omit to hide.
     github_url         (optional) — GitHub Issues URL. Omit to hide.
+    cta_label          (optional) — Label for a primary hero button below the text. Needs cta_url.
+    cta_url            (optional) — Destination for that button. Needs cta_label.
+    cta_icon_name      (optional) — Icon for that button, from includes/icon.html. Defaults to "arrow-right".
     hero_image_url     (optional) — Image URL. If omitted, image block is not shown.
     hero_image_url_mobile (optional) — Art-directed image swapped in at &lt;=767px (e.g. a tighter crop). If omitted, the desktop image is used at all widths.
     hero_background_image_url (optional) — Background image URL for the hero container.
@@ -57,6 +60,11 @@
           {% endif %}
         </div>
       </div>
+      {% if cta_label and cta_url %}
+      <div class="hero__actions">
+        {% include "v3/includes/_button_hero.html" with label=cta_label url=cta_url icon_name=cta_icon_name|default:"arrow-right" style="primary" %}
+      </div>
+      {% endif %}
       {% if doc_url or source_url or slack_url or github_url or rss_url or show_branch_buttons %}
       <div class="hero__links">
         {% if doc_url %}

--- a/templates/v3/includes/_hero_library.html
+++ b/templates/v3/includes/_hero_library.html
@@ -27,12 +27,20 @@
   row is hidden. If none of doc_url/source_url/slack_url/github_url are passed,
   the links row is hidden.
 
+  When version_alert/version_alert_message/selected_version are in context, the
+  v3/includes/_version_alert.html banner renders as the first child of the hero
+  section, above the block, which is where the design puts it. Callers using
+  `only` must forward those three explicitly. The banner carries the clearance
+  for the absolutely positioned header in that case; see .hero:has(> .banner) in
+  heros.css.
+
   Usage:
     {% include "v3/includes/_hero_library.html" with title="Boost.Asio" description="..." doc_url="/doc/libs/..." %}
 {% endcomment %}
 <section class="hero{% if not hero_image_url and not hero_image_url_light and not hero_image_url_dark %} hero--no-image{% endif %}{% if hero_background_image_url and hero_image_url or hero_background_image_url and hero_image_url_light or hero_background_image_url and hero_image_url_dark %} hero--with-bg-and-image{% endif %}{% if hero_background_image_url %} hero--with-background-image{% endif %}{% if extra_classes %} {{ extra_classes }}{% endif %}"
          {% if hero_background_image_url %}style="--hero-bg-image: url('{{ hero_background_image_url }}');"{% endif %}
          aria-label="Library hero">
+  {% include "v3/includes/_version_alert.html" %}
   <div class="hero__block">
     <div class="hero__content">
       <div class="hero__meta">
@@ -110,5 +118,4 @@
     {% endwith %}
     {% endif %}
   </div>
-  {% include "v3/includes/_version_alert.html" %}
 </section>

--- a/templates/v3/includes/_library_version_unavailable.html
+++ b/templates/v3/includes/_library_version_unavailable.html
@@ -1,0 +1,21 @@
+{% load custom_static %}
+{% comment %}
+  V3 library subpage empty state: the selected Boost release has no version of
+  this library (usually a release older than the library's first, but also a
+  library that has since been dropped from Boost).
+
+  Reuses the shared library hero — headline, sentence, "Switch to …" button and
+  the bookshelf illustration — on the page surface instead of the hero's accent
+  background.
+
+  Context (LibraryDetail.get_missing_version_context):
+    library_version_missing_description — sentence naming the library and versions.
+    library_version_missing_cta_label / _cta_url — the "Switch to …" button; both
+      are absent when the library has no releases at all, which collapses the button.
+
+  Usage:
+    {% include "v3/includes/_library_version_unavailable.html" %}
+{% endcomment %}
+{% large_static 'img/v3/library-page/empty-library-light.png' as empty_library_image_light %}
+{% large_static 'img/v3/library-page/empty-library-dark.png' as empty_library_image_dark %}
+{% include "v3/includes/_hero_library.html" with extra_classes="hero--library-unavailable" title="No library records available for this version." description=library_version_missing_description cta_label=library_version_missing_cta_label cta_url=library_version_missing_cta_url hero_image_url="" hero_image_url_light=empty_library_image_light hero_image_url_dark=empty_library_image_dark %}

--- a/templates/v3/libraries/library-subpage.html
+++ b/templates/v3/libraries/library-subpage.html
@@ -11,11 +11,7 @@
 {% block content %}
 
 {% if library_version_missing %}
-  {% comment %} TODO: Extract this to a separate template & implement UI for empty state {% endcomment %}
-  <div style="margin: 10rem auto; max-width: 40rem; text-align: center;">
-    <h1 class="library-no-version__title">No library records available for this version.</h1>
-    <p class="library-no-version__description">There is no version of the <b>{{ object.display_name }}</b> library for Boost {{ selected_version.display_name }}. The first release of <b>{{ object.display_name }}</b> library was version <b>{{ object.first_boost_version.display_name }}</b>.</p>
-  </div>
+  {% include "v3/includes/_library_version_unavailable.html" %}
 {% else %}
   {% with cpp_ver=library_version.get_cpp_standard_minimum_display|default:"C++03" %}
       {% if is_flagship_lib %}


### PR DESCRIPTION
# Issue: #2560

> Stacked on #2556 (`julia/improve-library-subpage-layout`), which added the placeholder this replaces. Retarget to `develop` once #2556 merges. Trying out the Github stacked layout thing.

## Summary & Context

Replaces the inline placeholder on the v3 library subpage with the designed empty state for a library that has no version in the selected Boost release: headline, a sentence naming the library and versions, a "Switch to ..." CTA and the bookshelf illustration.

- **Figma link**: [Unavailable Library page](https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=4510-47735&m=dev)
- **Link to components/page:** http://localhost:8000/library/1.85.0/decimal/

## Changes

#### View (`libraries/views.py`)

- Add `LibraryDetail.get_missing_version_context()`, which builds the sentence and the CTA label/URL. The sentence has two forms: past a library's last release, "The last release which included X was Y"; before its first, "The first release of X library was version Y". The two are selected by a numeric version comparison (`cleaned_version_parts_int`).
- The "first release" form excludes betas. `Library.first_boost_version` spans them, so Boost.Decimal was announcing "version 1.91.0.beta1".
- `get_v3_context_data()` now returns early for the missing-version case, so the subpage's contributor, quick-start, dependency and benchmark context is no longer computed for a page that renders none of it.

#### Hero component (`templates/v3/includes/_hero_library.html`)

- Add optional `cta_label` / `cta_url` / `cta_icon_name`, rendered through the existing `_button_hero.html` inside `.hero__actions`. The block collapses when they are absent, so every existing caller is unchanged.

#### Empty state template (`templates/v3/includes/_library_version_unavailable.html`, new)

- Wires the hero to the empty-state copy and to the existing `empty-library-light/dark.png` illustration already shipped for the library-list empty state. No new asset: it is the same artwork as the Figma frame.

#### Styles (`static/css/v3/heros.css`)
- Older version warning bar below Nav bar, as shown in Figma.
- New `hero--library-unavailable` variant: page surface instead of the hero's accent yellow, Figma's 32px rhythm between headline, sentence and CTA, and a bottom-flush illustration.
- The block's fixed height becomes a `min-height` for this variant only, since the empty state's copy is longer than a library hero's and would otherwise overflow the CTA onto the version alert in the tablet band.
- The illustration ships on an opaque plate (white in the light export, black in the dark one), so it is blended into the surface with `multiply` / `screen`. That needs a matching background on `.hero__image`, because `.hero__block` opens a stacking context and closes the blending group above the section background.

#### Tests (`libraries/tests/test_views.py`)

- Three tests: the empty-state context, the removed-library CTA, and the fallback to the "first release" sentence on releases older than the library.
- Pin the legacy v2 `test_library_detail_missing_version` with `override_flag("v3", active=False)`. It was passing only on ambient flag state and flipped to the v3 template whenever the cached waffle flag was warm.

## ‼️ Risks & Considerations ‼️

- ‼️ **The CTA does not always point at "latest".** For a library removed from Boost, the button targets the library's last release and the label changes from "Switch to latest (1.91.0)" to "Switch to 1.86.0". Compatibility and Signals are the only two on the site.
- **`Library.first_boost_version` still spans betas**, and it feeds the hero's "Added in {version}" chip, so a populated Boost.Decimal page reads "Added in 1.91.0.beta1". Fixing the shared property is out of scope here, and the chip and this empty state never render on the same page.
- **Rejected: a standalone empty-state template.** Reusing `_hero_library.html` costs three optional variables and keeps the responsive type ladder, the theme-aware image swap and the version alert in one place. A separate template would have duplicated all three and drifted from the other heroes.
- **Rejected: building the sentence in the template.** It reads as static copy, but it is two different sentences chosen by a numeric version comparison.

## Peer-Testing Guidelines

Every URL below is real Boost history and works on any environment with the catalogue imported.

1. *(Local only.)* If the page renders the legacy layout, the cached `v3` waffle flag is stale:

   ```
   docker compose exec redis redis-cli FLUSHALL
   ```

2. **Library newer than the release.** Visit `/library/1.85.0/decimal/`. Expect the headline, a sentence naming both versions, a "Switch to latest (1.91.0)" button naming the current release, and the illustration on the page surface rather than the yellow hero background. The button should land on `/library/latest/decimal/`.

3. **Library removed from Boost.** Visit `/library/latest/compatibility/`. The sentence should read "The last release which included Boost.Compatibility was 1.86.0", and the button "Switch to 1.86.0", linking to `/library/1.86.0/compatibility/` rather than back to latest.

4. **Responsive and themes.** Resize through 1440 / 768 / 375 in both themes. The illustration should have no visible panel edge behind it in either theme, and at 768 the CTA must stay clear of the version alert banner.

5. **No regression on a populated subpage.** Visit `/library/latest/decimal/` and confirm the hero still shows the tag row, the Documentation / Source code / Slack / GitHub Issues links and the Master/Develop buttons, with no CTA button. Those branch buttons should be absent from the empty state.

More URLs, covering both cases:

| URL | Why it is empty | Expected CTA |
| -- | -- | -- |
| `/library/1.85.0/decimal/` | added in 1.91.0 | Switch to latest (1.91.0) |
| `/library/1.80.0/cobalt/` | added in 1.84.0 | Switch to latest (1.91.0) |
| `/library/1.80.0/mysql/` | added in 1.82.0 | Switch to latest (1.91.0) |
| `/library/latest/compatibility/` | removed in 1.87.0 | Switch to 1.86.0 |
| `/library/latest/signals/` | removed in 1.69.0 | Switch to 1.68.0 |

To find more of the first kind without database access: open any library at `latest` and read the "Added in {version}" chip, then pick an older release from the version dropdown. The second kind needs no searching, since Compatibility and Signals are the only two.

## Screenshots

| Screenshot | Notes |
| -- | -- |
| <img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/90ec6864-ea48-44bd-852f-f62284538705" />| Desktop 1440, light. |
|<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/19440894-c100-46d3-abe9-3be50a900f1f" />| Desktop 1440, dark. Dark illustration export, no visible plate behind it. |
|<img width="1341" height="579" alt="image" src="https://github.com/user-attachments/assets/633d3e88-c2e6-4bdc-b307-d45293d0bbce" />| Boost.Compatibility at latest: the CTA reads "Switch to 1.86.0", the library's last release, instead of pointing back at latest. **Update:** Now it reads "The last release which included Boost.Compatibility was 1.86.0" |

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend

- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified (1440 / 768 / 375)
- [x] Accessibility checked: `<h1>` carries the message, the CTA is a plain focusable link, the illustration is decorative (`alt=""`)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. No hardcoded values
- [x] Test without JavaScript (the page is static markup)
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated empty state when a library version is unavailable.
  - Provides contextual explanations for missing releases, discontinued libraries, pre-release pages, and development branches.
  - Offers direct links to the latest or most relevant available release when applicable.
  - Added library-specific news cards with links to relevant news pages.
- **Style**
  - Added responsive unavailable-version hero layouts with light and dark illustrations.
  - Improved alert placement and CTA presentation across desktop and mobile views.
- **Bug Fixes**
  - Preserved existing error behavior for legacy library-detail pages while enabling the improved experience in the latest interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->