### PR TITLE
Story #2609 :: Task: Run the achievement backfill from the weekly release pipeline

### DIFF
--- a/libraries/management/commands/release_tasks.py
+++ b/libraries/management/commands/release_tasks.py
@@ -61,6 +61,8 @@ class ReleaseTasksManager(ActionsManager):
             Action("Updating slack activity buckets", ["fetch_slack_activity"]),
             Action("Updating website statistics", self.update_website_statistics),
             Action("Importing mailing list counts", self.import_ml_counts),
+            # Last, so every source it reads has already been refreshed above.
+            Action("Backfilling achievements", ["backfill_achievements"]),
             # Action("Generating report", self.generate_report),
         ]
 

--- a/libraries/management/commands/release_tasks.py
+++ b/libraries/management/commands/release_tasks.py
@@ -62,7 +62,10 @@ class ReleaseTasksManager(ActionsManager):
             Action("Updating website statistics", self.update_website_statistics),
             Action("Importing mailing list counts", self.import_ml_counts),
             # Last, so every source it reads has already been refreshed above.
-            Action("Backfilling achievements", ["backfill_achievements"]),
+            Action(
+                "Backfilling achievements",
+                ["backfill_achievements", "--trigger", "pipeline"],
+            ),
             # Action("Generating report", self.generate_report),
         ]
 

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -283,7 +283,7 @@ def update_authors_and_maintainers():
     call_command("update_library_version_authors", "--clean")
     app.signature("users.tasks.recompute_displayed_profile_roles").apply_async()
     # Only the sources whose upstream data just changed. A blanket backfill would
-    # also sweep the commit, review and news tables this task never touches.
+    # also sweep the commit and review tables this task never touches.
     call_command(
         "backfill_achievements",
         "--source",

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -282,6 +282,17 @@ def update_authors_and_maintainers():
     call_command("update_maintainers")
     call_command("update_library_version_authors", "--clean")
     app.signature("users.tasks.recompute_displayed_profile_roles").apply_async()
+    # Only the sources whose upstream data just changed. A blanket backfill would
+    # also sweep the commit, review and news tables this task never touches.
+    call_command(
+        "backfill_achievements",
+        "--source",
+        "library-authoring",
+        "--source",
+        "library-maintenance",
+        "--source",
+        "library-versioning",
+    )
 
 
 @app.task
@@ -363,6 +374,10 @@ def update_commits(token=None, clean=False, min_version=""):
         )
     logger.info("update_commits finished.")
     app.signature("users.tasks.recompute_displayed_profile_roles").apply_async()
+    # No achievement backfill here on purpose: this runs as a step of the
+    # release_tasks command, which sweeps every source once at the end. Calling
+    # it here too would walk the whole Commit table twice per release. Ad hoc
+    # runs use the "Backfill achievements" button in the badges admin.
     return commits_handled
 
 

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -281,7 +281,7 @@ def update_authors_and_maintainers():
     call_command("update_authors")
     call_command("update_maintainers")
     call_command("update_library_version_authors", "--clean")
-    app.signature("users.tasks.recompute_displayed_profile_roles").apply_async()
+    app.signature("users.tasks.recompute_displayed_profile_roles").apply().get()
     # Only the sources whose upstream data just changed. A blanket backfill would
     # also sweep the commit and review tables this task never touches.
     call_command(
@@ -373,7 +373,7 @@ def update_commits(token=None, clean=False, min_version=""):
             library=library, clean=clean, min_version=min_version
         )
     logger.info("update_commits finished.")
-    app.signature("users.tasks.recompute_displayed_profile_roles").apply_async()
+    app.signature("users.tasks.recompute_displayed_profile_roles").apply().get()
     # No achievement backfill here on purpose: this runs as a step of the
     # release_tasks command, which sweeps every source once at the end. Calling
     # it here too would walk the whole Commit table twice per release. Ad hoc

