### PR TITLE
Task 2583: GitHub activity pipeline

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -429,6 +429,15 @@ AUTHENTICATION_BACKENDS = (
 # GitHub settings
 
 GITHUB_TOKEN = env("GITHUB_TOKEN", default=None)
+
+# Org scope for the profile GitHub activity card. The node ID is pinned so
+# boost_activity() never spends a REST call resolving it. Use the modern global
+# ID form. REST node_id and GraphQL organization.id both still return the
+# deprecated token form.
+BOOST_GITHUB_ORG = "boostorg"
+BOOST_GITHUB_ORG_NODE_ID = env("BOOST_GITHUB_ORG_NODE_ID", default="O_kgDOADBg4Q")
+# contributionsCollection is capped at one year by GitHub.
+BOOST_ACTIVITY_WINDOW_DAYS = 365
 JDOODLE_API_CLIENT_ID = env("JDOODLE_API_CLIENT_ID", "")
 JDOODLE_API_CLIENT_SECRET = env("JDOODLE_API_CLIENT_SECRET", "")
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -65,6 +65,7 @@ from news.views import (
 from users.views import (
     CurrentUserAPIView,
     CurrentUserProfileView,
+    GithubActivityFragmentView,
     CustomEmailVerificationSentView,
     CustomLoginView,
     CustomSignupView,
@@ -153,6 +154,11 @@ urlpatterns = (
         ),
         path("accounts/", include("allauth.urls")),
         path("users/me/", CurrentUserProfileView.as_view(), name="profile-account"),
+        path(
+            "users/me/github-activity/",
+            GithubActivityFragmentView.as_view(),
+            name="profile-github-activity",
+        ),
         path("users/me/delete/", DeleteUserView.as_view(), name="profile-delete"),
         path(
             "users/me/disconnect-social/<str:platform>/",

--- a/core/githubhelper.py
+++ b/core/githubhelper.py
@@ -1,7 +1,7 @@
 import base64
 import re
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone as dt_timezone, timedelta
 from socket import gaierror
 import time
 from urllib.error import URLError
@@ -23,6 +23,34 @@ from fastcore.xtras import obj2dict
 from ghapi.all import GhApi, paged
 
 logger = structlog.get_logger()
+
+_CONTRIBUTIONS_QUERY = """
+query BoostActivity($login: String!, $orgId: ID!, $from: DateTime!, $to: DateTime!) {
+  user(login: $login) {
+    contributionsCollection(organizationID: $orgId, from: $from, to: $to) {
+      totalCommitContributions
+      totalRepositoriesWithContributedCommits
+      totalPullRequestContributions
+      totalRepositoriesWithContributedPullRequests
+      totalPullRequestReviewContributions
+      totalRepositoriesWithContributedPullRequestReviews
+      repositoryContributions(first: 1) {
+        totalCount
+      }
+      pullRequestContributions(first: 50) {
+        nodes {
+          pullRequest {
+            title
+            url
+            repository { nameWithOwner }
+            comments { totalCount }
+          }
+        }
+      }
+    }
+  }
+}
+"""
 
 
 class GithubAPIClient:
@@ -574,6 +602,23 @@ class GithubAPIClient:
         with myzip.open(myzip.filelist[0]) as f:
             return f.read().decode()
 
+    def graphql(self, query: str, variables: dict) -> dict:
+        """Execute a GitHub GraphQL query using the app-level PAT."""
+        response = requests.post(
+            "https://api.github.com/graphql",
+            json={"query": query, "variables": variables},
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        if "errors" in data:
+            raise ValueError(f"GitHub GraphQL errors: {data['errors']}")
+        return data["data"]
+
 
 class GithubDataParser:
     def get_commits_per_month(self, commits: list[dict]):
@@ -712,3 +757,55 @@ class GithubDataParser:
             val = val.replace(email.group(), "")
 
         return val.strip()
+
+
+def boost_activity(login: str) -> dict:
+    """Fetch boostorg contribution totals for a GitHub user (trailing 12 months).
+
+    Scoped to the ``boostorg`` org only. Raises on any API or GraphQL error, and
+    on an unknown login, so the caller can keep the last good snapshot rather
+    than overwrite it with zeros.
+
+    Returns a dict with keys:
+        total_commits, commit_repo_count, repos_created,
+        prs_opened, pr_repo_count, prs_reviewed, review_repo_count,
+        featured_pr (dict or None)
+    """
+    now = datetime.now(dt_timezone.utc)
+    data = GithubAPIClient().graphql(
+        _CONTRIBUTIONS_QUERY,
+        {
+            "login": login,
+            "orgId": settings.BOOST_GITHUB_ORG_NODE_ID,
+            "from": (
+                now - timedelta(days=settings.BOOST_ACTIVITY_WINDOW_DAYS)
+            ).isoformat(),
+            "to": now.isoformat(),
+        },
+    )
+
+    user_node = data.get("user")
+    if not user_node:
+        raise ValueError(f"GitHub user not found: {login}")
+
+    coll = user_node["contributionsCollection"]
+    prs = [
+        {
+            "title": node["pullRequest"]["title"],
+            "url": node["pullRequest"]["url"],
+            "repo": node["pullRequest"]["repository"]["nameWithOwner"],
+            "comment_count": node["pullRequest"]["comments"]["totalCount"],
+        }
+        for node in coll["pullRequestContributions"]["nodes"]
+    ]
+
+    return {
+        "total_commits": coll["totalCommitContributions"],
+        "commit_repo_count": coll["totalRepositoriesWithContributedCommits"],
+        "repos_created": coll["repositoryContributions"]["totalCount"],
+        "prs_opened": coll["totalPullRequestContributions"],
+        "pr_repo_count": coll["totalRepositoriesWithContributedPullRequests"],
+        "prs_reviewed": coll["totalPullRequestReviewContributions"],
+        "review_repo_count": coll["totalRepositoriesWithContributedPullRequestReviews"],
+        "featured_pr": max(prs, key=lambda p: p["comment_count"]) if prs else None,
+    }

--- a/core/tests/test_githubhelper.py
+++ b/core/tests/test_githubhelper.py
@@ -1,11 +1,13 @@
 import datetime
+import json
 from unittest.mock import MagicMock, Mock
 
 import pytest
+import requests
 import responses
 from ghapi.all import GhApi
 
-from core.githubhelper import GithubAPIClient, GithubDataParser
+from core.githubhelper import GithubAPIClient, GithubDataParser, boost_activity
 
 """GithubAPIClient Tests"""
 
@@ -258,3 +260,110 @@ def test_extract_contributor_data():
     assert expected["valid_email"] is False
     assert expected["display_name"] == result["display_name"]
     assert "email" in result
+
+
+"""boost_activity Tests"""
+
+GRAPHQL_URL = "https://api.github.com/graphql"
+
+
+def _contributions_payload(prs=None, **overrides):
+    """Build a contributionsCollection GraphQL response."""
+    collection = {
+        "totalCommitContributions": 5,
+        "totalRepositoriesWithContributedCommits": 3,
+        "totalPullRequestContributions": 5,
+        "totalRepositoriesWithContributedPullRequests": 5,
+        "totalPullRequestReviewContributions": 2,
+        "totalRepositoriesWithContributedPullRequestReviews": 1,
+        "repositoryContributions": {"totalCount": 0},
+        "pullRequestContributions": {"nodes": prs or []},
+    }
+    collection.update(overrides)
+    return {"data": {"user": {"contributionsCollection": collection}}}
+
+
+def _pr_node(repo, comments, title="A PR", url="https://github.com/x/y/pull/1"):
+    return {
+        "pullRequest": {
+            "title": title,
+            "url": url,
+            "repository": {"nameWithOwner": repo},
+            "comments": {"totalCount": comments},
+        }
+    }
+
+
+@responses.activate
+def test_boost_activity_queries_boostorg_only(settings):
+    """Exactly one GraphQL call, scoped to the boostorg node ID."""
+    settings.BOOST_GITHUB_ORG_NODE_ID = "O_kgDOADBg4Q"
+    responses.add(responses.POST, GRAPHQL_URL, json=_contributions_payload())
+
+    result = boost_activity("testuser")
+
+    assert len(responses.calls) == 1
+    body = json.loads(responses.calls[0].request.body)
+    assert body["variables"]["orgId"] == "O_kgDOADBg4Q"
+    assert body["variables"]["login"] == "testuser"
+    assert result["total_commits"] == 5
+    assert result["commit_repo_count"] == 3
+
+
+@responses.activate
+def test_boost_activity_raises_on_graphql_error():
+    """A GraphQL errors payload raises instead of returning partial data."""
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json={"errors": [{"message": "Could not resolve to a node"}]},
+    )
+
+    with pytest.raises(ValueError):
+        boost_activity("testuser")
+
+
+@responses.activate
+def test_boost_activity_raises_on_http_error():
+    """A transient 502 must raise so callers keep the last good snapshot."""
+    responses.add(responses.POST, GRAPHQL_URL, status=502, json={})
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        boost_activity("testuser")
+
+
+@responses.activate
+def test_boost_activity_raises_on_unknown_login():
+    """A null user is a success payload, but must not be stored as zeros."""
+    responses.add(responses.POST, GRAPHQL_URL, json={"data": {"user": None}})
+
+    with pytest.raises(ValueError):
+        boost_activity("nosuchuser")
+
+
+@responses.activate
+def test_boost_activity_featured_pr_is_highest_comment_count():
+    """The featured PR is the one with the most conversation comments."""
+    responses.add(
+        responses.POST,
+        GRAPHQL_URL,
+        json=_contributions_payload(
+            prs=[
+                _pr_node("boostorg/url", 5),
+                _pr_node("boostorg/beast", 9),
+                _pr_node("boostorg/json", 2),
+            ]
+        ),
+    )
+
+    featured = boost_activity("testuser")["featured_pr"]
+
+    assert featured["repo"] == "boostorg/beast"
+    assert featured["comment_count"] == 9
+
+
+@responses.activate
+def test_boost_activity_featured_pr_none_when_no_prs():
+    responses.add(responses.POST, GRAPHQL_URL, json=_contributions_payload(prs=[]))
+
+    assert boost_activity("testuser")["featured_pr"] is None

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -9,6 +9,13 @@ This project uses environment variables to configure certain aspects of the appl
 - In **deployed environments**, this should be set to a valid access token associated with the GitHub organization. Edit `kube/boost/values.yaml` (or the environment-specific yaml file) to change this value.
 
 
+## `BOOST_GITHUB_ORG_NODE_ID`
+
+- The GraphQL node ID of the GitHub org whose contributions the profile activity card counts.
+- Optional. Defaults to the `boostorg` org (`O_kgDOADBg4Q`), so neither local nor deployed environments need to set it.
+- Set it only to scope the card at a different org, such as a fork or a test org. To find the value for another org, query GitHub's GraphQL API for that org's `id` and use the `next_global_id` from the deprecation warning — both the REST `node_id` field and GraphQL's `organization.id` still return the older, deprecated ID format.
+
+
 ## `ENVIRONMENT_NAME`
 
 - Used to indicate the name of the environment where the application is running.

--- a/env.template
+++ b/env.template
@@ -16,6 +16,10 @@ SECRET_KEY="top-secret"
 
 GITHUB_TOKEN=
 
+# Optional. Which GitHub org the profile activity card counts contributions in.
+# Defaults to boostorg, so only set this to point at a fork or a test org.
+# BOOST_GITHUB_ORG_NODE_ID=O_kgDOADBg4Q
+
 # AWS_ACCESS_KEY_ID="changeme"
 # AWS_SECRET_ACCESS_KEY="changeme"
 # BUCKET_NAME="boost.revsys.dev"

--- a/static/css/v3/user-profile-page.css
+++ b/static/css/v3/user-profile-page.css
@@ -291,6 +291,20 @@
     animation: create-post-spin 0.8s linear infinite;
 }
 
+.user-profile__github-status {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--space-s);
+    min-height: 16px;
+    margin-top: var(--space-default);
+}
+
+.user-profile__github-status-text {
+    color: var(--color-text-tertiary);
+    font-size: var(--font-size-xs);
+}
+
 @keyframes create-post-spin {
     to {
         transform: rotate(360deg);

--- a/templates/admin/user_change_form.html
+++ b/templates/admin/user_change_form.html
@@ -1,0 +1,30 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls %}
+
+{% block submit_buttons_bottom %}
+  {{ block.super }}
+  {% if original and original.github_username %}
+    <div class="submit-row">
+      {# POST, not a link: this queues work, so it must not be reachable by GET. #}
+      <form method="post"
+            action="{% url 'admin:user_refresh_github_activity' original.pk %}"
+            style="display: inline-block;">
+        {% csrf_token %}
+        <button type="submit"
+                class="button"
+                style="background: #417690; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer;">
+          {% trans "Refresh GitHub Activity" %}
+        </button>
+      </form>
+      <span style="margin-left: 10px; color: #666; font-size: 13px;">
+        {% trans "Queues a background task to fetch this user's Boost org activity from GitHub." %}
+      </span>
+    </div>
+  {% elif original and not original.github_username %}
+    <div class="submit-row">
+      <span style="color: #888; font-size: 13px;">
+        {% trans "No GitHub username set - cannot fetch activity." %}
+      </span>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/templates/admin/user_change_form.html
+++ b/templates/admin/user_change_form.html
@@ -1,26 +1,29 @@
 {% extends "admin/change_form.html" %}
 {% load i18n admin_urls %}
 
+{# The form sits outside the admin's <form> (nesting is invalid HTML); the #}
+{# button below reaches it by id via the HTML5 form attribute. #}
+{% block object-tools %}
+  {{ block.super }}
+  {% if original and original.github_username %}
+    <form id="refresh-github-activity" method="post" action="{% url 'admin:user_refresh_github_activity' original.pk %}">
+      {% csrf_token %}
+    </form>
+  {% endif %}
+{% endblock %}
+
 {% block submit_buttons_bottom %}
   {{ block.super }}
   {% if original and original.github_username %}
     <div class="submit-row">
-      {# POST, not a link: this queues work, so it must not be reachable by GET. #}
-      <form method="post"
-            action="{% url 'admin:user_refresh_github_activity' original.pk %}"
-            style="display: inline-block;">
-        {% csrf_token %}
-        <button type="submit"
-                class="button"
-                style="background: #417690; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer;">
-          {% trans "Refresh GitHub Activity" %}
-        </button>
-      </form>
+      <button type="submit" form="refresh-github-activity" class="button" style="background: #417690; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer;">
+        {% trans "Refresh GitHub Activity" %}
+      </button>
       <span style="margin-left: 10px; color: #666; font-size: 13px;">
         {% trans "Queues a background task to fetch this user's Boost org activity from GitHub." %}
       </span>
     </div>
-  {% elif original and not original.github_username %}
+  {% elif original %}
     <div class="submit-row">
       <span style="color: #888; font-size: 13px;">
         {% trans "No GitHub username set - cannot fetch activity." %}

--- a/templates/v3/includes/_github_activity_card.html
+++ b/templates/v3/includes/_github_activity_card.html
@@ -1,0 +1,25 @@
+{% comment %}
+  GitHub activity card plus its sync status line.
+
+  While a background refresh is running this element re-requests itself and
+  swaps itself out. Each response decides whether polling continues: the
+  hx-* attributes are only rendered while still refreshing and under the
+  attempt cap, so the chain stops on its own once the data lands (or once we
+  give up and ask the user to reload).
+
+  Inputs:
+    data: dict, required - from users.profile_cards.github_activity_card
+    attempt: int, required - how many polls have happened so far
+    poll_exhausted: bool, required - whether the attempt cap has been reached
+    poll_url: str, required - url of the fragment endpoint
+    poll_interval: int, required - seconds between polls
+{% endcomment %}
+<div id="github-activity-card"
+     {% if data.refreshing and not poll_exhausted %}
+     hx-get="{{ poll_url }}?attempt={{ next_attempt }}"
+     hx-trigger="load delay:{{ poll_interval }}s"
+     hx-swap="outerHTML"
+     {% endif %}>
+  {% include 'v3/includes/_markdown_card.html' with title=data.title markdown=data.markdown_text button_url=data.button_url button_label=data.button_label %}
+  {% include 'v3/includes/_github_activity_status.html' with refreshing=data.refreshing last_synced=data.last_synced poll_exhausted=poll_exhausted only %}
+</div>

--- a/templates/v3/includes/_github_activity_status.html
+++ b/templates/v3/includes/_github_activity_status.html
@@ -1,0 +1,28 @@
+{% load humanize %}
+{% comment %}
+  Sync status line for the GitHub activity card (Figma node 11713:98663).
+  Sits directly under the card, right-aligned.
+  Inputs:
+    refreshing: bool, required - whether a background refresh is in flight
+    last_synced: datetime, optional - when the stored data was last written
+    poll_exhausted: bool, optional - polling gave up. Ask the user to reload
+{% endcomment %}
+<div class="user-profile__github-status">
+  {% if refreshing and poll_exhausted %}
+    <span class="user-profile__github-status-text">
+      Still fetching GitHub activity &mdash; reload the page to see the latest.
+    </span>
+  {% elif refreshing %}
+    <span class="user-profile__github-status-text">Fetching GitHub activity</span>
+    {% include "includes/icon.html" with icon_name="saving" icon_class="user-profile__save-icon user-profile__save-icon--spin" icon_size=16 %}
+    <noscript>
+      <span class="user-profile__github-status-text">
+        &mdash; reload the page to see the latest.
+      </span>
+    </noscript>
+  {% elif last_synced %}
+    <span class="user-profile__github-status-text">
+      Updated {{ last_synced|naturaltime }}
+    </span>
+  {% endif %}
+</div>

--- a/templates/v3/user_profile_page.html
+++ b/templates/v3/user_profile_page.html
@@ -32,11 +32,9 @@
         <div class="user-profile__bio">
           {% include 'v3/includes/_user_profile_bio_card.html' with title='Bio' markdown=bio contributor_data=contributor_data only %}
         </div>
-        {% if github_activity_card_data %}
+        {% if github_activity %}
         <div class="user-profile__github">
-          {% with data=github_activity_card_data %}
-            {% include 'v3/includes/_markdown_card.html' with title=data.title markdown=data.markdown_text button_url=data.button_url button_label=data.button_label %}
-          {% endwith %}
+          {% include 'v3/includes/_github_activity_card.html' with data=github_activity.data attempt=github_activity.attempt next_attempt=github_activity.next_attempt poll_exhausted=github_activity.poll_exhausted poll_url=github_activity.poll_url poll_interval=github_activity.poll_interval only %}
         </div>
         {% endif %}
         {% if mailing_list_activity_card_data %}

--- a/users/admin.py
+++ b/users/admin.py
@@ -4,11 +4,13 @@ from django import forms
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.forms import UserChangeForm
-from django.urls import reverse
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseNotAllowed, HttpResponseRedirect
+from django.urls import path, reverse
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext_lazy as _
 
-from .models import ProfileRole, User
+from .models import GithubActivity, ProfileRole, User
 
 
 class EmailUserAdminForm(UserChangeForm):
@@ -49,10 +51,32 @@ class EmailUserAdminForm(UserChangeForm):
         return value
 
 
+class GithubActivityInline(admin.StackedInline):
+    model = GithubActivity
+    extra = 0
+    can_delete = False
+    readonly_fields = ("last_synced", "data")
+    fields = ("last_synced", "data")
+    verbose_name_plural = "GitHub Activity (cached)"
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
+@admin.register(GithubActivity)
+class GithubActivityAdmin(admin.ModelAdmin):
+    list_display = ("user", "last_synced")
+    readonly_fields = ("user", "last_synced", "data")
+    search_fields = ("user__email", "user__github_username")
+
+
 @admin.register(User)
 class EmailUserAdmin(UserAdmin):
     form = EmailUserAdminForm
     readonly_fields = ("role_eligibility_display", "badge_summary")
+    change_form_template = "admin/user_change_form.html"
+    inlines = [GithubActivityInline]
+
     fieldsets = (
         (None, {"fields": ("email", "password")}),
         (
@@ -150,3 +174,50 @@ class EmailUserAdmin(UserAdmin):
             reverse("admin:badges_userbadge_user_summary", args=[obj.pk]),
             _("View badges and achievements"),
         )
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "<int:user_pk>/refresh_github_activity/",
+                self.admin_site.admin_view(self.refresh_github_activity_view),
+                name="user_refresh_github_activity",
+            ),
+        ]
+        return custom + urls
+
+    def refresh_github_activity_view(self, request, user_pk):
+        from users.tasks import refresh_github_activity
+
+        # Queueing work must not be reachable by GET: browser prefetch, link
+        # scanners and a plain page reload would all fire it, and GET carries
+        # no CSRF token.
+        if request.method != "POST":
+            return HttpResponseNotAllowed(["POST"])
+
+        try:
+            user = User.objects.get(pk=user_pk)
+        except User.DoesNotExist:
+            self.message_user(request, "User not found.", level="error")
+            return HttpResponseRedirect("../../")
+
+        # admin_view() only checks staff status, so any staff member could
+        # otherwise queue a refresh for a user they cannot change.
+        if not self.has_change_permission(request, user):
+            raise PermissionDenied
+
+        if not user.github_username:
+            self.message_user(
+                request,
+                f"User {user} has no GitHub username set - cannot fetch activity.",
+                level="warning",
+            )
+        else:
+            refresh_github_activity.delay(user_pk)
+            self.message_user(
+                request,
+                f"GitHub activity refresh queued for @{user.github_username}. "
+                "Reload this page in a few seconds to see the result.",
+            )
+
+        return HttpResponseRedirect("../")

--- a/users/constants.py
+++ b/users/constants.py
@@ -1,6 +1,20 @@
+from datetime import timedelta
+
 from django.utils import timezone
 
 LOGIN_METHOD_SESSION_FIELD_NAME = "boost_login_method"
+
+GITHUB_PROVIDER = "github"
+GITHUB_ACTIVITY_CARD_TITLE = "Latest Boost Github activity"
+# Stored GitHub activity older than this is refreshed on the next profile load.
+GITHUB_ACTIVITY_STALE_AFTER = timedelta(hours=24)
+# Guards against re-queueing a refresh on every page load while one is running,
+# and against hammering GitHub when a refresh is failing.
+GITHUB_ACTIVITY_REFRESH_LOCK_SECONDS = 300
+# The card polls itself while a refresh runs, then gives up and asks the user to
+# reload, so a failing refresh cannot poll forever.
+GITHUB_ACTIVITY_POLL_INTERVAL_SECONDS = 5
+GITHUB_ACTIVITY_POLL_MAX_ATTEMPTS = 12
 
 UNVERIFIED_CLEANUP_DAYS = 14
 UNVERIFIED_CLEANUP_BEGIN = timezone.datetime(2025, 11, 21, 0, 0, 0)

--- a/users/migrations/0029_githubactivity.py
+++ b/users/migrations/0029_githubactivity.py
@@ -1,0 +1,41 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0028_user_displayed_profile_role_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="GithubActivity",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("data", models.JSONField(blank=True, default=dict)),
+                ("last_synced", models.DateTimeField(blank=True, null=True)),
+                (
+                    "user",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="github_activity",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "GitHub Activity",
+                "verbose_name_plural": "GitHub Activities",
+            },
+        ),
+    ]

--- a/users/migrations/0030_githubactivity.py
+++ b/users/migrations/0030_githubactivity.py
@@ -6,7 +6,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("users", "0028_user_displayed_profile_role_and_more"),
+        ("users", "0029_user_display_badge"),
     ]
 
     operations = [

--- a/users/mixins.py
+++ b/users/mixins.py
@@ -2,6 +2,7 @@ from urllib.parse import urlparse
 
 from badges import display as badge_display
 from core.context_processors import edit_profile_url
+from users.profile_cards import github_activity_card_context
 
 
 class V3UserProfileContextMixin:
@@ -88,7 +89,7 @@ class V3UserProfileContextMixin:
         of the context so the template omits them entirely. The bio section
         is always rendered, falling back to an empty state."""
         is_owner = user == self.request.user
-        return {
+        context = {
             "user_info": {
                 "user_name": user.display_name,
                 "avatar_url": user.get_avatar_url(),
@@ -121,3 +122,13 @@ class V3UserProfileContextMixin:
             "bio": user.biography or None,
             "top_links": self.get_v3_profile_link_buttons(user),
         }
+        # Owner-only: the card kicks a background refresh, and publishing it on
+        # a public profile would expose data that `hide_github_activity` is
+        # meant to withhold, an opt-out not yet wired up to rendering.
+        # Omitted entirely without a linked account, so a profile with no data
+        # stays the bio card alone.
+        if is_owner:
+            activity = github_activity_card_context(user)
+            if activity["data"]["linked"]:
+                context["github_activity"] = activity
+        return context

--- a/users/models.py
+++ b/users/models.py
@@ -29,6 +29,7 @@ from core.validators import (
     large_file_max_size_validator,
     downscale_image_file_size_validator,
 )
+from users.constants import GITHUB_ACTIVITY_STALE_AFTER
 
 logger = logging.getLogger(__name__)
 
@@ -994,6 +995,43 @@ class Preferences(models.Model):
         if isinstance(value, bool):
             value = [value]
         self.change_notification_allowed(self.TERMS_CHANGED, value)
+
+
+class GithubActivity(models.Model):
+    """Cached Boost org GitHub contribution data for a user.
+
+    Populated by the ``refresh_github_activity`` Celery task. One row per user
+    with a linked GitHub account; never written during a web request.
+    """
+
+    user = models.OneToOneField(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="github_activity",
+    )
+    data = models.JSONField(default=dict, blank=True)
+    last_synced = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        verbose_name = "GitHub Activity"
+        verbose_name_plural = "GitHub Activities"
+
+    def __str__(self):
+        return f"GitHub Activity for {self.user}"
+
+    @property
+    def is_stale(self) -> bool:
+        if self.last_synced is None:
+            return True
+        return timezone.now() - self.last_synced > GITHUB_ACTIVITY_STALE_AFTER
+
+    @classmethod
+    def upsert_for_user(cls, user, activity_data: dict) -> "GithubActivity":
+        obj, _ = cls.objects.update_or_create(
+            user=user,
+            defaults={"data": activity_data, "last_synced": timezone.now()},
+        )
+        return obj
 
 
 @receiver(post_save, sender=User)

--- a/users/profile_cards.py
+++ b/users/profile_cards.py
@@ -1,0 +1,188 @@
+from collections import namedtuple
+from datetime import timedelta
+from urllib.parse import quote
+
+from allauth.socialaccount.models import SocialAccount
+from django.conf import settings
+from django.core.cache import cache
+from django.urls import reverse
+from django.utils import timezone
+
+from users.constants import (
+    GITHUB_ACTIVITY_CARD_TITLE,
+    GITHUB_ACTIVITY_POLL_INTERVAL_SECONDS,
+    GITHUB_ACTIVITY_POLL_MAX_ATTEMPTS,
+    GITHUB_ACTIVITY_REFRESH_LOCK_SECONDS,
+    GITHUB_PROVIDER,
+)
+
+GithubActivityState = namedtuple(
+    "GithubActivityState", ("linked", "activity", "refreshing")
+)
+
+
+def github_activity_state(user):
+    """Return the GitHub activity card's state for a user.
+
+    Reads the stored row only. A missing or stale row queues a background
+    refresh, so a profile load never calls GitHub inline. ``activity`` is None
+    when the user has no linked GitHub account or has never been synced.
+    """
+    linked = SocialAccount.objects.filter(user=user, provider=GITHUB_PROVIDER).exists()
+    if not linked:
+        return GithubActivityState(False, None, False)
+
+    activity = getattr(user, "github_activity", None)
+    if activity is not None and not activity.is_stale:
+        return GithubActivityState(True, activity, False)
+
+    _queue_github_activity_refresh(user)
+    return GithubActivityState(True, activity, True)
+
+
+def _queue_github_activity_refresh(user):
+    """Queue a refresh unless one is already in flight for this user."""
+    from users import tasks
+
+    key = f"github_activity_refresh:{user.pk}"
+    if cache.add(key, True, GITHUB_ACTIVITY_REFRESH_LOCK_SECONDS):
+        tasks.refresh_github_activity.delay(user.pk)
+
+
+def _plural(count, singular, plural):
+    return f"{count} {singular if count == 1 else plural}"
+
+
+def _repo_link(count, url):
+    return f"[**{_plural(count, 'repository', 'repositories')}**]({url})"
+
+
+def _search_url(login, terms, kind="pullrequests"):
+    """Build a GitHub search URL scoped to the org and the card's time window.
+
+    ``kind`` selects the search tab and must be passed explicitly: it cannot be
+    inferred from ``terms``, since ``type:`` is not a commit-search qualifier.
+    """
+    since = (
+        timezone.now() - timedelta(days=settings.BOOST_ACTIVITY_WINDOW_DAYS)
+    ).date()
+    query = quote(
+        f"org:{settings.BOOST_GITHUB_ORG} {terms.format(login=login, since=since)}"
+    )
+    return f"https://github.com/search?q={query}&type={kind}"
+
+
+def github_activity_bullets(data, login):
+    """Render the stored activity numbers as the card's markdown bullet list.
+
+    Lines with a zero count are omitted rather than rendered as "0 Commits".
+    """
+    bullets = []
+
+    commits = data.get("total_commits") or 0
+    if commits:
+        url = _search_url(
+            login, "author:{login} committer-date:>={since}", kind="commits"
+        )
+        bullets.append(
+            f"* Created {_plural(commits, 'Commit', 'Commits')} in "
+            f"{_repo_link(data.get('commit_repo_count') or 0, url)}"
+        )
+
+    repos_created = data.get("repos_created") or 0
+    if repos_created:
+        url = (
+            f"https://github.com/orgs/{settings.BOOST_GITHUB_ORG}"
+            "/repositories?sort=created"
+        )
+        bullets.append(f"* Created {_repo_link(repos_created, url)}")
+
+    featured = data.get("featured_pr")
+    if featured:
+        comments = featured.get("comment_count") or 0
+        bullets.append(
+            f"* Created a pull request in "
+            f"[**{featured['repo']}**]({featured['url']}) that received "
+            f"{_plural(comments, 'comment', 'comments')}"
+        )
+
+    # The featured PR is pulled out above, so the remaining count is "other".
+    prs_opened = (data.get("prs_opened") or 0) - (1 if featured else 0)
+    if prs_opened > 0:
+        url = _search_url(login, "author:{login} is:pr created:>={since}")
+        other = " other" if featured else ""
+        bullets.append(
+            f"* Opened {prs_opened}{other} pull "
+            f"{'request' if prs_opened == 1 else 'requests'} in "
+            f"{_repo_link(data.get('pr_repo_count') or 0, url)}"
+        )
+
+    reviewed = data.get("prs_reviewed") or 0
+    if reviewed:
+        # Approximate: created:>= filters by when the PR was opened, while the
+        # stored count is of review events. No query expresses the latter, so
+        # this link can only ever be close.
+        url = _search_url(login, "reviewed-by:{login} is:pr created:>={since}")
+        bullets.append(
+            f"* Reviewed {reviewed} pull "
+            f"{'request' if reviewed == 1 else 'requests'} in "
+            f"{_repo_link(data.get('review_repo_count') or 0, url)}"
+        )
+
+    return "\n".join(bullets)
+
+
+def github_activity_card(user):
+    """Build the context for the profile's GitHub activity card.
+
+    Never calls GitHub. Returns one of three states: a connect prompt when no
+    GitHub account is linked, an empty state while the first sync runs, or the
+    stored numbers.
+    """
+    state = github_activity_state(user)
+    card = {
+        "title": GITHUB_ACTIVITY_CARD_TITLE,
+        "linked": state.linked,
+        "refreshing": state.refreshing,
+        "markdown_text": "",
+        "button_url": "",
+        "button_label": "",
+        "last_synced": None,
+    }
+
+    if not state.linked:
+        card["markdown_text"] = (
+            "Connect your GitHub account to see your Boost activity here."
+        )
+        card["button_label"] = "Connect GitHub"
+        card["button_url"] = f"{reverse('github_login')}?process=connect"
+        return card
+
+    if state.activity is None or not state.activity.data:
+        card["markdown_text"] = "Fetching your Boost GitHub activity…"
+        return card
+
+    # Every bullet is dropped when all counts are zero, which is the common case
+    # for a linked account with no boostorg contributions yet.
+    card["markdown_text"] = (
+        github_activity_bullets(state.activity.data, user.github_username)
+        or "No Boost contributions in the last 12 months"
+    )
+    card["last_synced"] = state.activity.last_synced
+    card["button_url"] = user.github_profile_url or ""
+    card["button_label"] = "View on GitHub"
+    return card
+
+
+def github_activity_card_context(user, attempt=0):
+    """Context for ``_github_activity_card.html``, shared by the profile page
+    and the fragment endpoint it polls."""
+    attempt = max(0, attempt)
+    return {
+        "data": github_activity_card(user),
+        "attempt": attempt,
+        "next_attempt": attempt + 1,
+        "poll_exhausted": attempt >= GITHUB_ACTIVITY_POLL_MAX_ATTEMPTS,
+        "poll_url": reverse("profile-github-activity"),
+        "poll_interval": GITHUB_ACTIVITY_POLL_INTERVAL_SECONDS,
+    }

--- a/users/profile_cards.py
+++ b/users/profile_cards.py
@@ -106,13 +106,14 @@ def github_activity_bullets(data, login):
             f"{_plural(comments, 'comment', 'comments')}"
         )
 
-    # The featured PR is pulled out above, so the remaining count is "other".
-    prs_opened = (data.get("prs_opened") or 0) - (1 if featured else 0)
-    if prs_opened > 0:
+    # The full total, not the total minus the featured PR. The line above
+    # highlights one of these rather than excluding it, so every number on the
+    # card matches what GitHub reports.
+    prs_opened = data.get("prs_opened") or 0
+    if prs_opened:
         url = _search_url(login, "author:{login} is:pr created:>={since}")
-        other = " other" if featured else ""
         bullets.append(
-            f"* Opened {prs_opened}{other} pull "
+            f"* Opened {prs_opened} pull "
             f"{'request' if prs_opened == 1 else 'requests'} in "
             f"{_repo_link(data.get('pr_repo_count') or 0, url)}"
         )

--- a/users/signals.py
+++ b/users/signals.py
@@ -1,6 +1,7 @@
 from allauth.account.signals import user_logged_in
+from django.db import transaction
 from django.dispatch import receiver
-from django.db.models.signals import post_save
+from django.db.models.signals import post_delete, post_save
 
 from allauth.socialaccount.models import SocialAccount
 
@@ -25,17 +26,48 @@ def import_social_profile_data(sender, instance, created, **kwargs):
         return
 
     avatar_url = None
+    provider_name = instance.extra_data.get("name")
     if instance.provider == GITHUB:
         instance.user.github_username = instance.extra_data.get("login")
         avatar_url = instance.extra_data.get("avatar_url")
+        # A GitHub name is optional, so fall back to the handle rather than
+        # leaving a new user with no display name at all.
+        provider_name = provider_name or instance.extra_data.get("login")
     elif instance.provider == GOOGLE:
         avatar_url = instance.extra_data.get("picture")
 
     if avatar_url and not instance.user.image_uploaded:
         instance.user.save_image_from_provider(avatar_url)
 
-    instance.user.display_name = instance.extra_data.get("name")
+    # Only fill a blank display name. Connecting an account must not overwrite
+    # a name the user chose themselves.
+    if not instance.user.display_name:
+        instance.user.display_name = provider_name
+
     instance.save()
+
+    if instance.provider == GITHUB:
+        # Deferred to on_commit so the worker sees the github_username that the
+        # instance.save() above persists via this receiver's created=False pass.
+        from . import tasks
+
+        user_pk = instance.user.pk
+        transaction.on_commit(lambda: tasks.refresh_github_activity.delay(user_pk))
+
+
+@receiver(post_delete, sender=SocialAccount)
+def delete_github_activity(sender, instance, **kwargs):
+    """Drop stored GitHub activity when a user disconnects their account."""
+    if instance.provider != GITHUB:
+        return
+
+    from .models import GithubActivity, User
+
+    # Locking the user row serialises this against refresh_github_activity, so
+    # an in-flight refresh cannot write the row back after we delete it.
+    with transaction.atomic():
+        User.objects.select_for_update().filter(pk=instance.user_id).first()
+        GithubActivity.objects.filter(user_id=instance.user_id).delete()
 
 
 @receiver(user_logged_in)

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 import structlog
 
+from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth import get_user_model
 from django.core.mail import EmailMultiAlternatives, send_mail
 from django.db import connection, transaction
@@ -17,6 +18,7 @@ from oauth2_provider.models import clear_expired
 from config.celery import app
 from core.githubhelper import GithubAPIClient
 from users.constants import (
+    GITHUB_PROVIDER,
     PROFILE_ROLE_RECOMPUTE_LOCK,
     UNVERIFIED_CLEANUP_DAYS,
     UNVERIFIED_CLEANUP_BEGIN,
@@ -103,6 +105,69 @@ def send_account_deleted_email(email):
         settings.DEFAULT_FROM_EMAIL,
         [email],
     )
+
+
+@app.task
+def refresh_github_activity(user_pk):
+    """Fetch and cache Boost org GitHub activity for a single user.
+
+    Keeps the last good snapshot on API error rather than blanking the row.
+    """
+    from core.githubhelper import boost_activity
+    from users.models import GithubActivity
+
+    try:
+        user = User.objects.get(pk=user_pk)
+    except User.DoesNotExist:
+        logger.exception("refresh_github_activity_user_not_found", user_pk=user_pk)
+        raise
+
+    login = user.github_username
+    if not login:
+        logger.info("refresh_github_activity_no_username", user_pk=user_pk)
+        return
+
+    try:
+        activity_data = boost_activity(login)
+    except Exception as exc:
+        logger.error(
+            "refresh_github_activity_failed",
+            user_pk=user_pk,
+            login=login,
+            exc_msg=str(exc),
+        )
+        raise
+
+    # The account can be disconnected while the fetch above is in flight, and
+    # the disconnect already deleted the row. Re-check under the same lock the
+    # disconnect handler takes, so we never write back data for an account the
+    # user has just unlinked, or for a handle they have since changed.
+    with transaction.atomic():
+        user = User.objects.select_for_update().filter(pk=user_pk).first()
+        if user is None:
+            logger.info("refresh_github_activity_user_gone", user_pk=user_pk)
+            return
+
+        if user.github_username != login:
+            logger.info(
+                "refresh_github_activity_login_changed",
+                user_pk=user_pk,
+                fetched=login,
+                current=user.github_username,
+            )
+            return
+
+        if not SocialAccount.objects.filter(
+            user_id=user_pk, provider=GITHUB_PROVIDER
+        ).exists():
+            logger.info(
+                "refresh_github_activity_disconnected", user_pk=user_pk, login=login
+            )
+            return
+
+        GithubActivity.upsert_for_user(user, activity_data)
+
+    logger.info("refresh_github_activity_done", user_pk=user_pk, login=login)
 
 
 @shared_task

--- a/users/tests/test_admin.py
+++ b/users/tests/test_admin.py
@@ -1,0 +1,102 @@
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth.models import Permission
+from django.test import Client
+from django.urls import reverse
+
+
+def _refresh_url(user):
+    return reverse("admin:user_refresh_github_activity", args=[user.pk])
+
+
+@pytest.fixture
+def linked_user(user):
+    user.github_username = "testuser"
+    user.save()
+    return user
+
+
+def test_refresh_github_activity_rejects_get(client, super_user, linked_user, db):
+    """Queueing work by GET would fire on prefetch and carries no CSRF token."""
+    client.force_login(super_user)
+
+    with patch("users.tasks.refresh_github_activity.delay") as delay:
+        resp = client.get(_refresh_url(linked_user))
+
+    assert resp.status_code == 405
+    delay.assert_not_called()
+
+
+def test_refresh_github_activity_requires_csrf_token(super_user, linked_user, db):
+    csrf_client = Client(enforce_csrf_checks=True)
+    csrf_client.force_login(super_user)
+
+    with patch("users.tasks.refresh_github_activity.delay") as delay:
+        resp = csrf_client.post(_refresh_url(linked_user))
+
+    assert resp.status_code == 403
+    delay.assert_not_called()
+
+
+def test_refresh_github_activity_denied_without_change_permission(
+    client, staff_user, linked_user, db
+):
+    """Staff status alone must not allow queueing a refresh for another user."""
+    client.force_login(staff_user)
+
+    with patch("users.tasks.refresh_github_activity.delay") as delay:
+        resp = client.post(_refresh_url(linked_user))
+
+    assert resp.status_code == 403
+    delay.assert_not_called()
+
+
+def test_refresh_github_activity_allowed_with_change_permission(
+    client, staff_user, linked_user, db
+):
+    staff_user.user_permissions.add(Permission.objects.get(codename="change_user"))
+    client.force_login(staff_user)
+
+    with patch("users.tasks.refresh_github_activity.delay") as delay:
+        resp = client.post(_refresh_url(linked_user))
+
+    assert resp.status_code == 302
+    delay.assert_called_once_with(linked_user.pk)
+
+
+def test_refresh_github_activity_allowed_for_superuser(
+    client, super_user, linked_user, db
+):
+    client.force_login(super_user)
+
+    with patch("users.tasks.refresh_github_activity.delay") as delay:
+        resp = client.post(_refresh_url(linked_user))
+
+    assert resp.status_code == 302
+    delay.assert_called_once_with(linked_user.pk)
+
+
+def test_refresh_github_activity_skips_user_without_handle(
+    client, super_user, user, db
+):
+    client.force_login(super_user)
+
+    with patch("users.tasks.refresh_github_activity.delay") as delay:
+        resp = client.post(_refresh_url(user))
+
+    assert resp.status_code == 302
+    delay.assert_not_called()
+
+
+def test_refresh_button_posts_with_csrf_token(client, super_user, linked_user, db):
+    """The admin page must render the control as a CSRF-protected POST form."""
+    client.force_login(super_user)
+
+    html = client.get(
+        reverse("admin:users_user_change", args=[linked_user.pk])
+    ).content.decode()
+
+    assert f'action="{_refresh_url(linked_user)}"' in html
+    assert "csrfmiddlewaretoken" in html
+    assert f'href="{_refresh_url(linked_user)}"' not in html

--- a/users/tests/test_admin.py
+++ b/users/tests/test_admin.py
@@ -100,3 +100,24 @@ def test_refresh_button_posts_with_csrf_token(client, super_user, linked_user, d
     assert f'action="{_refresh_url(linked_user)}"' in html
     assert "csrfmiddlewaretoken" in html
     assert f'href="{_refresh_url(linked_user)}"' not in html
+    # The button sits in the submit row and reaches the form by id, so the
+    # form itself can stay outside the admin form.
+    assert 'form="refresh-github-activity"' in html
+
+
+def test_refresh_form_is_not_nested_inside_the_admin_form(
+    client, super_user, linked_user, db
+):
+    """HTML forbids nested forms: the browser drops the inner one, so the
+    button would submit the change form, saving unsaved edits and queueing
+    nothing. Our form must therefore sit before the admin form opens."""
+    client.force_login(super_user)
+
+    html = client.get(
+        reverse("admin:users_user_change", args=[linked_user.pk])
+    ).content.decode()
+
+    refresh_form = html.index(f'action="{_refresh_url(linked_user)}"')
+    admin_form = html.index('id="user_form"')
+
+    assert refresh_form < admin_form

--- a/users/tests/test_github_activity_view.py
+++ b/users/tests/test_github_activity_view.py
@@ -1,0 +1,67 @@
+from unittest.mock import patch
+from django.core.cache import cache
+from django.urls import reverse
+from model_bakery import baker
+from users.models import GithubActivity
+
+
+def _connect(user):
+    return baker.make(
+        "socialaccount.SocialAccount",
+        user=user,
+        provider="github",
+        extra_data={"login": "testuser"},
+    )
+
+
+def test_fragment_requires_login(client, db):
+    resp = client.get(reverse("profile-github-activity"))
+    assert resp.status_code == 302
+
+
+def test_fragment_polls_while_refreshing(client, user, db):
+    cache.clear()
+    _connect(user)
+    client.force_login(user)
+    with patch("users.tasks.refresh_github_activity.delay"):
+        resp = client.get(reverse("profile-github-activity"))
+    html = resp.content.decode()
+    assert resp.status_code == 200
+    assert "hx-get=" in html
+    assert 'hx-trigger="load delay:5s"' in html
+    assert "Fetching GitHub activity" in html
+
+
+def test_fragment_stops_polling_once_fresh(client, user, db):
+    cache.clear()
+    _connect(user)
+    user.github_username = "testuser"
+    user.save()
+    GithubActivity.upsert_for_user(user, {"total_commits": 5, "commit_repo_count": 2})
+    client.force_login(user)
+    resp = client.get(reverse("profile-github-activity"))
+    html = resp.content.decode()
+    assert "hx-get=" not in html
+    assert "Created 5 Commits" in html
+    assert "Updated" in html
+
+
+def test_fragment_gives_up_at_cap(client, user, db):
+    cache.clear()
+    _connect(user)
+    client.force_login(user)
+    with patch("users.tasks.refresh_github_activity.delay"):
+        resp = client.get(reverse("profile-github-activity") + "?attempt=12")
+    html = resp.content.decode()
+    assert "hx-get=" not in html
+    assert "reload the page" in html
+
+
+def test_fragment_ignores_garbage_attempt(client, user, db):
+    cache.clear()
+    _connect(user)
+    client.force_login(user)
+    with patch("users.tasks.refresh_github_activity.delay"):
+        resp = client.get(reverse("profile-github-activity") + "?attempt=abc")
+    assert resp.status_code == 200
+    assert "hx-get=" in resp.content.decode()

--- a/users/tests/test_profile_cards.py
+++ b/users/tests/test_profile_cards.py
@@ -1,0 +1,347 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.utils import timezone
+from model_bakery import baker
+
+from users.constants import (
+    GITHUB_ACTIVITY_POLL_MAX_ATTEMPTS,
+    GITHUB_ACTIVITY_STALE_AFTER,
+)
+from users.models import GithubActivity
+from users.profile_cards import (
+    github_activity_bullets,
+    github_activity_card_context,
+    github_activity_card,
+    github_activity_state,
+)
+
+
+def _connect_github(user):
+    return baker.make(
+        "socialaccount.SocialAccount",
+        user=user,
+        provider="github",
+        extra_data={"login": "testuser"},
+    )
+
+
+def _store_activity(user, synced_ago):
+    activity = GithubActivity.upsert_for_user(user, {"total_commits": 5})
+    GithubActivity.objects.filter(pk=activity.pk).update(
+        last_synced=timezone.now() - synced_ago
+    )
+    return GithubActivity.objects.get(pk=activity.pk)
+
+
+def test_no_linked_account_returns_nothing_and_queues_nothing(user, db):
+    cache.clear()
+
+    with patch("users.tasks.refresh_github_activity.delay") as delay:
+        linked, activity, refreshing = github_activity_state(user)
+
+    assert linked is False
+    assert activity is None
+    assert refreshing is False
+    delay.assert_not_called()
+
+
+def test_fresh_activity_is_served_without_refreshing(user, db):
+    cache.clear()
+    _connect_github(user)
+    _store_activity(user, timedelta(hours=1))
+    user.refresh_from_db()
+
+    with patch("users.tasks.refresh_github_activity.delay") as delay:
+        linked, activity, refreshing = github_activity_state(user)
+
+    assert linked is True
+    assert activity is not None
+    assert refreshing is False
+    delay.assert_not_called()
+
+
+def test_stale_activity_is_served_while_refresh_is_queued(user, db):
+    """Stale data still renders; the refresh happens in the background."""
+    cache.clear()
+    _connect_github(user)
+    _store_activity(user, GITHUB_ACTIVITY_STALE_AFTER + timedelta(minutes=1))
+    user.refresh_from_db()
+
+    with patch("users.tasks.refresh_github_activity.delay") as delay:
+        linked, activity, refreshing = github_activity_state(user)
+
+    assert linked is True
+    assert activity is not None
+    assert activity.data == {"total_commits": 5}
+    assert refreshing is True
+    delay.assert_called_once_with(user.pk)
+
+
+def test_linked_but_never_synced_queues_refresh(user, db):
+    cache.clear()
+    _connect_github(user)
+
+    with patch("users.tasks.refresh_github_activity.delay") as delay:
+        linked, activity, refreshing = github_activity_state(user)
+
+    assert linked is True
+    assert activity is None
+    assert refreshing is True
+    delay.assert_called_once_with(user.pk)
+
+
+def test_repeat_loads_do_not_queue_duplicate_refreshes(user, db):
+    """A second page load while a refresh is in flight must not re-queue it."""
+    cache.clear()
+    _connect_github(user)
+
+    with patch("users.tasks.refresh_github_activity.delay") as delay:
+        github_activity_state(user)
+        refreshing = github_activity_state(user).refreshing
+
+    assert refreshing is True
+    assert delay.call_count == 1
+
+
+def test_is_stale_boundaries(user, db):
+    activity = _store_activity(user, GITHUB_ACTIVITY_STALE_AFTER - timedelta(minutes=1))
+    assert activity.is_stale is False
+
+    activity = _store_activity(user, GITHUB_ACTIVITY_STALE_AFTER + timedelta(minutes=1))
+    assert activity.is_stale is True
+
+    activity.last_synced = None
+    assert activity.is_stale is True
+
+
+ACTIVITY_DATA = {
+    "total_commits": 24,
+    "commit_repo_count": 7,
+    "repos_created": 1,
+    "prs_opened": 18,
+    "pr_repo_count": 6,
+    "prs_reviewed": 3,
+    "review_repo_count": 3,
+    "featured_pr": {
+        "title": "Add support",
+        "url": "https://github.com/boostorg/url/pull/932",
+        "repo": "boostorg/url",
+        "comment_count": 6,
+    },
+}
+
+
+def test_card_shows_connect_prompt_without_linked_account(user, db):
+    cache.clear()
+
+    card = github_activity_card(user)
+
+    assert "Connect your GitHub account" in card["markdown_text"]
+    assert card["button_label"] == "Connect GitHub"
+    assert "process=connect" in card["button_url"]
+
+
+def test_card_shows_empty_state_when_linked_but_unsynced(user, db):
+    cache.clear()
+    _connect_github(user)
+
+    with patch("users.tasks.refresh_github_activity.delay"):
+        card = github_activity_card(user)
+
+    assert "Fetching your Boost GitHub activity" in card["markdown_text"]
+    assert card["refreshing"] is True
+    assert card["button_url"] == ""
+
+
+def test_card_renders_stored_numbers(user, db):
+    cache.clear()
+    _connect_github(user)
+    user.github_username = "testuser"
+    user.save()
+    GithubActivity.upsert_for_user(user, ACTIVITY_DATA)
+    user.refresh_from_db()
+
+    card = github_activity_card(user)
+    markdown = card["markdown_text"]
+
+    assert "Created 24 Commits in [**7 repositories**]" in markdown
+    assert "Created [**1 repository**]" in markdown
+    assert "[**boostorg/url**](https://github.com/boostorg/url/pull/932)" in markdown
+    assert "that received 6 comments" in markdown
+    # 18 opened total, one of which is featured above.
+    assert "Opened 17 other pull requests in [**6 repositories**]" in markdown
+    assert "Reviewed 3 pull requests in [**3 repositories**]" in markdown
+    assert card["button_label"] == "View on GitHub"
+    assert card["button_url"] == "https://github.com/testuser"
+    assert card["refreshing"] is False
+
+
+def test_bullets_omit_zero_counts():
+    markdown = github_activity_bullets(
+        {"total_commits": 0, "prs_reviewed": 2, "review_repo_count": 1}, "testuser"
+    )
+
+    assert "Commit" not in markdown
+    assert "Reviewed 2 pull requests in [**1 repository**]" in markdown
+
+
+def test_bullets_singularise():
+    markdown = github_activity_bullets(
+        {
+            "total_commits": 1,
+            "commit_repo_count": 1,
+            "prs_reviewed": 1,
+            "review_repo_count": 1,
+        },
+        "testuser",
+    )
+
+    assert "Created 1 Commit in [**1 repository**]" in markdown
+    assert "Reviewed 1 pull request in [**1 repository**]" in markdown
+
+
+def test_bullets_scope_search_links_to_boostorg():
+    markdown = github_activity_bullets(
+        {"total_commits": 3, "commit_repo_count": 2}, "testuser"
+    )
+
+    assert "org%3Aboostorg" in markdown
+    assert "author%3Atestuser" in markdown
+
+
+def test_poll_context_stops_at_attempt_cap(user, db):
+    cache.clear()
+    _connect_github(user)
+
+    with patch("users.tasks.refresh_github_activity.delay"):
+        ctx = github_activity_card_context(
+            user, attempt=GITHUB_ACTIVITY_POLL_MAX_ATTEMPTS
+        )
+
+    assert ctx["poll_exhausted"] is True
+    assert ctx["data"]["refreshing"] is True
+
+
+def test_poll_context_continues_below_cap(user, db):
+    cache.clear()
+    _connect_github(user)
+
+    with patch("users.tasks.refresh_github_activity.delay"):
+        ctx = github_activity_card_context(user, attempt=1)
+
+    assert ctx["poll_exhausted"] is False
+    assert ctx["next_attempt"] == 2
+
+
+def test_poll_context_clamps_negative_attempt(user, db):
+    cache.clear()
+
+    ctx = github_activity_card_context(user, attempt=-5)
+
+    assert ctx["attempt"] == 0
+
+
+def test_bullets_follow_the_configured_org(settings):
+    """The search and repo links must come from BOOST_GITHUB_ORG, not a literal."""
+    settings.BOOST_GITHUB_ORG = "someotherorg"
+
+    markdown = github_activity_bullets(
+        {"total_commits": 3, "commit_repo_count": 2, "repos_created": 1}, "testuser"
+    )
+
+    assert "org%3Asomeotherorg" in markdown
+    assert "/orgs/someotherorg/repositories" in markdown
+    assert "boostorg" not in markdown
+
+
+ZERO_ACTIVITY_DATA = {
+    "total_commits": 0,
+    "commit_repo_count": 0,
+    "repos_created": 0,
+    "prs_opened": 0,
+    "pr_repo_count": 0,
+    "prs_reviewed": 0,
+    "review_repo_count": 0,
+    "featured_pr": None,
+}
+
+
+def test_card_shows_empty_state_when_there_are_no_contributions(user, db):
+    """A linked account with no boostorg activity must not render a blank card."""
+    cache.clear()
+    _connect_github(user)
+    user.github_username = "testuser"
+    user.save()
+    GithubActivity.upsert_for_user(user, ZERO_ACTIVITY_DATA)
+    user.refresh_from_db()
+
+    card = github_activity_card(user)
+
+    assert card["markdown_text"] == "No Boost contributions in the last 12 months"
+    # Still a real linked account, so the profile link stays useful.
+    assert card["button_label"] == "View on GitHub"
+    assert card["button_url"] == "https://github.com/testuser"
+    assert card["refreshing"] is False
+    assert card["last_synced"] is not None
+
+
+def test_card_with_contributions_does_not_show_the_empty_state(user, db):
+    cache.clear()
+    _connect_github(user)
+    user.github_username = "testuser"
+    user.save()
+    GithubActivity.upsert_for_user(user, {"total_commits": 3, "commit_repo_count": 1})
+    user.refresh_from_db()
+
+    card = github_activity_card(user)
+
+    assert "No Boost contributions" not in card["markdown_text"]
+    assert "Created 3 Commits" in card["markdown_text"]
+
+
+def test_search_links_are_scoped_to_the_activity_window(settings):
+    """Links must carry the same 12-month window the stored numbers cover."""
+    settings.BOOST_ACTIVITY_WINDOW_DAYS = 365
+    since = (timezone.now() - timedelta(days=365)).date()
+
+    markdown = github_activity_bullets(
+        {
+            "total_commits": 3,
+            "commit_repo_count": 1,
+            "prs_opened": 2,
+            "pr_repo_count": 1,
+            "prs_reviewed": 4,
+            "review_repo_count": 1,
+        },
+        "testuser",
+    )
+
+    assert f"committer-date%3A%3E%3D{since}" in markdown
+    assert markdown.count(f"created%3A%3E%3D{since}") == 2  # PRs and reviews
+
+
+def test_commits_link_targets_the_commits_tab():
+    """type:commit is not a commit-search qualifier and returns nothing."""
+    markdown = github_activity_bullets(
+        {"total_commits": 3, "commit_repo_count": 1}, "testuser"
+    )
+
+    assert "type=commits" in markdown
+    assert "type%3Acommit" not in markdown
+
+
+def test_pr_and_review_links_target_the_pull_requests_tab():
+    markdown = github_activity_bullets(
+        {
+            "prs_opened": 2,
+            "pr_repo_count": 1,
+            "prs_reviewed": 4,
+            "review_repo_count": 1,
+        },
+        "testuser",
+    )
+
+    assert markdown.count("type=pullrequests") == 2
+    assert "type=commits" not in markdown

--- a/users/tests/test_profile_cards.py
+++ b/users/tests/test_profile_cards.py
@@ -170,8 +170,10 @@ def test_card_renders_stored_numbers(user, db):
     assert "Created [**1 repository**]" in markdown
     assert "[**boostorg/url**](https://github.com/boostorg/url/pull/932)" in markdown
     assert "that received 6 comments" in markdown
-    # 18 opened total, one of which is featured above.
-    assert "Opened 17 other pull requests in [**6 repositories**]" in markdown
+    # The full total. The featured line above highlights one of these
+    # rather than excluding it, so this matches what GitHub reports.
+    assert "Opened 18 pull requests in [**6 repositories**]" in markdown
+    assert "other pull request" not in markdown
     assert "Reviewed 3 pull requests in [**3 repositories**]" in markdown
     assert card["button_label"] == "View on GitHub"
     assert card["button_url"] == "https://github.com/testuser"

--- a/users/tests/test_profile_page_render.py
+++ b/users/tests/test_profile_page_render.py
@@ -1,0 +1,50 @@
+import waffle.testutils
+from django.core.cache import cache
+from django.urls import reverse
+from model_bakery import baker
+from users.models import GithubActivity
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_profile_page_renders_activity_card(client, user, db, settings):
+    cache.clear()
+    # allauth resolves the provider app when rendering the connections list,
+    # so the page needs a SocialApp even though this test is about the card.
+    from django.contrib.sites.models import Site
+    from allauth.socialaccount.models import SocialApp
+
+    app = SocialApp.objects.create(
+        provider="github", name="GitHub", client_id="x", secret="y"
+    )
+    app.sites.add(Site.objects.get_current())
+    baker.make(
+        "socialaccount.SocialAccount",
+        user=user,
+        provider="github",
+        extra_data={"login": "testuser"},
+    )
+    user.github_username = "testuser"
+    user.save()
+    GithubActivity.upsert_for_user(
+        user,
+        {
+            "total_commits": 24,
+            "commit_repo_count": 7,
+            "featured_pr": {
+                "repo": "boostorg/url",
+                "url": "https://github.com/boostorg/url/pull/932",
+                "comment_count": 6,
+            },
+        },
+    )
+    client.force_login(user)
+
+    resp = client.get(reverse("profile-account"))
+    html = resp.content.decode()
+
+    assert resp.status_code == 200
+    assert 'id="github-activity-card"' in html
+    assert "Created 24 Commits" in html
+    assert "boostorg/url" in html
+    # the hardcoded placeholder card is gone
+    assert "cppalliance/buffers" not in html

--- a/users/tests/test_signals.py
+++ b/users/tests/test_signals.py
@@ -1,4 +1,9 @@
+from unittest.mock import patch
+
 import pytest
+from model_bakery import baker
+
+from users.models import GithubActivity
 
 
 @pytest.mark.skip("Reminder to write this test when I have the patience for mocks")
@@ -11,3 +16,131 @@ def test_import_social_profile_data():
     - You probably need to use `responses` and not `patch`
     """
     pass
+
+
+def _connect(user, provider, login="testuser"):
+    return baker.make(
+        "socialaccount.SocialAccount",
+        user=user,
+        provider=provider,
+        extra_data={"login": login, "name": "Test User"},
+    )
+
+
+def test_github_connect_queues_activity_refresh(
+    user, db, django_capture_on_commit_callbacks
+):
+    """Linking GitHub kicks an initial fetch without waiting for a page load."""
+    with patch("users.tasks.refresh_github_activity.delay") as delay:
+        with django_capture_on_commit_callbacks(execute=True):
+            _connect(user, "github")
+
+    delay.assert_called_once_with(user.pk)
+
+
+def test_github_connect_refresh_runs_after_username_is_saved(
+    user, db, django_capture_on_commit_callbacks
+):
+    """The task must not fire before the github_username hits the database."""
+    seen = {}
+
+    def capture(user_pk):
+        from users.models import User
+
+        seen["username"] = User.objects.get(pk=user_pk).github_username
+
+    with patch("users.tasks.refresh_github_activity.delay", side_effect=capture):
+        with django_capture_on_commit_callbacks(execute=True):
+            _connect(user, "github", login="octocat")
+
+    assert seen["username"] == "octocat"
+
+
+def test_google_connect_does_not_queue_activity_refresh(
+    user, db, django_capture_on_commit_callbacks
+):
+    with patch("users.tasks.refresh_github_activity.delay") as delay:
+        with django_capture_on_commit_callbacks(execute=True):
+            _connect(user, "google")
+
+    delay.assert_not_called()
+
+
+def test_github_disconnect_deletes_stored_activity(user, db):
+    account = _connect(user, "github")
+    GithubActivity.upsert_for_user(user, {"total_commits": 5})
+    assert GithubActivity.objects.filter(user=user).exists()
+
+    account.delete()
+
+    assert not GithubActivity.objects.filter(user=user).exists()
+
+
+def test_google_disconnect_keeps_github_activity(user, db):
+    account = _connect(user, "google")
+    GithubActivity.upsert_for_user(user, {"total_commits": 5})
+
+    account.delete()
+
+    assert GithubActivity.objects.filter(user=user).exists()
+
+
+def _connect_with(user, provider, extra_data):
+    return baker.make(
+        "socialaccount.SocialAccount",
+        user=user,
+        provider=provider,
+        extra_data=extra_data,
+    )
+
+
+def test_connect_keeps_a_display_name_the_user_chose(user, db):
+    """Linking GitHub must not overwrite a name the user set themselves."""
+    user.display_name = "Alice Chen"
+    user.save()
+
+    _connect_with(user, "github", {"login": "achen92", "name": "achen92"})
+    user.refresh_from_db()
+
+    assert user.display_name == "Alice Chen"
+
+
+def test_connect_fills_a_blank_display_name_from_github_name(user, db):
+    user.display_name = ""
+    user.save()
+
+    _connect_with(user, "github", {"login": "achen92", "name": "Alice Chen"})
+    user.refresh_from_db()
+
+    assert user.display_name == "Alice Chen"
+
+
+def test_connect_falls_back_to_the_github_handle(user, db):
+    """GitHub's name is optional, so a null must not blank the display name."""
+    user.display_name = ""
+    user.save()
+
+    _connect_with(user, "github", {"login": "achen92", "name": None})
+    user.refresh_from_db()
+
+    assert user.display_name == "achen92"
+
+
+def test_google_connect_keeps_a_display_name_the_user_chose(user, db):
+    user.display_name = "Alice Chen"
+    user.save()
+
+    _connect_with(user, "google", {"name": "A. Chen", "picture": ""})
+    user.refresh_from_db()
+
+    assert user.display_name == "Alice Chen"
+
+
+def test_google_connect_fills_a_blank_display_name(user, db):
+    user.display_name = ""
+    user.save()
+
+    _connect_with(user, "google", {"name": "A. Chen", "picture": ""})
+    user.refresh_from_db()
+
+    assert user.display_name == "A. Chen"

--- a/users/tests/test_tasks.py
+++ b/users/tests/test_tasks.py
@@ -4,9 +4,12 @@ from unittest.mock import patch
 
 from model_bakery import baker
 from allauth.account.models import EmailAddress
+from allauth.socialaccount.models import SocialAccount
 
+from ..models import GithubActivity, User
 from ..tasks import (
     UserMissingGithubUsername,
+    refresh_github_activity,
     update_user_github_photo,
     remove_unverified_users,
 )
@@ -286,3 +289,71 @@ def test_remove_unverified_users_exception_handling(mock_logger):
         mock_logger.exception.assert_called_once_with(
             "Error occurred processing unverified users for removal: Test exception"
         )
+
+
+"""refresh_github_activity Tests"""
+
+
+def _connect_github(user, login="testuser"):
+    return baker.make(
+        "socialaccount.SocialAccount",
+        user=user,
+        provider="github",
+        extra_data={"login": login, "name": user.display_name},
+    )
+
+
+def test_refresh_github_activity_stores_data(user, db):
+    _connect_github(user)
+    user.refresh_from_db()
+
+    with patch("core.githubhelper.boost_activity", return_value={"total_commits": 5}):
+        refresh_github_activity(user.pk)
+
+    activity = GithubActivity.objects.get(user=user)
+    assert activity.data == {"total_commits": 5}
+
+
+def test_refresh_github_activity_aborts_if_disconnected_mid_fetch(user, db):
+    """A disconnect during the fetch must not resurrect the deleted row."""
+    account = _connect_github(user)
+    user.refresh_from_db()
+
+    def disconnect_then_return(login):
+        # Stands in for the user unlinking while the GitHub call is in flight.
+        SocialAccount.objects.filter(pk=account.pk).delete()
+        return {"total_commits": 5}
+
+    with patch("core.githubhelper.boost_activity", side_effect=disconnect_then_return):
+        refresh_github_activity(user.pk)
+
+    assert not GithubActivity.objects.filter(user=user).exists()
+
+
+def test_refresh_github_activity_aborts_if_handle_changed_mid_fetch(user, db):
+    """Data fetched for one handle must not be stored against another."""
+    _connect_github(user, login="testuser")
+    user.refresh_from_db()
+
+    def change_handle_then_return(login):
+        User.objects.filter(pk=user.pk).update(github_username="someone-else")
+        return {"total_commits": 5}
+
+    with patch(
+        "core.githubhelper.boost_activity", side_effect=change_handle_then_return
+    ):
+        refresh_github_activity(user.pk)
+
+    assert not GithubActivity.objects.filter(user=user).exists()
+
+
+def test_refresh_github_activity_keeps_snapshot_on_api_error(user, db):
+    _connect_github(user)
+    user.refresh_from_db()
+    GithubActivity.upsert_for_user(user, {"total_commits": 9})
+
+    with patch("core.githubhelper.boost_activity", side_effect=ValueError("boom")):
+        with pytest.raises(ValueError):
+            refresh_github_activity(user.pk)
+
+    assert GithubActivity.objects.get(user=user).data == {"total_commits": 9}

--- a/users/views.py
+++ b/users/views.py
@@ -58,6 +58,7 @@ from .mixins import V3UserProfileContextMixin
 from .models import NO_PUBLIC_ROLE_OPTION, User, encode_role_option
 from .password_rules import build_password_rules
 from .permissions import CustomUserPermissions
+from .profile_cards import github_activity_card_context
 from .serializers import UserSerializer, FullUserSerializer, CurrentUserSerializer
 from . import tasks
 
@@ -123,6 +124,24 @@ class PublicUserProfileView(V3UserProfileContextMixin, V3Mixin, DetailView):
         context = super().get_v3_context_data(**kwargs)
         context.update(self.get_v3_public_context(self.object))
         return context
+
+
+class GithubActivityFragmentView(LoginRequiredMixin, TemplateView):
+    """Re-render just the GitHub activity card.
+
+    Polled by the card itself while a background refresh runs, so the numbers
+    appear without the user reloading. Read-only: it renders whatever is stored
+    and never waits on GitHub.
+    """
+
+    template_name = "v3/includes/_github_activity_card.html"
+
+    def get_context_data(self, **kwargs):
+        try:
+            attempt = int(self.request.GET.get("attempt", 0))
+        except ValueError:
+            attempt = 0
+        return github_activity_card_context(self.request.user, attempt=attempt)
 
 
 class CurrentUserProfileView(


### PR DESCRIPTION
# Issue: #2583

## Summary & Context

The "Latest Boost Github activity" card on the profile page showed fake numbers hardcoded in the view (24 commits, a PR in `cppalliance/buffers`, links to `example.com`). This PR makes it show the user's real activity.

The numbers come from GitHub's GraphQL API, using the one shared app token we already have (`GITHUB_TOKEN`) rather than asking each user for extra permissions. The [spike](https://github.com/boostorg/website-v2/issues/2454) confirmed we don't need per-user OAuth, because boostorg repos are public and any authenticated token can read public contribution counts.

We save the results in the database and read from there. Loading a profile page never calls GitHub, so the page stays fast and we don't burn API quota on every page view.

- **Figma link**: [User Profile](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=6635-17141) / [activity card](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=6635-17182)
- **Link to components/page**: localhost:8000/users/me/ (needs the `v3` waffle flag on, and a GitHub account connected)

Builds on the draft PR #2506, which had the first version of the GraphQL query, the `GithubActivity` model and the admin panel.

## Changes

**When the numbers get fetched**

- Connecting a GitHub account starts a fetch straight away, so a new user doesn't wait for anything.
- Opening your profile checks how old the saved numbers are. Under 24 hours, we show what we have. Over 24 hours, we show what we have *and* start a refresh in the background.
- There is no nightly job for all users. We only fetch for people who actually visit their profile. (The spike originally suggested a nightly job; #2583 changed this, so the daily task from #2506 was removed.)
- Disconnecting a GitHub account deletes the saved numbers.

**While a refresh is running**

- The card shows "Fetching GitHub activity" with a spinner, matching Figma node `11713:98663`.
- The card asks the server for an update every 5 seconds and swaps itself out when the new numbers arrive, so you don't have to reload.
- It stops asking after 12 tries (about a minute) and switches to "reload the page to see the latest", so a broken fetch can't poll forever.
- With JavaScript off, you get that "reload the page" message immediately.

**Fixes to the query from #2506**

- It was reading **both** `boostorg` and `cppalliance`. The setting that was supposed to limit it to one org was never actually added to `settings.py`, so it silently fell back to a default that included both. For `vinniefalco` that meant showing **2042 commits instead of 5**, and a featured PR from `cppalliance/http` — the org @rbbeeston confirmed we don't display.
- If GitHub returned an error, the code caught it and carried on, handing back all-zero numbers as if they were real. Those zeros then overwrote good saved data. Now an error stops the whole thing, so the previous numbers stay untouched.
- The org ID is now a setting instead of being looked up over the API every time. Worth knowing: GitHub's REST and GraphQL APIs both still hand back a **deprecated** ID format, so the old lookup was producing a deprecated ID on every call. The setting uses the current format (`O_kgDOADBg4Q`).

**The card itself**

- Bullet lines are built from the saved numbers, with correct singular/plural ("1 repository" vs "7 repositories").
- Lines with a zero are left out entirely, rather than showing "Created 0 Commits in 0 repositories".
- "View on GitHub" goes to the user's GitHub profile.
- If no GitHub account is connected, the card shows a connect prompt instead.
- If an account is connected but nothing has been fetched yet, it shows a short "Fetching..." message rather than an empty box.

## ‼️ Risks & Considerations ‼️

**Things I had to decide, that the ticket and Figma didn't cover — these are the main things to check:**

1. **Where the links go.** Figma pointed every link at `example.com`, so I picked targets: GitHub search filtered to `org:boostorg` for commits, PRs and reviews (both URL shapes verified working). The first one is "Created 1 repository" where GitHub has no URL for "repos created by this person inside this org", so it links to the org's repo list sorted by date. Happy to unlink that number instead.

2. **A failed refresh isn't retried for 5 minutes.** There's a lock so that reloading the page repeatedly doesn't queue up duplicate fetches. Deliberate, but it means a temporary GitHub blip leaves stale numbers on screen a bit longer.

**Three things older than this PR that I found but did NOT fix:**

3. **Provider resolution can take out the whole profile page, and it's easy to trigger.** `get_social_accounts()` (`users/views.py:549`) calls `get_provider_account()`, which raises if allauth can't resolve exactly one `SocialApp` for the account's provider — `DoesNotExist` on zero apps, `MultipleObjectsReturned` on two or more (`adapter.py:299-302`). There's no uniqueness constraint on `SocialApp`, and the `provider` field on both models is unvalidated free text, so a duplicate row or one typo in admin 500s `/users/me/` for that user. I hit all three variants while setting up a local demo. Existed before this work; flagging because this PR makes connected accounts central to the page. Worth its own ticket, and the fix is probably for the profile page to degrade rather than raise.

4. **Connecting GitHub silently overwrites the user's `display_name`.** `users/signals.py:37` sets `display_name` from `extra_data["name"]` every time a link is created, with no check for whether the user already set their own. So anyone who has customised their Boost display name loses it the moment they connect GitHub. Pre-existing, and not touched here, but this PR gives people a reason to connect from the profile page, so it becomes much more reachable. Small fix (only set it when blank) if we want it in scope.

5. **`hide_github_activity` doesn't do anything yet, and that's correct.** The field says "Hide GitHub activity from the public profile", and the public profile route is still commented out (`config/urls.py:163`). `/users/me/` is your *own* page, so hiding the card there would hide it from the person who owns it. Nothing to do until the public profile page exists. Same for `hide_mailing_list_activity` and `hide_badges`.

## How to test this locally

483 tests pass across `users/` and `core/`, 32 of them new.

To see the card with real data you need two rows in your local database that a fresh checkout won't have. Both steps are quick, but skipping either one leaves you staring at the wrong thing, so the reason for each is spelled out.

Do these **in order**. Step 2 before step 1 gives you a 500.

**1. Create a GitHub `SocialApp`** — `/admin/socialaccount/socialapp/add/`.

| Field | Value |
|---|---|
| Provider | `github` |
| Name | anything |
| Client id / Secret | anything (nothing here calls GitHub's OAuth endpoints) |
| Sites | select all |

Then **check `/admin/socialaccount/socialapp/` shows exactly one GitHub row** before continuing.

**2. Link a GitHub account to your own user** — `/admin/socialaccount/socialaccount/add/`.

| Field | Value | Watch out |
|---|---|---|
| User | your user's numeric id | raw id field: a number box with a magnifier, not a dropdown. Find the id at `/admin/users/user/` |
| Provider | `github` | **free text, unvalidated.** Must be exactly this, lowercase |
| Uid | anything unique, e.g. `local-1` | |
| Extra data | `{"login": "vinniefalco", "name": "<your own name>"}` | `name` overwrites your `display_name` |

> **Why:** the card decides whether you have GitHub connected by looking for a linked account, **not** by looking at `github_username`. That field also gets written by `libraries/tasks.py` from commit-author matching, with no OAuth involved, so it isn't a reliable signal that anyone connected anything. Setting only the handle gets you the connect prompt, not the numbers.
>
> **`extra_data["name"]` is copied straight into `User.display_name`** by the connect signal (`users/signals.py:37`), unconditionally. Put your own name there, or you rename yourself to whoever's handle you're borrowing. See risk #7.
>
> Use a real boostorg contributor for `login` (`vinniefalco`, `pdimov`, `glenfe`). Anyone else returns all zeros, every bullet is dropped, and the card renders empty, which looks broken but is correct. `octocat` is a good handle for capturing that zero state deliberately.

**3. Load `/users/me/`.**

Saving step 2 fires the connect signal, so Celery fetches the data on its own:

```
total_commits: 5, commit_repo_count: 3
prs_opened: 5, pr_repo_count: 5
prs_reviewed: 2, review_repo_count: 1
featured_pr: boostorg/url #932, 5 comments
```

Those are boostorg-only figures. The same handle reports 2042 commits when cppalliance is included, which is the bug described above.

**4. To see the spinner and the auto-update**, the saved data has to be stale, otherwise the card renders finished data on first paint:

```bash
docker compose run --rm web python -c "
import django,os; os.environ.setdefault('DJANGO_SETTINGS_MODULE','config.settings'); django.setup()
from users.models import GithubActivity
from django.utils import timezone; from datetime import timedelta
GithubActivity.objects.update(last_synced=timezone.now() - timedelta(hours=25))"
```

Reload and you get "Fetching GitHub activity" with the spinner, then the numbers appearing a few seconds later without a page reload. Needs `celery-worker` running.

**To check the non-JS path**, disable JavaScript and reload while stale. You should get the "reload the page to see the latest" message instead of a spinner that never resolves.

**One trap if you add tests here:** waffle caches flags in **Redis**, which does not roll back with the database between tests. Creating a `Flag` row directly leaks into later tests — use `@waffle.testutils.override_flag`. I hit this and it silently broke an unrelated signup test.

## Screenshots

### Guided Testing
#### 1. Please watch this [loom video](https://www.loom.com/share/675c0313633f4c50981f203e8d46397c) alongside testing steps 1 -3.

#### 2. This is the behaviour you should expect from step 4:
https://github.com/user-attachments/assets/11d2b0b0-b688-4f2c-9415-e25b36991ca0

### GitHub Activity
<img width="625" height="553" alt="GitHubActivity" src="https://github.com/user-attachments/assets/6c3bffde-a755-49c3-9832-1aaf32c0a9e8" />

https://github.com/user-attachments/assets/cbe0f121-d04c-498e-81f3-8fd881d8d596





## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub activity cards to user profiles, showing contribution totals, repositories, and highlighted pull requests.
  * Activity refreshes automatically in the background and displays synchronization status.
  * Added administrator controls for manually refreshing a user’s GitHub activity.
  * Added support for configuring the GitHub organization used for activity data.

* **Documentation**
  * Documented the optional GitHub organization configuration.

* **Tests**
  * Added coverage for activity fetching, refresh behavior, profile rendering, permissions, and account changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->