### PR TITLE
fix(2522): support testimonials without body

### DIFF
--- a/static/css/v3/testimonial-card.css
+++ b/static/css/v3/testimonial-card.css
@@ -216,6 +216,14 @@
     box-sizing: border-box;
 }
 
+/* Rendered as a <span> when the testimonial has no body to open, so :disabled
+   does not apply — mirror the .btn:disabled treatment here. */
+.testimonial-card__cta[aria-disabled="true"] {
+    opacity: 0.5;
+    pointer-events: none;
+    cursor: default;
+}
+
 .testimonial-card__author-role-text {
     color: var(--color-text-secondary);
 }

--- a/templates/v3/includes/_content_modal_group.html
+++ b/templates/v3/includes/_content_modal_group.html
@@ -8,8 +8,13 @@
                           subtitle (optional), prev_url, next_url.
                           Caller is responsible for slug stability and for
                           setting prev_url / next_url to "" at endpoints.
+                          Items with empty content are skipped rather than
+                          rendered as an empty modal, so callers may pass a
+                          mixed list and keep the ordering intact.
     close_url (optional): close target. Defaults to "#_".
 {% endcomment %}
 {% for item in items %}
-  {% include "v3/includes/_content_modal.html" with modal_id=item.slug title=item.title subtitle=item.subtitle content=item.content prev_url=item.prev_url next_url=item.next_url close_url=close_url only %}
+  {% if item.content %}
+    {% include "v3/includes/_content_modal.html" with modal_id=item.slug title=item.title subtitle=item.subtitle content=item.content prev_url=item.prev_url next_url=item.next_url close_url=close_url only %}
+  {% endif %}
 {% endfor %}

--- a/templates/v3/includes/_testimonial_card.html
+++ b/templates/v3/includes/_testimonial_card.html
@@ -8,12 +8,15 @@
     testimonials   (list, optional)    — list of testimonial objects with:
       - quote      (string, optional)  — testimonial text to display
       - author     (object, optional)  — passed to _user_profile.html (see that template for fields)
-      - slug       (string, optional)  — when set, the quote bubble becomes a
-                                         link to "#{slug}", opening a matching
-                                         Content Modal via :target.
-      - content    (HTML, optional)    — when set on at least the first item,
-                                         the matching Content Modal group is
-                                         bundled below the card.
+      - slug       (string, optional)  — when set alongside content, the quote
+                                         bubble becomes a link to "#{slug}",
+                                         opening a matching Content Modal via
+                                         :target.
+      - content    (HTML, optional)    — full text shown in the modal. Items
+                                         carrying content get a Content Modal
+                                         bundled below the card; items without
+                                         it keep a plain quote bubble and a
+                                         disabled "Read more".
 
   Usage:
     {% include "v3/includes/_testimonial_card.html" with heading="Testimonials" testimonials=testimonials %}
@@ -109,7 +112,7 @@
           {% if testimonials %}
             {% for testimonial in testimonials %}
               <li class="testimonial-card__list-item">
-                {% if testimonial.slug %}<a class="testimonial-card__quote-link" href="#{{ testimonial.slug }}">{% else %}<div>{% endif %}
+                {% if testimonial.slug and testimonial.content %}<a class="testimonial-card__quote-link" href="#{{ testimonial.slug }}">{% else %}<div>{% endif %}
                   <div class="testimonial-card__text-wrapper">
                     <div class="testimonial-card__text">{{ testimonial.quote }}</div>
                   </div>
@@ -118,7 +121,7 @@
                       <path class="testimonial-card__text-tail" d="M0 0H32L3.41421 28.5858C2.15428 29.8457 0 28.9534 0 27.1716V0Z" />
                     </svg>
                   </div>
-                {% if testimonial.slug %}</a>{% else %}</div>{% endif %}
+                {% if testimonial.slug and testimonial.content %}</a>{% else %}</div>{% endif %}
                 {% include "v3/includes/_user_profile.html" with author=testimonial.author new_tab=True only %}
               </li>
             {% endfor %}