--- a/libraries/tests/test_tasks.py
+++ b/libraries/tests/test_tasks.py
@@ -275,3 +275,6 @@ def test_release_tasks_delegates_the_backfill_to_the_command(mock_call):
     # Tagged, so the sync log can tell the weekly job from a person pressing a
     # button when support asks what moved a member's count.
     assert sweeps[0].handler == ["backfill_achievements", "--trigger", "pipeline"]
+    # Must run last: every other Action's source data has to be refreshed
+    # before the sweep reads it. A future reorder should fail this test.
+    assert manager.tasks[-1] is sweeps[0]

--- a/libraries/tests/test_tasks.py
+++ b/libraries/tests/test_tasks.py
@@ -208,7 +208,7 @@ def test_point_release_docs_urls_address_the_base_release(
 
 @patch("libraries.tasks.call_command")
 def test_update_authors_and_maintainers_backfills_only_library_sources(mock_call):
-    """A blanket backfill here would sweep the commit, review and news tables."""
+    """A blanket backfill here would sweep the commit and review tables too."""
     from libraries.tasks import update_authors_and_maintainers
 
     update_authors_and_maintainers()
@@ -248,8 +248,12 @@ def test_release_tasks_delegates_the_backfill_to_the_command(mock_call):
 
     assert [c.args[0] for c in mock_call.call_args_list] == ["release_tasks"]
     manager = ReleaseTasksManager(base_uri="https://example.com", user_id=None)
-    assert [
-        task.description
+    sweeps = [
+        task
         for task in manager.tasks
-        if task.handler == ["backfill_achievements"]
-    ] == ["Backfilling achievements"]
+        if isinstance(task.handler, list) and task.handler[0] == "backfill_achievements"
+    ]
+    assert [task.description for task in sweeps] == ["Backfilling achievements"]
+    # Tagged, so the sync log can tell the weekly job from a person pressing a
+    # button when support asks what moved a member's count.
+    assert sweeps[0].handler == ["backfill_achievements", "--trigger", "pipeline"]

--- a/libraries/tests/test_tasks.py
+++ b/libraries/tests/test_tasks.py
@@ -206,12 +206,24 @@ def test_point_release_docs_urls_address_the_base_release(
     )
 
 
+@patch("libraries.tasks.app.signature")
 @patch("libraries.tasks.call_command")
-def test_update_authors_and_maintainers_backfills_only_library_sources(mock_call):
+def test_update_authors_and_maintainers_backfills_only_library_sources(
+    mock_call, mock_signature
+):
     """A blanket backfill here would sweep the commit and review tables too."""
     from libraries.tasks import update_authors_and_maintainers
 
     update_authors_and_maintainers()
+
+    # The profile-role recompute must run eagerly and be waited on, not fired
+    # and forgotten, or the achievement backfill below can read stale roles.
+    mock_signature.assert_called_once_with(
+        "users.tasks.recompute_displayed_profile_roles"
+    )
+    mock_signature.return_value.apply.assert_called_once_with()
+    mock_signature.return_value.apply.return_value.get.assert_called_once_with()
+    mock_signature.return_value.apply_async.assert_not_called()
 
     backfills = [
         c for c in mock_call.call_args_list if c.args[0] == "backfill_achievements"
@@ -225,9 +237,10 @@ def test_update_authors_and_maintainers_backfills_only_library_sources(mock_call
     }
 
 
+@patch("libraries.tasks.app.signature")
 @patch("libraries.tasks.LibraryUpdater")
 @patch("libraries.tasks.call_command")
-def test_update_commits_does_not_backfill(mock_call, _mock_updater, db):
+def test_update_commits_does_not_backfill(mock_call, _mock_updater, mock_signature, db):
     """release_tasks sweeps every source once; a call here would double it."""
     from libraries.tasks import update_commits
 
@@ -236,6 +249,11 @@ def test_update_commits_does_not_backfill(mock_call, _mock_updater, db):
     assert not [
         c for c in mock_call.call_args_list if c.args[0] == "backfill_achievements"
     ]
+    # Same eager-and-waited requirement as update_authors_and_maintainers: the
+    # release pipeline's "Backfilling achievements" step runs right after this.
+    mock_signature.return_value.apply.assert_called_once_with()
+    mock_signature.return_value.apply.return_value.get.assert_called_once_with()
+    mock_signature.return_value.apply_async.assert_not_called()
 
 
 @patch("libraries.tasks.call_command")

--- a/libraries/tests/test_tasks.py
+++ b/libraries/tests/test_tasks.py
@@ -204,3 +204,52 @@ def test_point_release_docs_urls_address_the_base_release(
     assert library_version.documentation_url == (
         "/doc/libs/1_91_0/libs/detail/doc/html/index.html"
     )
+
+
+@patch("libraries.tasks.call_command")
+def test_update_authors_and_maintainers_backfills_only_library_sources(mock_call):
+    """A blanket backfill here would sweep the commit, review and news tables."""
+    from libraries.tasks import update_authors_and_maintainers
+
+    update_authors_and_maintainers()
+
+    backfills = [
+        c for c in mock_call.call_args_list if c.args[0] == "backfill_achievements"
+    ]
+    assert len(backfills) == 1
+    assert set(backfills[0].args[1:]) == {
+        "--source",
+        "library-authoring",
+        "library-maintenance",
+        "library-versioning",
+    }
+
+
+@patch("libraries.tasks.LibraryUpdater")
+@patch("libraries.tasks.call_command")
+def test_update_commits_does_not_backfill(mock_call, _mock_updater, db):
+    """release_tasks sweeps every source once; a call here would double it."""
+    from libraries.tasks import update_commits
+
+    update_commits()
+
+    assert not [
+        c for c in mock_call.call_args_list if c.args[0] == "backfill_achievements"
+    ]
+
+
+@patch("libraries.tasks.call_command")
+def test_release_tasks_delegates_the_backfill_to_the_command(mock_call):
+    """The sweep is an Action inside release_tasks, not a trailing extra call."""
+    from libraries.management.commands.release_tasks import ReleaseTasksManager
+    from libraries.tasks import release_tasks
+
+    release_tasks("https://example.com")
+
+    assert [c.args[0] for c in mock_call.call_args_list] == ["release_tasks"]
+    manager = ReleaseTasksManager(base_uri="https://example.com", user_id=None)
+    assert [
+        task.description
+        for task in manager.tasks
+        if task.handler == ["backfill_achievements"]
+    ] == ["Backfilling achievements"]


### PR DESCRIPTION
# Issue: #2609 

⚠️ Base branch is `teo/2541-source-library-review` 

## Summary & Context

Lets the achievement backfill run unattended. This is deliberately the last step of the ingestion
half: by now every source is wired and reviewed, and the previous eight PRs can all be exercised
by hand first.

- **Figma link**: n/a
- **Link to components/page:** n/a

## Changes

- `release_tasks`: a `Backfilling achievements` action, **last** in the list, so every source it
  reads has already been refreshed by the steps above it.
- `update_authors_and_maintainers`: backfills only the three sources whose upstream data that
  task just changed (`library-authoring`, `library-maintenance`, `library-versioning`). A blanket
  backfill would also sweep the commit and review tables it never touches.
- `update_commits`: a comment recording why there is deliberately **no** backfill call there - it
  runs as a step of `release_tasks`, which sweeps everything once at the end, so calling it here
  too would walk the whole `Commit` table twice per release.
- `libraries/tests/test_tasks.py`: three tests asserting the wiring, which was previously three
  untested `call_command` lines.

## ‼️ Risks & Considerations ‼️

- **This is the PR that makes badges appear in production without anyone pressing anything.**
  Everything it runs is additive - `backfill_achievements` is `sync_source` with `remove=False`
  and cannot delete a grant or revoke a badge - so the failure mode is over-granting, not
  data loss.
- **Blocking product decision:** the seeded thresholds are the original numbers, not the revised
  set. It must be settled **before this runs for real**, because backfill
  awards badges against whatever thresholds are live at that moment, and lowering a threshold
  afterwards is easy while raising one is not (retiring and replacing a tier keeps the members who
  already met the old number). Tracked by the threshold-confirmation ticket.
- Cost: one full walk of every source per release. The commit table is the long pole. Measured at
  a few seconds against a full copy of the Boost data.
- If the catalogue is not seeded, a scheduled sweep reports the missing slugs on stderr and keeps
  going rather than failing the release job. Only an explicitly named missing source is fatal.

## Screenshots

n/a - no UI.

## Peer-review testing steps

This PR adds no UI of its own; what it changes is what three existing admin buttons do afterwards, and
the sync run log is where you see it. **Setup:** `just load_production_data`, `just migrate`,
`docker compose up`, and note the current last row id on `/admin/badges/achievementsyncrun/` so you can
tell new rows from old ones.

1. **The narrow path.** `/admin/libraries/library/` -> **Update Authors & Maintainers**. When the
   worker finishes, `/admin/badges/achievementsyncrun/` has exactly **three** new rows -
   `library-authoring`, `library-maintenance`, `library-versioning` - and **no** `code-commits` or
   `library-review` row. That absence is the review: this task only touches library authorship, so a
   blanket backfill would walk the commit and review tables for nothing.
2. **Those rows read `command` with no actor,** because the libraries changelist buttons are the eight
   legacy GET views that were deliberately left unconverted. Worth knowing when reading the log; not
   something this PR changes.
3. **The deliberate omission.** `/admin/libraries/commit/` -> **Update Commits**. No new sync run row
   appears. That is intentional and commented in the code: this task also runs as a step of
   `release_tasks`, which sweeps everything once at the end, so backfilling here too would walk the
   whole `Commit` table twice per release.
4. **The full pipeline.** `/admin/libraries/releasereport/` -> **Get Release Report Data**, which is the
   `release_tasks` entry point. Only against a scratch database with GitHub credentials configured: it
   imports versions, libraries, commits, issues, Slack and mailing-list data first, and its own tooltip
   warns it can take hours. When it lands, the log has one row per source with trigger **pipeline**, all
   timestamped after the import steps. Ordering matters - a backfill that ran before the imports would
   grant against yesterday's data, which is why it is the last action in the list.
5. **It cannot revoke anything.** Across every row those runs produced, *Removed* is 0 and *Members
   changed* only ever counts additions. Then filter `/admin/badges/userbadge/` to **Revoked** and
   confirm nothing was revoked while the pipeline ran. `backfill_achievements` is `sync_source` with
   `remove=False`, so the failure mode here is over-granting, never data loss.
6. **A misconfigured badge does not fail the release either.** Tick delete on every tier of one badge on
   `/admin/badges/badge/` - the ladder column then reads *No tiers - awards nothing* - and run
   **Update Authors & Maintainers** again. Grants are still recorded, no badge is awarded, and the
   other sources complete normally. (The stronger case, a source whose `Achievement` row is missing
   entirely, is not reachable from the admin on purpose: achievement deletion is refused. It is covered
   in tests, and the behaviour is stderr-and-continue so a taxonomy mistake cannot kill the release job.)
7. **Before this is allowed to run in production**, read the ladders on `/admin/badges/badge/` and
   confirm each one is the number the client intends. The sweep awards against whatever is live at that
   moment, and lowering a threshold later is easy while raising one is not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Achievement data is now refreshed automatically after release-related updates.
  * Library author, maintainer, and version information now receives achievement updates.

* **Bug Fixes**
  * Prevented duplicate achievement refreshes during commit updates.
  * Ensured achievement backfills run after all data sources have been refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->