### PR TITLE
Story #2586 :: Task: Wire the Library Maintenance achievement, counting libraries and not versions

### DIFF
--- a/badges/sources.py
+++ b/badges/sources.py
@@ -40,6 +40,27 @@ def _iter_library_authoring():
             yield user, library
 
 
+def _iter_library_maintenance():
+    """Yield (user, library) once per library the user maintains.
+
+    Maintainers are recorded per ``LibraryVersion``, but the badge counts
+    *libraries* maintained (thresholds 1/2/5/...), so pairs are deduplicated
+    across versions and the ``Library`` is the achievement source.
+    """
+    from libraries.models import LibraryVersion
+
+    seen = set()
+    versions = LibraryVersion.objects.select_related("library").prefetch_related(
+        "maintainers"
+    )
+    for version in versions.iterator(chunk_size=500):
+        for user in version.maintainers.all():
+            key = (user.pk, version.library_id)
+            if key not in seen:
+                seen.add(key)
+                yield user, version.library
+
+
 def _iter_code_commits():
     """Yield (user, commit) for every attributed commit."""
     from libraries.models import Commit
@@ -55,6 +76,7 @@ def _iter_code_commits():
 
 BACKFILL_ITERATORS = {
     AchievementSlug.LIBRARY_AUTHORING: _iter_library_authoring,
+    AchievementSlug.LIBRARY_MAINTENANCE: _iter_library_maintenance,
     AchievementSlug.CODE_COMMITS: _iter_code_commits,
 }
 

--- a/badges/sources.py
+++ b/badges/sources.py
@@ -45,13 +45,16 @@ def _iter_library_maintenance():
 
     Maintainers are recorded per ``LibraryVersion``, but the badge counts
     *libraries* maintained (thresholds 1/2/5/...), so pairs are deduplicated
-    across versions and the ``Library`` is the achievement source.
+    across versions and the ``Library`` is the achievement source. Only parent
+    libraries count: see the module docstring.
     """
     from libraries.models import LibraryVersion
 
     seen = set()
-    versions = LibraryVersion.objects.select_related("library").prefetch_related(
-        "maintainers"
+    versions = (
+        LibraryVersion.objects.exclude(library__key__in=SUB_LIBRARIES)
+        .select_related("library")
+        .prefetch_related("maintainers")
     )
     for version in versions.iterator(chunk_size=500):
         for user in version.maintainers.all():

--- a/badges/tests/test_commands.py
+++ b/badges/tests/test_commands.py
@@ -85,6 +85,26 @@ def test_backfill_library_authoring(plain_user):
     ).exists()
 
 
+def test_backfill_library_maintenance(plain_user):
+    """Backfill grants the maintenance achievement once per library maintained."""
+    library = baker.make("libraries.Library")
+    for _ in range(2):
+        version = baker.make("libraries.LibraryVersion", library=library)
+        version.maintainers.add(plain_user)
+
+    call_command("backfill_achievements", "--source", "library-maintenance")
+
+    assert (
+        UserAchievement.objects.filter(
+            user=plain_user, achievement__slug="library-maintenance"
+        ).count()
+        == 1
+    )
+    assert UserBadge.objects.filter(
+        user=plain_user, badge__achievement__slug="library-maintenance"
+    ).exists()
+
+
 def test_backfill_fails_loudly_on_an_explicit_unseeded_source(plain_user):
     """A named source with no Achievement row is a deploy bug, not a skip."""
     Achievement.objects.filter(slug=AchievementSlug.CODE_COMMITS).delete()

--- a/badges/tests/test_sources.py
+++ b/badges/tests/test_sources.py
@@ -66,6 +66,17 @@ def test_iter_library_authoring_skips_sub_libraries(plain_user):
     assert list(sources._iter_library_authoring()) == []
 
 
+def test_iter_library_maintenance_dedupes_versions(plain_user):
+    """Maintaining many versions of one library yields a single pair."""
+    library = baker.make("libraries.Library")
+    for _ in range(3):
+        version = baker.make("libraries.LibraryVersion", library=library)
+        version.maintainers.add(plain_user)
+
+    pairs = list(sources._iter_library_maintenance())
+    assert pairs == [(plain_user, library)]
+
+
 def test_iter_code_commits_skips_unlinked(plain_user):
     """Only commits whose author has a linked user are yielded."""
     linked = baker.make("libraries.CommitAuthor", user=plain_user)

--- a/badges/tests/test_sources.py
+++ b/badges/tests/test_sources.py
@@ -77,6 +77,15 @@ def test_iter_library_maintenance_dedupes_versions(plain_user):
     assert pairs == [(plain_user, library)]
 
 
+def test_iter_library_maintenance_skips_sub_libraries(plain_user):
+    """Maintaining a sub-library is maintaining part of its parent's docs."""
+    sub = baker.make("libraries.Library", key="math/quaternion")
+    version = baker.make("libraries.LibraryVersion", library=sub)
+    version.maintainers.add(plain_user)
+
+    assert list(sources._iter_library_maintenance()) == []
+
+
 def test_iter_code_commits_skips_unlinked(plain_user):
     """Only commits whose author has a linked user are yielded."""
     linked = baker.make("libraries.CommitAuthor", user=plain_user)