@@ -129,20 +132,31 @@
 
   <hr class="card__hr" aria-hidden="true" />
 
-  {% comment %} One CTA per slide; targets the same modal slug as the quote-bubble link. {% endcomment %}
+  {% comment %}
+    One CTA per slide; targets the same modal slug as the quote-bubble link.
+    Items without content have no modal to open, so their CTA stays in place
+    but renders disabled.
+  {% endcomment %}
   {% for testimonial in testimonials %}
     {% if testimonial.slug %}
-      <a href="#{{ testimonial.slug }}"
-         class="btn btn-primary testimonial-card__cta testimonial-card__cta--{{ forloop.counter }}"
-         aria-label="Read more about {{ testimonial.title }}">
-        Read more
-      </a>
+      {% if testimonial.content %}
+        <a href="#{{ testimonial.slug }}"
+           class="btn btn-primary testimonial-card__cta testimonial-card__cta--{{ forloop.counter }}"
+           aria-label="Read more about {{ testimonial.title }}">
+          Read more
+        </a>
+      {% else %}
+        <span class="btn btn-primary testimonial-card__cta testimonial-card__cta--{{ forloop.counter }}"
+              role="link"
+              aria-disabled="true"
+              aria-label="Read more about {{ testimonial.title }}">
+          Read more
+        </span>
+      {% endif %}
     {% endif %}
   {% endfor %}
 </section>
 
 {% comment %} Modals rendered as siblings of the card so :target wires up the quote-bubble links. {% endcomment %}
-{% if testimonials.0.content %}
-  {% include "v3/includes/_content_modal_group.html" with items=testimonials only %}
-{% endif %}
+{% include "v3/includes/_content_modal_group.html" with items=testimonials only %}
 {% endwith %}

--- a/testimonials/tests.py
+++ b/testimonials/tests.py
@@ -1,1 +1,0 @@
-# Create your tests here.

--- a/testimonials/tests/test_testimonial_cards.py
+++ b/testimonials/tests/test_testimonial_cards.py
@@ -1,0 +1,108 @@
+"""Presenter and template behaviour for the homepage testimonial carousel."""
+
+from django.template.loader import render_to_string
+
+from testimonials.models import Testimonial
+from testimonials.utils import get_testimonial_cards
+
+
+def make_testimonial(slug, body=None):
+    """Build an unsaved Testimonial; the presenter only reads fields, so no DB."""
+    testimonial = Testimonial(
+        title=slug.title(), author="Author", author_slug=slug, slug=slug
+    )
+    testimonial.pull_quote = [("md", f"Quote for {slug}")]
+    if body is not None:
+        testimonial.body = body
+    return testimonial
+
+
+def render_card(cards):
+    return render_to_string(
+        "v3/includes/_testimonial_card.html",
+        {"heading": "What engineers are saying", "testimonials": cards},
+    )
+
+
+def test_testimonial_without_body_has_no_content():
+    (card,) = get_testimonial_cards(qs=[make_testimonial("no-body")])
+
+    assert card["content"] == ""
+
+
+def test_blank_rich_text_block_counts_as_no_content():
+    """An empty rich-text block still renders a wrapper div, but shows nothing."""
+    (card,) = get_testimonial_cards(qs=[make_testimonial("blank", [("rich", "")])])
+
+    assert card["content"] == ""
+
+
+def test_body_holding_only_an_image_counts_as_content():
+    (card,) = get_testimonial_cards(
+        qs=[make_testimonial("image", [("rich", '<img src="/a.png">')])]
+    )
+
+    assert card["content"] != ""
+
+
+def test_modal_navigation_skips_testimonials_without_a_body():
+    """Prev/next must never point at a slug with no modal behind it."""
+    cards = get_testimonial_cards(
+        qs=[
+            make_testimonial("first", [("md", "First body")]),
+            make_testimonial("middle"),
+            make_testimonial("last", [("md", "Last body")]),
+        ]
+    )
+
+    first, middle, last = cards
+    assert (first["prev_url"], first["next_url"]) == ("#last", "#last")
+    assert (last["prev_url"], last["next_url"]) == ("#first", "#first")
+    assert (middle["prev_url"], middle["next_url"]) == ("", "")
+
+
+def test_modals_render_when_the_first_testimonial_has_no_body():
+    """A body-less card in the lead slot must not suppress the other modals."""
+    cards = get_testimonial_cards(
+        qs=[
+            make_testimonial("no-body"),
+            make_testimonial("has-body", [("md", "Full testimonial text")]),
+        ]
+    )
+
+    html = render_card(cards)
+
+    assert 'id="has-body"' in html
+    assert 'href="#has-body"' in html
+    assert 'id="no-body"' not in html
+
+
+def test_read_more_is_disabled_for_a_testimonial_without_a_body():
+    cards = get_testimonial_cards(qs=[make_testimonial("no-body")])
+
+    html = render_card(cards)
+
+    assert 'aria-disabled="true"' in html
+    assert "Read more" in html
+    assert 'href="#no-body"' not in html
+
+
+def test_quote_bubble_is_not_a_link_without_a_body():
+    cards = get_testimonial_cards(qs=[make_testimonial("no-body")])
+
+    html = render_card(cards)
+
+    assert "testimonial-card__quote-link" not in html
+
+
+def test_every_testimonial_still_gets_a_card():
+    """Missing bodies hide the modal, not the quote."""
+    cards = get_testimonial_cards(
+        qs=[make_testimonial("no-body"), make_testimonial("has-body", [("md", "Hi")])]
+    )
+
+    html = render_card(cards)
+
+    assert len(cards) == 2
+    assert "Quote for no-body" in html
+    assert "Quote for has-body" in html

