### PR TITLE
Fix upsert logic during release import

### DIFF
--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -223,6 +223,10 @@ def import_version(
     # Save the response we got from Github, if present
     if perform_upsert:
         version, created = _upsert_version_from_tag(tag, base_url, beta, full_release)
+    else:
+        # The version was already upserted by the caller (import_versions flow).
+        version = Version.objects.with_partials().get(name=name)
+        created = False
 
     logger.info(f"import_versions_version {created=} {name=} {version.pk} ")
 

--- a/versions/tests/test_tasks.py
+++ b/versions/tests/test_tasks.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 from versions.models import Version
-from versions.tasks import get_release_date_for_version, skip_tag
+from versions.tasks import get_release_date_for_version, import_version, skip_tag
 from libraries.management.commands.release_tasks import ReleaseTasksManager
 
 import pytest
@@ -51,6 +51,24 @@ def test_skip_tag(version):
 
     # Assert a random tag name is not skipped
     assert skip_tag("sample") is False
+
+
+@pytest.mark.django_db
+@patch("versions.tasks.import_library_versions")
+@patch("versions.tasks.import_release_downloads")
+def test_import_version_without_upsert(downloads_mock, library_versions_mock, version):
+    """
+    Regression test: when called with perform_upsert=False (as the
+    import_versions release flow does), import_version must load the
+    already-upserted Version instead of crashing on unbound locals.
+    """
+    import_version.run(
+        name=version.name,
+        tag={"name": version.name},
+        perform_upsert=False,
+    )
+    downloads_mock.assert_called_once_with(version.pk)
+    library_versions_mock.assert_called_once_with(version.name, token=None)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The import of boost 1.92.0 failed.

"""

What happened

Your correlation with post-April commits is exactly right. Commit 9aa3413d ("Bug: Correct race condition in release tasks version import", merged May 5, 2026 — after the 1.91.0 release) restructured the import flow:

import_versions (what "IMPORT NEW RELEASES" triggers) now upserts all the Version rows synchronously up front, in _import_missing_versions, to fix the race condition.
It then fans out an import_version Celery task per tag with perform_upsert=False, so the version isn't saved a second time.
But inside import_version, the assignment of both version and created was left inside the if perform_upsert: branch:


tasks.py

Lines 222-226

Save the response we got from Github, if present
if perform_upsert:
    version, created = _upsert_version_from_tag(tag, base_url, beta, full_release)
logger.info(f"import_versions_version {created=} {name=} {version.pk} ")
So when called from the release import flow (the only caller that passes perform_upsert=False), neither variable exists. The log line trips first on created, but version is also unbound, and it's used for real work right after — version.release_date (line 229), version.pk for import_release_downloads (line 234), and version.name for import_library_versions (line 237). So the task would fail regardless of the logging.

Why it wasn't caught until now
Every other caller (import_development_versions, import_beta_release, etc.) uses the default perform_upsert=True, which works fine. The broken path only executes during a full release import — which hasn't happened since the commit landed. This is its first run in production.

The fix
Since _import_missing_versions already upserted the row, import_version just needs to fetch it when it's told not to upsert:

if perform_upsert:
    version, created = _upsert_version_from_tag(tag, base_url, beta, full_release)
else:
    version = Version.objects.with_partials().get(name=name)
    created = False
One reassuring note: because the upserts already completed synchronously before the tasks crashed, your Version rows for 1.92.0 are likely in the database — what got skipped is the per-version downstream work (release date, downloads, library-versions). But note line 93 deletes any versions with fully_imported=False at the start of each run, so re-running the import after the fix should cleanly redo everything.

cc @jlchilders11 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version imports when update mode is disabled, ensuring existing versions are correctly recognized instead of being treated as uninitialized.
  * Preserved expected download and library-version import behavior during this workflow.

* **Tests**
  * Added regression coverage for importing an existing version without performing an upsert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->