### PR DESCRIPTION
# Issue: #2586 

⚠️ Base branch is `teo/2541-source-library-authoring`

## Summary & Context

Wires the **Library Maintenance** achievement. The one thing worth reviewing here is the grain:
maintainers are recorded per `LibraryVersion`, but the badge counts **libraries maintained**
(1 / 2 / 5 / 10 / 20), so the iterator deduplicates across versions and yields the `Library` as
the achievement source.

Without that, a maintainer of one library with 40 releases would hold diamond.

- **Figma link**: n/a
- **Link to components/page:** n/a

## Changes

- `_iter_library_maintenance` walks `LibraryVersion` with its maintainers prefetched and yields
  `(user, library)` once per `(user, library)` pair, tracking what it has already seen.
- Registered in `BACKFILL_ITERATORS`.
- `test_iter_library_maintenance_dedupes_versions` - three versions of one library yield exactly
  one pair.
- `test_backfill_library_maintenance` - two versions, one grant, one badge.

## ‼️ Risks & Considerations ‼️

- The dedup set is held in memory for the whole walk. It is one tuple per `(user, library)` pair,
  bounded by the number of maintainer relationships, not by the number of versions - a few
  thousand entries at Boost's scale.
- The source object recorded on the grant is the **`Library`**, not the `LibraryVersion`. This is
  what makes the grant idempotent under `unique_automatic_user_achievement_source` and what lets
  reconciliation match it. An earlier iteration of this feature recorded versions and had to be
  cleaned up with a data migration; a fresh install never creates those rows.
- Dropping a maintainer from every version of a library removes the grant on the next
  **reconcile**, the two-way command, not on a backfill. That is by design.

## Screenshots

n/a - no UI.

## Peer-review testing steps

The dedup is basically the whole PR, and it is visible on a changelist.

1. **The source is wired.** `/admin/badges/badge/` - the **Maintainer** row's *Automatic* column is a
   tick and its ladder reads `1 / 2 / 5 / 10 / 20`.

2. **Make yourself a maintainer of one library, several times over.**
   `/admin/libraries/libraryversion/`, filter by a single library, then open **three** of its versions
   and add your own user to **Maintainers** on each.

3. **Backfill.** `/admin/badges/userachievement/` -> **Backfill achievements** with *Source* set to
   **Library Maintenance**.

4. **Three versions, one grant.** Filter that changelist by *Achievement: Library Maintenance*: you
   have exactly **one** row, and its **Source** column links to the **library**, not to any of the
   three versions. Without the dedup this step is where you would see three. `/admin/badges/userbadge/`
   shows **Maintainer / Bronze**; the per-member page (your name, linked from either badge changelist)
   reads one valid grant and *1 to go* to Silver.

5. **A second library does move the count.** Add yourself to **Maintainers** on one version of a
   *different* library and press **Backfill** again: two grants, and **Maintainer / Silver** is
   awarded. This is what proves the dedup is per (member, library) and not just "one grant per member".

6. **Removal is a reconcile, and it demotes.** Drop yourself from all three versions of the first
   library. **Backfill** changes nothing. Then **Reconcile achievements** with *Source* on **Library
   Maintenance**: the preview reports one removal, Apply, and the Silver row is revoked with
   *Count at revocation* 1 while Bronze stays held. `/admin/badges/achievementsyncrun/` shows the run
   with **Removed 1**, and the revoked badge's notes name it.

7. **Sanity-check against real data.** Backfill **All sources** on a production copy, then filter
   `/admin/badges/userbadge/` to *Badge: Maintainer* and *Rank: Diamond*. Every name there must genuinely
   maintain 20 or more libraries - filter `/admin/badges/userachievement/` by *Achievement: Library
   Maintenance*, search their email, and count the rows, whose Source links must all be distinct
   libraries. Without the dedup, anyone maintaining a single long-lived library would be sitting in that
   Diamond list, which is the failure this PR exists to prevent.

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Backend
- [x] Black + Ruff clean
- [x] No new models or migrations
- [x] Full suite green: **1336 passed / 43 skipped**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic recognition of the Library Maintenance achievement for users who maintain libraries.
  - Prevented duplicate achievements when users maintain multiple versions of the same library.
  - Excluded sub-libraries from Library Maintenance achievement awards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->