--- a/testimonials/utils.py
+++ b/testimonials/utils.py
@@ -1,6 +1,7 @@
 """Reusable presenters for Testimonial pages (homepage carousel, demo page, etc.)."""
 
 import html
+import re
 
 from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
@@ -8,10 +9,29 @@ from wagtail.rich_text import expand_db_html
 
 from testimonials.models import Testimonial
 
+# Tags that carry visible content on their own, so a body holding only these
+# is not blank even though stripping tags leaves no text behind.
+_MEDIA_TAG_RE = re.compile(
+    r"<(img|iframe|video|audio|embed|object|svg)\b", re.IGNORECASE
+)
+
 
 def _pull_quote_text(testimonial):
     """Plain-text pull quote for the carousel bubble (StreamField renders to HTML)."""
     return html.unescape(strip_tags(str(testimonial.pull_quote))).strip()
+
+
+def _body_html(testimonial):
+    """Rendered body HTML, normalized to "" when it holds nothing visible.
+
+    An unset StreamField already stringifies to "", but a rich-text block left
+    blank renders an empty wrapper div. Both mean "no modal to open", so the
+    templates get a single falsy value to branch on.
+    """
+    body = str(testimonial.body)
+    if strip_tags(body).strip() or _MEDIA_TAG_RE.search(body):
+        return body
+    return ""
 
 
 def _avatar_url(testimonial):
@@ -36,15 +56,15 @@ def _author_role_html(testimonial):
     return mark_safe(expanded)
 
 
