### PR TITLE
Story #2607 :: Task: Wire the Library Versioning achievement to per-release authorship

### DIFF
--- a/badges/sources.py
+++ b/badges/sources.py
@@ -64,6 +64,17 @@ def _iter_library_maintenance():
                 yield user, version.library
 
 
+def _iter_library_versioning():
+    """Yield (user, library_version) for every per-version authorship."""
+    from libraries.models import LibraryVersion
+
+    for version in LibraryVersion.objects.prefetch_related("authors").iterator(
+        chunk_size=500
+    ):
+        for user in version.authors.all():
+            yield user, version
+
+
 def _iter_code_commits():
     """Yield (user, commit) for every attributed commit."""
     from libraries.models import Commit
@@ -80,6 +91,7 @@ def _iter_code_commits():
 BACKFILL_ITERATORS = {
     AchievementSlug.LIBRARY_AUTHORING: _iter_library_authoring,
     AchievementSlug.LIBRARY_MAINTENANCE: _iter_library_maintenance,
+    AchievementSlug.LIBRARY_VERSIONING: _iter_library_versioning,
     AchievementSlug.CODE_COMMITS: _iter_code_commits,
 }
 

--- a/badges/sources.py
+++ b/badges/sources.py
@@ -65,12 +65,16 @@ def _iter_library_maintenance():
 
 
 def _iter_library_versioning():
-    """Yield (user, library_version) for every per-version authorship."""
+    """Yield (user, library_version) for every authorship of a parent's release.
+
+    Only parent libraries count: see the module docstring.
+    """
     from libraries.models import LibraryVersion
 
-    for version in LibraryVersion.objects.prefetch_related("authors").iterator(
-        chunk_size=500
-    ):
+    versions = LibraryVersion.objects.exclude(
+        library__key__in=SUB_LIBRARIES
+    ).prefetch_related("authors")
+    for version in versions.iterator(chunk_size=500):
         for user in version.authors.all():
             yield user, version
 

--- a/badges/tests/test_commands.py
+++ b/badges/tests/test_commands.py
@@ -105,6 +105,22 @@ def test_backfill_library_maintenance(plain_user):
     ).exists()
 
 
+def test_backfill_library_versioning(plain_user):
+    """Backfill grants the versioning achievement per LibraryVersion authored."""
+    for _ in range(2):
+        version = baker.make("libraries.LibraryVersion")
+        version.authors.add(plain_user)
+
+    call_command("backfill_achievements", "--source", "library-versioning")
+
+    assert (
+        UserAchievement.objects.filter(
+            user=plain_user, achievement__slug="library-versioning"
+        ).count()
+        == 2
+    )
+
+
 def test_backfill_fails_loudly_on_an_explicit_unseeded_source(plain_user):
     """A named source with no Achievement row is a deploy bug, not a skip."""
     Achievement.objects.filter(slug=AchievementSlug.CODE_COMMITS).delete()

--- a/badges/tests/test_sources.py
+++ b/badges/tests/test_sources.py
@@ -86,6 +86,15 @@ def test_iter_library_maintenance_skips_sub_libraries(plain_user):
     assert list(sources._iter_library_maintenance()) == []
 
 
+def test_iter_library_versioning_skips_sub_libraries(plain_user):
+    """A sub-library's releases belong to its parent, and count for nothing here."""
+    sub = baker.make("libraries.Library", key="math/quaternion")
+    version = baker.make("libraries.LibraryVersion", library=sub)
+    version.authors.add(plain_user)
+
+    assert list(sources._iter_library_versioning()) == []
+
+
 def test_iter_code_commits_skips_unlinked(plain_user):
     """Only commits whose author has a linked user are yielded."""
     linked = baker.make("libraries.CommitAuthor", user=plain_user)


### PR DESCRIPTION
# Issue: #2607 

⚠️ Base branch is `teo/2486-badge-profile-display` 

## Summary & Context

