### PR TITLE
Task #2589: Guard Libraries API Endpoint

### DIFF
--- a/libraries/api.py
+++ b/libraries/api.py
@@ -1,5 +1,6 @@
 from django.db.models import Q
 
+from rest_framework import mixins
 from rest_framework import permissions
 from rest_framework import viewsets
 from rest_framework import serializers
@@ -19,7 +20,14 @@ class LibrarySearchSerializer(serializers.ModelSerializer):
         )
 
 
-class LibrarySearchView(viewsets.ModelViewSet):
+class LibrarySearchView(mixins.ListModelMixin, viewsets.GenericViewSet):
+    """Read-only list endpoint for library search.
+
+    Only `list` is routed; every other method returns 405. No caller remains
+    in the codebase — the search box that used this is commented out in
+    `libraries/includes/library_preferences.html`.
+    """
+
     model = Library
     serializer_class = LibrarySearchSerializer
     permission_classes = [permissions.AllowAny]

--- a/libraries/tests/test_api.py
+++ b/libraries/tests/test_api.py
@@ -1,3 +1,10 @@
+import pytest
+
+from django.urls import NoReverseMatch, reverse
+
+from libraries.models import Library
+
+
 def test_library_search(library, tp):
     """
     GET /api/v1/libraries/?q=
@@ -7,3 +14,50 @@ def test_library_search(library, tp):
     res = tp.get(f"/api/v1/libraries/?q={library.name[:3]}")
     tp.response_200(res)
     assert len(res.context["libraries"]) == 1
+
+
+def test_library_api_rejects_anonymous_create(db, tp):
+    """POST /api/v1/libraries/ must not create a record for an anonymous caller."""
+    before = Library.objects.count()
+    res = tp.client.post(
+        "/api/v1/libraries/",
+        {"name": "probe", "slug": "probe", "description": "probe"},
+    )
+    tp.response_405(res)
+    assert Library.objects.count() == before
+
+
+def test_library_api_rejects_authenticated_create(super_user, tp):
+    """The endpoint is read-only for everyone, not just anonymous callers."""
+    before = Library.objects.count()
+    with tp.login(super_user):
+        res = tp.client.post(
+            "/api/v1/libraries/",
+            {"name": "probe", "slug": "probe", "description": "probe"},
+        )
+    tp.response_405(res)
+    assert Library.objects.count() == before
+
+
+def test_library_api_detail_route_not_registered():
+    """The router exposes no per-library route for edits or deletes to target."""
+    with pytest.raises(NoReverseMatch):
+        reverse("libraries-detail", kwargs={"pk": 1})
+
+
+@pytest.mark.parametrize("method", ["put", "patch", "delete"])
+def test_library_api_rejects_detail_writes(method, library, tp):
+    """Writes to the old detail path leave the record untouched.
+
+    The status varies by client — the catch-all page URL this path now falls
+    through to answers 405, but a real client without a CSRF token is refused
+    with 403 before reaching it — so only assert that nothing succeeded.
+    """
+    res = getattr(tp.client, method)(
+        f"/api/v1/libraries/{library.pk}/",
+        data={"name": "renamed", "slug": "renamed", "description": "renamed"},
+        content_type="application/json",
+    )
+    assert not 200 <= res.status_code < 300
+    library.refresh_from_db()
+    assert library.name == "multi_array"


### PR DESCRIPTION
# Issue: #2589

## Summary & Context

`LibrarySearchView` was a `ModelViewSet` with `AllowAny`, so `/api/v1/libraries/` accepted writes from anyone with no login. An anonymous `POST` creates a real `Library` row — reproduced against the dev database, probe row removed afterwards.

The response is a 500 rather than a success: the view renders through `TemplateHTMLRenderer` and only `list` supplies a `template_name`, so the write commits and the response fails to render afterwards. The damage never showed up in the status code, which is a fair part of why this went unnoticed.

`PUT`/`PATCH`/`DELETE` on `/api/v1/libraries/<id>/` were routed and equally permission-open, but happen to be non-functional: every detail action calls the overridden `filter_queryset`, which raises `ValueError` when `?q=` is absent (500) and returns a sliced queryset when it is present, which DRF's `get_object_or_404` turns into a 404. Verified — the row survives all three methods. That is an accident of the search filter, not protection, and a `GET` detail is broken for the same reason.

Nothing in the site calls this endpoint. The search box that used to is commented out at `libraries/includes/library_preferences.html:8-11`, alongside a note reading "LibrarySearchView can be removed if this isn't ever used again" — commented out on 2025-03-03 in `a55111ca`. So this is a publicly writable endpoint serving nothing. This PR makes it read-only and adds tests so the write methods can't come back unnoticed.

- **Link to endpoint**: http://localhost:8000/api/v1/libraries/?q=multi — no UI to link, since no page renders a consumer of it.

## Changes

- Make `LibrarySearchView` read-only, building on `ListModelMixin` + `GenericViewSet` instead of `ModelViewSet`. `list` is the only routed action, so create, update and delete no longer exist. `permission_classes` stays `AllowAny` — search results are public.
- The detail route disappears as a consequence, since the router only generates URLs for actions the viewset defines. Nothing consumed it and nothing worked there.
- Tests: anonymous `POST` is refused with the row count unchanged, and so is a superuser `POST` — read-only for everyone, not gated by role. `libraries-detail` no longer reverses, pinning the route removal directly. `PUT`/`PATCH`/`DELETE` against the old detail path leave the library untouched.

## ‼️ Risks & Considerations ‼️

- **No user-facing behaviour changes.** No template or script calls this endpoint. `list` is unchanged — same querystring filter, same 5-result limit, same `search_results.html` — so any caller outside this repo keeps working for reads.
- **Writes are removed outright rather than permission-gated.** An out-of-repo integration doing writes would now get a 405. That is the intent, but an external caller is the one thing this change cannot rule out from inside the codebase.
- **`/api/v1/libraries/<id>/` no longer resolves to the API.** It falls through to the catch-all `static-content-page` route — a plain Django view, so an unsafe method without a CSRF token is refused with a 403 by middleware, and with a token gets a 405. Nothing working is lost. The detail-write test asserts only that nothing succeeded, since the exact status depends on the client.
- **Deleting the view outright is the natural follow-up, deliberately not done here.** With no consumers and a prior note saying it can go, the view, its router registration and the two dead templates (`search_input.html`, `search_results.html`) could all be removed. Different risk profile, and a 405 is a softer landing than a 404 if an external caller exists. V3 won't need it — `v3/library_page.html` filters client-side with Fuse.js.

## Peer-Testing Guidelines

1. Confirm reads still work, so the endpoint is intact for any caller outside this repo:
   ```bash
   curl -i "http://localhost:8000/api/v1/libraries/?q=multi"
   ```
   Expect 200 and an HTML fragment listing matching libraries.
2. Confirm anonymous create is refused and writes nothing:
   ```bash
   curl -i -X POST http://localhost:8000/api/v1/libraries/ \
     -d "name=probe-test&slug=probe-test&description=probe-test"
   ```
   Expect `405 Method Not Allowed`, and no `probe-test` library at http://localhost:8000/admin/libraries/library/. On `develop` the same call returns a 500 but creates the row anyway — delete it if you try that.
3. Confirm the detail path can't be used to edit or delete. Substitute a real library id:
   ```bash
   curl -i -X DELETE http://localhost:8000/api/v1/libraries/1/
   ```
   Expect `403 Forbidden` with "CSRF verification failed", and the library still present in the admin. The path no longer belongs to the API, so it falls through to a regular Django view that enforces CSRF in middleware. On `develop` this returns a 500 and leaves the row intact, but only because the detail lookup is broken — the route is open, not safe.
4. Confirm a signed-in staff user gets the same 405 on step 2.



## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restricted the libraries API to read-only search and listing operations.
  - Prevented record creation and updates through unsupported write requests.
  - Removed access to library detail routes.

- **Tests**
  - Added coverage confirming anonymous and authenticated write requests are rejected without modifying library data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->