-def _to_card(testimonial, *, prev_slug, next_slug):
+def _to_card(testimonial, *, content, prev_slug, next_slug):
     return {
         "quote": _pull_quote_text(testimonial),
-        "content": str(testimonial.body),
+        "content": content,
         "title": testimonial.title,
         "subtitle": f"By {testimonial.author}",
         "slug": testimonial.slug,
-        "prev_url": f"#{prev_slug}",
-        "next_url": f"#{next_slug}",
+        "prev_url": f"#{prev_slug}" if prev_slug else "",
+        "next_url": f"#{next_slug}" if next_slug else "",
         "author": {
             "name": testimonial.author,
             "profile_url": testimonial.author_url,
@@ -60,6 +80,10 @@ def get_testimonial_cards(qs=None, limit=None):
     Defaults to live testimonials that have a pull quote, newest first; pass a
     custom `qs` to scope/order differently. The page slug targets the bundled
     Content Modal, with prev/next wrapping cyclically.
+
+    A testimonial may have a pull quote but no body. Those still get a card, so
+    the quote stays on the page, but no modal — and the prev/next cycle skips
+    them so paging never lands on a slug with nothing rendered behind it.
     """
     if qs is None:
         qs = (
@@ -68,12 +92,30 @@ def get_testimonial_cards(qs=None, limit=None):
             .order_by("-first_published_at")
         )
     testimonials = list(qs[:limit] if limit is not None else qs)
-    count = len(testimonials)
-    return [
-        _to_card(
-            testimonial,
-            prev_slug=testimonials[(i - 1) % count].slug,
-            next_slug=testimonials[(i + 1) % count].slug,
-        )
-        for i, testimonial in enumerate(testimonials)
+    contents = [_body_html(testimonial) for testimonial in testimonials]
+
+    modal_slugs = [
+        testimonial.slug
+        for testimonial, content in zip(testimonials, contents)
+        if content
     ]
+    neighbors = {
+        slug: (
+            modal_slugs[(i - 1) % len(modal_slugs)],
+            modal_slugs[(i + 1) % len(modal_slugs)],
+        )
+        for i, slug in enumerate(modal_slugs)
+    }
+
+    cards = []
+    for testimonial, content in zip(testimonials, contents):
+        prev_slug, next_slug = neighbors.get(testimonial.slug, ("", ""))
+        cards.append(
+            _to_card(
+                testimonial,
+                content=content,
+                prev_slug=prev_slug,
+                next_slug=next_slug,
+            )
+        )
+    return cards


### PR DESCRIPTION
# Issue: #2522 

## Summary & Context
By giving support for testimonials without body text, this fixes the bug that broke the modal for the ones that did have it.

- **Figma link**: https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=4361-27813&m=dev
- **Link to components/page:** http://localhost:8000/ (home)

## Changes

- **testimonials/utils.py**: new _body_html() normalizes a body to "" when it renders nothing visible (a blank rich-text block stringifies to a truthy empty <div>; media-only bodies still count as content), and get_testimonial_cards() builds the modal prev/next cycle from only the cards that have a body, so paging never lands on a slug with no modal behind it.
- **templates/v3/includes/_testimonial_card.html**: removed the {% if testimonials.0.content %} gate that suppressed every modal when the first testimonial had an empty body (the actual bug); the quote bubble now links only when the item has both a slug and content, and "Read more" stays visible but renders as <span role="link" aria-disabled="true"> when there's no body.
- **templates/v3/includes/_content_modal_group.html**: skips items with empty content instead of emitting an empty modal shell.
- **testimonial-card.css**: .testimonial-card__cta[aria-disabled="true"] mirrors .btn:disabled, which doesn't apply to a `<span>`.
- **testimonials/tests/test_testimonial_cards.py**: 8 tests covering the presenter and rendered markup, moved out of the placeholder testimonials/tests.py that pytest.ini (python_files = test_*.py) would never have collected.

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*

## Screenshots

### Before: broken modals for testimonials with body text

https://github.com/user-attachments/assets/6fb1385e-91d1-488f-a2d1-22589d7fe871


### After: disabled button for testimonials without body text, the others work again.

<img width="714" height="431" alt="SCR-20260810-qgea" src="https://github.com/user-attachments/assets/f78b4c15-58ac-477a-8230-743a268487d6" />
<img width="1213" height="761" alt="SCR-20260810-qgib" src="https://github.com/user-attachments/assets/cb78094a-4c65-433a-8d69-88f816648ac2" />


## Self-review Checklist
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved testimonial cards to distinguish between testimonials with readable content and quote-only entries.
  * Added modal navigation that includes only testimonials with available content.
  * Preserved testimonial cards without bodies while disabling unavailable “Read more” actions.
  * Recognized text and standalone media as valid testimonial content.

* **Bug Fixes**
  * Prevented empty content modals and invalid quote links from being displayed.
  * Added clearer disabled styling for unavailable testimonial actions.

* **Tests**
  * Added coverage for testimonial content detection, modal rendering, navigation, and disabled actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->