Wires the **Library Maintenance** achievement. The one thing worth reviewing here is the grain:
maintainers are recorded per `LibraryVersion`, but the badge counts **libraries maintained**
(1 / 2 / 5 / 10 / 20), so the iterator deduplicates across versions and yields the `Library` as
the achievement source.

Without that, a maintainer of one library with 40 releases would hold diamond.

- **Figma link**: n/a
- **Link to components/page:** n/a

## Changes

- `_iter_library_maintenance` walks `LibraryVersion` with its maintainers prefetched and yields
  `(user, library)` once per `(user, library)` pair, tracking what it has already seen.
- Registered in `BACKFILL_ITERATORS`.
- `test_iter_library_maintenance_dedupes_versions` - three versions of one library yield exactly
  one pair.
- `test_backfill_library_maintenance` - two versions, one grant, one badge.

## ‼️ Risks & Considerations ‼️

- The dedup set is held in memory for the whole walk. It is one tuple per `(user, library)` pair,
  bounded by the number of maintainer relationships, not by the number of versions - a few
  thousand entries at Boost's scale.
- The source object recorded on the grant is the **`Library`**, not the `LibraryVersion`. This is
  what makes the grant idempotent under `unique_automatic_user_achievement_source` and what lets
  reconciliation match it. An earlier iteration of this feature recorded versions and had to be
  cleaned up with a data migration; 
- Dropping a maintainer from every version of a library removes the grant on the next
  **reconcile**, the two-way command, not on a backfill. That is by design.

## Screenshots

n/a - no UI.

## Peer-review & QA testing steps

The dedup is the whole PR, and it is visible on a changelist. 
**Setup for local env only** (@kattyode, you may ignore this): `just load_production_data`,
`just migrate`, `docker compose up`.

1. **The source is wired.** `/admin/badges/badge/` - the **Maintainer** row's *Automatic* column is a
   tick and its ladder reads `1 / 2 / 5 / 10 / 20`.

2. **Make yourself a maintainer of one library, several times over.**
   `/admin/libraries/libraryversion/`, filter by a single library, then open **three** of its versions
   and add your own user to **Maintainers** on each.

3. **Backfill.** `/admin/badges/userachievement/` -> **Backfill achievements** with *Source* set to
   **Library Maintenance**.

4. **Three versions, one grant.** Filter that changelist by *Achievement: Library Maintenance*: you
   have exactly **one** row, and its **Source** column links to the **library**, not to any of the
   three versions. Without the dedup this step is where you would see three. `/admin/badges/userbadge/`
   shows **Maintainer / Bronze**; the per-member page (your name, linked from either badge changelist)
   reads one valid grant and *1 to go* to Silver.

5. **A second library does move the count.** Add yourself to **Maintainers** on one version of a
   *different* library and press **Backfill** again: two grants, and **Maintainer / Silver** is
   awarded. This is what proves the dedup is per (member, library) and not just "one grant per member".

6. **Removal is a reconcile, and it demotes.** Drop yourself from all three versions of the first
   library. **Backfill** changes nothing. Then **Reconcile achievements** with *Source* on **Library
   Maintenance**: the preview reports one removal, Apply, and the Silver row is revoked with
   *Count at revocation* 1 while Bronze stays held. `/admin/badges/achievementsyncrun/` shows the run
   with **Removed 1**, and the revoked badge's notes name it.

7. **Sanity-check against real data.** Backfill **All sources** on a production copy, then filter
   `/admin/badges/userbadge/` to *Badge: Maintainer* and *Rank: Diamond*. Every name there must genuinely
   maintain 20 or more libraries - filter `/admin/badges/userachievement/` by *Achievement: Library
   Maintenance*, search their email, and count the rows, whose Source links must all be distinct
   libraries. Without the dedup, anyone maintaining a single long-lived library would be sitting in that
   Diamond list, which is the failure this PR exists to prevent.