### PR TITLE
Story #2558 :: Task: Show real earned badges on the v3 user profile (and honour `hide_badges`)

### DIFF
--- a/ak/homepage.py
+++ b/ak/homepage.py
@@ -2,6 +2,7 @@
 
 from django.urls import reverse
 
+from badges.display import active_badges_prefetch
 from core.constants import SLACK_MEMBER_COUNT
 from core.models import HomepageSettings
 from core.templatetags.custom_static import large_static
@@ -107,7 +108,8 @@ def build_community_posts(limit=5):
     popular_entries = (
         Entry.objects.ranked()
         .filter(deleted_at__isnull=True, published=True)
-        .select_related("author", "author__displayed_profile_role_library")[:limit]
+        .select_related("author", "author__displayed_profile_role_library")
+        .prefetch_related(active_badges_prefetch("author__badges"))[:limit]
     )
     return [entry.to_v3_post_card_dict() for entry in popular_entries]
 

--- a/badges/display.py
+++ b/badges/display.py
@@ -278,13 +278,27 @@ def held_badges(user, include_hidden=False):
 
 
 def featured_badge(user, include_hidden=False):
-    """The user's headline badge as a card dict, or ``None`` if they hold none.
+    """The badge the member picked, or ``None``. Never a badge they did not pick.
 
-    Display-only for now; letting the user choose which badge to feature comes
-    later.
+    There is no default: a member holding badges but choosing none features none.
+    Featuring one for them would publish a choice they never made, and the picker
+    already opens on a suggestion, so the only way here is a deliberate save.
+
+    ``None`` likewise covers a pick that has stopped being displayable - revoked,
+    hidden from the public, or a rank held twice where grandfathering left the row
+    ``held_badges`` folded away.
+
+    ``display_badge_id`` is read rather than ``display_badge`` because a page
+    rendering many users would otherwise cost a query each: the picked row, when
+    the member still holds it, is already among ``held_badges``.
     """
-    badges = held_badges(user, include_hidden=include_hidden)
-    return badge_card(badges[0]) if badges else None
+    picked = user.display_badge_id
+    if picked is None:
+        return None
+    for row in held_badges(user, include_hidden=include_hidden):
+        if row.pk == picked:
+            return badge_card(row)
+    return None
 
 
 def badge_cards(user, include_hidden=False):

--- a/badges/display.py
+++ b/badges/display.py
@@ -5,11 +5,24 @@ wording rather than something staff tune beside a threshold.
 
 Every row is built from ``badges.summary.user_badge_summary``, so the picker adds
 no queries of its own.
+
+The same module turns a user's awarded badges into what the v3 badge templates
+render. Those templates take a component token and a label, never a model
+instance, so the rank-to-asset mapping belongs here rather than on the user
+model.
+
+Ordering there is by *rank*, not threshold: thresholds are not comparable across
+badges (a reviewer diamond needs 5 achievements, a commits silver needs 12), so
+the raw threshold only breaks ties within a rank.
 """
 
 from typing import NamedTuple
 
+from django.db.models import Prefetch
+from django.utils import timezone
+
 from badges.enums import BadgeLabel, TierRank, label_order, rank_order
+from badges.models import UserBadge
 from badges.summary import user_badge_summary
 from core.constants import BadgeToken
 
@@ -220,3 +233,81 @@ def _detail(phrases, tier, count, is_held, gap):
 def _unit(phrases, count):
     """The badge's unit noun, pluralised for ``count``."""
     return phrases.unit if count == 1 else phrases.plural
+
+
+def active_badges_prefetch(lookup="badges"):
+    """The rows ``held_badges`` reads, prefetched at ``lookup``.
+
+    Callers rendering many users at once (author cards on a news page) need this,
+    or ``held_badges`` queries once per user instead of reading the cache.
+
+    ``lookup`` exists because the path is load-bearing. A queryset that reaches
+    its users through ``select_related`` cannot be handed
+    ``Prefetch("author", queryset=User.objects.prefetch_related(...))``: Django
+    finds the foreign key already cached, skips the prefetch, and silently drops
+    the nested badge prefetch with it. Such a caller asks for the badges through
+    the path instead - ``active_badges_prefetch("author__badges")``.
+    """
+    return Prefetch(
+        lookup,
+        queryset=UserBadge.objects.active().select_related("badge", "tier"),
+    )
+
+
+def held_badges(user, include_hidden=False):
+    """The user's active badges, highest rank first, each rank once.
+
+    Returns an empty list when the user has hidden their badges, unless
+    ``include_hidden`` is set - which only the owner's own views should do.
+
+    Retiring a tier keeps the badges already awarded against it, so a user who
+    also qualifies under its replacement holds the same rank twice. Both rows are
+    real history; only one of them is a badge to show.
+    """
+    if user.hide_badges and not include_hidden:
+        return []
+    if "badges" in getattr(user, "_prefetched_objects_cache", {}):
+        rows = [badge for badge in user.badges.all() if badge.revoked_at is None]
+    else:
+        rows = list(user.badges.active().select_related("badge", "tier"))
+
+    unique = {}
+    for row in sorted(rows, key=_rank_key, reverse=True):
+        unique.setdefault((row.badge_id, row.tier.rank), row)
+    return list(unique.values())
+
+
+def featured_badge(user, include_hidden=False):
+    """The user's headline badge as a card dict, or ``None`` if they hold none.
+
+    Display-only for now; letting the user choose which badge to feature comes
+    later.
+    """
+    badges = held_badges(user, include_hidden=include_hidden)
+    return badge_card(badges[0]) if badges else None
+
+
+def badge_cards(user, include_hidden=False):
+    """Every active badge as a card dict, highest rank first."""
+    return [
+        badge_card(badge) for badge in held_badges(user, include_hidden=include_hidden)
+    ]
+
+
+def badge_card(user_badge):
+    """One awarded badge as the dict the badge templates read.
+
+    ``awarded_at`` is stored in UTC, so the calendar day has to be taken in the
+    project's timezone rather than off the raw value: an evening award would
+    otherwise be dated to the following day everywhere west of UTC.
+    """
+    return {
+        "name": user_badge.badge.get_label_display(),
+        "icon": TIER_TOKENS[user_badge.tier.rank],
+        "earned_date": timezone.localtime(user_badge.awarded_at).date(),
+    }
+
+
+def _rank_key(user_badge):
+    """Sort key placing the highest rank first, threshold breaking ties."""
+    return rank_order(user_badge.tier.rank), user_badge.tier.threshold

--- a/badges/tests/test_profile.py
+++ b/badges/tests/test_profile.py
@@ -38,6 +38,28 @@ def _reload(user):
     return type(user).objects.get(pk=user.pk)
 
 
+def _pick(user, rank, slug="library-review"):
+    """Store `rank` of `slug`'s badge as the user's chosen display badge."""
+    user_badge = UserBadge.objects.get(
+        user=user, badge__achievement__slug=slug, tier__rank=rank
+    )
+    user.display_badge = user_badge
+    user.save(update_fields=["display_badge"])
+    return user_badge
+
+
+def _feature(user, slug, count=1):
+    """Grant `count` of `slug` and feature the top badge that awards.
+
+    Nothing is featured until the member picks one, so every test that expects a
+    rendered badge has to make that choice, exactly as the edit page does.
+    """
+    _grant(user, slug, count=count)
+    user.display_badge = display.held_badges(_reload(user), include_hidden=True)[0]
+    user.save(update_fields=["display_badge"])
+    return _reload(user)
+
+
 def _published_entry(author, index):
     """A visible entry suitable for both recent and ranked card origins."""
     from news.models import Entry
@@ -74,8 +96,7 @@ def test_no_badges_yields_no_featured_badge(plain_user):
 
 def test_featured_badge_and_card_list(plain_user):
     """The featured badge and the card list expose real earned badges."""
-    _grant(plain_user, "library-authoring")  # bronze (threshold 1)
-    plain_user = _reload(plain_user)
+    plain_user = _feature(plain_user, "library-authoring")  # bronze (threshold 1)
 
     featured = display.featured_badge(plain_user)
     assert featured["name"] == "Library Author"
@@ -161,8 +182,8 @@ def test_badge_card_dates_the_award_in_the_project_timezone(plain_user):
     assert display.badge_card(user_badge)["earned_date"] == date(2025, 3, 7)
 
 
-def test_featured_badge_picks_the_top_tier(plain_user):
-    """With several tiers earned, the highest one is featured."""
+def test_held_badges_lead_with_the_top_tier(plain_user):
+    """With several tiers earned, the highest one leads the list."""
     badge = Achievement.objects.get(slug="library-review").badges.first()
     # Reviewer tiers: bronze=1, silver=2, gold=3. Three achievements -> gold.
     _grant(plain_user, "library-review", count=3)
@@ -175,6 +196,72 @@ def test_featured_badge_picks_the_top_tier(plain_user):
         ).count()
         == 3
     )
+
+
+def test_featured_badge_honours_the_members_choice(plain_user):
+    """A picked badge outranks the top tier - that is the point of picking."""
+    _grant(plain_user, "library-review", count=3)  # bronze, silver and gold
+    _pick(plain_user, TierRank.BRONZE)
+    plain_user = _reload(plain_user)
+
+    assert display.held_badges(plain_user)[0].tier.rank == TierRank.GOLD
+    assert display.featured_badge(plain_user)["icon"] == BadgeToken.TIER_1
+
+
+def test_badges_held_but_none_picked_features_nothing(plain_user):
+    """No pick, no featured badge - even holding several.
+
+    Featuring the top rank for a member who never chose would publish a choice
+    they did not make. The cards list is unaffected; only the headline is a pick.
+    """
+    _grant(plain_user, "library-review", count=3)
+    plain_user = _reload(plain_user)
+
+    assert plain_user.display_badge_id is None
+    assert display.held_badges(plain_user) != []
+    assert display.featured_badge(plain_user) is None
+    assert plain_user.featured_badge is None
+    assert plain_user.to_v3_profile_dict()["badge"] is None
+    assert len(display.badge_cards(plain_user)) == 3
+
+
+def test_featured_badge_shows_nothing_when_the_choice_is_revoked(plain_user):
+    """A revoked pick features nothing rather than silently moving to another."""
+    _grant(plain_user, "library-review", count=3)
+    picked = _pick(plain_user, TierRank.BRONZE)
+    UserBadge.objects.filter(pk=picked.pk).update(revoked_at="2026-01-01T00:00:00Z")
+    plain_user = _reload(plain_user)
+
+    assert display.held_badges(plain_user) != []
+    assert display.featured_badge(plain_user) is None
+
+
+def test_a_chosen_badge_is_still_hidden_by_hide_badges(plain_user):
+    """Picking a badge is not a way to publish badges the member hid."""
+    _grant(plain_user, "library-review", count=3)
+    _pick(plain_user, TierRank.BRONZE)
+    plain_user.hide_badges = True
+    plain_user.save(update_fields=["hide_badges"])
+    plain_user = _reload(plain_user)
+
+    assert display.featured_badge(plain_user) is None
+    assert display.featured_badge(plain_user, include_hidden=True)["icon"] == (
+        BadgeToken.TIER_1
+    )
+
+
+def test_the_chosen_badge_costs_no_extra_query(plain_user, django_assert_num_queries):
+    """Reading the pick must not reintroduce a query per rendered user."""
+    from users.models import User
+
+    _grant(plain_user, "library-review", count=3)
+    _pick(plain_user, TierRank.BRONZE)
+
+    user = User.objects.prefetch_related(display.active_badges_prefetch()).get(
+        pk=plain_user.pk
+    )
+    with django_assert_num_queries(0):
+        assert display.featured_badge(user)["icon"] == BadgeToken.TIER_1
 
 
 def test_rank_beats_threshold_across_badge_types(plain_user):
@@ -221,8 +308,7 @@ def test_replaced_tier_does_not_duplicate_a_rank(plain_user):
 
 def test_hide_badges_suppresses_every_public_accessor(plain_user):
     """hide_badges empties everything the public profile can reach."""
-    _grant(plain_user, "library-authoring")
-    plain_user = _reload(plain_user)
+    plain_user = _feature(plain_user, "library-authoring")
     assert plain_user.featured_badge is not None
 
     plain_user.hide_badges = True
@@ -238,7 +324,7 @@ def test_hide_badges_suppresses_every_public_accessor(plain_user):
 
 def test_hide_badges_can_be_bypassed_for_the_owner(plain_user):
     """include_hidden lets the owner still see badges they have hidden."""
-    _grant(plain_user, "library-authoring")
+    plain_user = _feature(plain_user, "library-authoring")
     plain_user.hide_badges = True
     plain_user.save(update_fields=["hide_badges"])
     plain_user = _reload(plain_user)
@@ -263,7 +349,7 @@ def test_held_badges_uses_the_prefetch_cache(plain_user, django_assert_num_queri
     """Callers rendering many users must be able to avoid a query each."""
     from users.models import User
 
-    _grant(plain_user, "library-authoring")
+    plain_user = _feature(plain_user, "library-authoring")
 
     user = User.objects.prefetch_related(display.active_badges_prefetch()).get(
         pk=plain_user.pk
@@ -287,7 +373,7 @@ def test_news_author_prefetch_covers_the_whole_card(
     from news.models import Entry
     from news.views import EntryDetailView
 
-    _grant(plain_user, "library-authoring")
+    plain_user = _feature(plain_user, "library-authoring")
     for index in range(3):
         Entry.objects.create(
             title=f"Post {index}",
@@ -312,14 +398,14 @@ def test_community_recent_post_badge_query_is_constant(plain_user):
     """The community page loads author badges once, not once per post card."""
     from core.views import build_recent_community_posts
 
-    _grant(plain_user, "library-authoring")
+    plain_user = _feature(plain_user, "library-authoring")
     _published_entry(plain_user, 0)
 
     one_card, one_badge_query = _badge_queries(build_recent_community_posts)
 
     for index in range(1, 4):
         author = baker.make("users.User", email=f"community-{index}@example.com")
-        _grant(author, "library-authoring")
+        _feature(author, "library-authoring")
         _published_entry(author, index)
     four_cards, four_badge_queries = _badge_queries(build_recent_community_posts)
 
@@ -333,14 +419,14 @@ def test_homepage_ranked_post_badge_query_is_constant(plain_user):
     """The V3 homepage loads ranked-post author badges in one query."""
     from ak.homepage import build_community_posts
 
-    _grant(plain_user, "library-authoring")
+    plain_user = _feature(plain_user, "library-authoring")
     _published_entry(plain_user, 0)
 
     one_card, one_badge_query = _badge_queries(build_community_posts)
 
     for index in range(1, 4):
         author = baker.make("users.User", email=f"homepage-{index}@example.com")
-        _grant(author, "library-authoring")
+        _feature(author, "library-authoring")
         _published_entry(author, index)
     four_cards, four_badge_queries = _badge_queries(build_community_posts)
 
@@ -354,7 +440,7 @@ def test_library_intro_badge_query_is_constant(library_version, plain_user):
     """The homepage library intro prefetches its User authors and maintainers."""
     from libraries.utils import build_library_intro_context
 
-    _grant(plain_user, "library-authoring")
+    plain_user = _feature(plain_user, "library-authoring")
     library_version.authors.add(plain_user)
 
     one_card, one_badge_query = _badge_queries(
@@ -363,7 +449,7 @@ def test_library_intro_badge_query_is_constant(library_version, plain_user):
 
     for index in range(1, 4):
         user = baker.make("users.User", email=f"library-intro-{index}@example.com")
-        _grant(user, "library-authoring")
+        _feature(user, "library-authoring")
         relation = library_version.authors if index % 2 else library_version.maintainers
         relation.add(user)
     four_cards, four_badge_queries = _badge_queries(
@@ -380,7 +466,7 @@ def test_library_detail_user_badge_query_is_constant(library_version, plain_user
     """The detail-page User origins prefetch badges before card conversion."""
     from libraries.mixins import ContributorMixin
 
-    _grant(plain_user, "library-authoring")
+    plain_user = _feature(plain_user, "library-authoring")
     library_version.authors.add(plain_user)
     mixin = ContributorMixin()
 
@@ -392,7 +478,7 @@ def test_library_detail_user_badge_query_is_constant(library_version, plain_user
 
     for index in range(1, 4):
         user = baker.make("users.User", email=f"library-detail-{index}@example.com")
-        _grant(user, "library-authoring")
+        _feature(user, "library-authoring")
         library_version.authors.add(user)
     four_cards, four_badge_queries = _badge_queries(author_cards)
 
@@ -405,7 +491,7 @@ def test_library_detail_user_badge_query_is_constant(library_version, plain_user
 @waffle.testutils.override_flag("v3", active=True)
 def test_own_profile_page_shows_hidden_badges(plain_user, tp):
     """The owner's own v3 profile still renders badges they have hidden."""
-    _grant(plain_user, "library-authoring")
+    plain_user = _feature(plain_user, "library-authoring")
     plain_user.hide_badges = True
     plain_user.save(update_fields=["hide_badges"])
 
@@ -427,8 +513,7 @@ def test_v3_profile_dict_without_badges(plain_user):
 
 def test_v3_profile_dict_carries_the_badge_label(plain_user):
     """_user_profile.html shows the badge label on hover, so it must be set."""
-    _grant(plain_user, "library-authoring")
-    plain_user = _reload(plain_user)
+    plain_user = _feature(plain_user, "library-authoring")
 
     profile = plain_user.to_v3_profile_dict()
 
@@ -440,7 +525,7 @@ def test_v3_profile_dict_carries_the_badge_label(plain_user):
 @waffle.testutils.override_flag("v3", active=True)
 def test_v3_news_list_renders_a_real_badge_for_the_sidebar_user(plain_user, tp):
     """The sidebar card showed a hardcoded "Bug Catcher" label for everyone."""
-    _grant(plain_user, "library-authoring")
+    plain_user = _feature(plain_user, "library-authoring")
     tp.client.force_login(plain_user)
 
     response = tp.get(tp.reverse("news"))

--- a/badges/tests/test_profile.py
+++ b/badges/tests/test_profile.py
@@ -1,0 +1,475 @@
+"""Tests for turning a user's awarded badges into rendered profile data."""
+
+from datetime import date, timedelta
+
+import pytest
+import waffle.testutils
+from django.db import connection
+from django.template.loader import render_to_string
+from django.test.utils import CaptureQueriesContext, override_settings
+from django.utils import timezone
+from django.utils.formats import date_format
+from model_bakery import baker
+
+from badges import display
+from badges.enums import TierRank
+from badges.models import Achievement, UserAchievement, UserBadge
+from core.constants import BadgeToken
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def _catalogue(catalogue):
+    """Seed the real achievement catalogue for every test in this module."""
+
+
+def _grant(user, slug, count=1):
+    """Grant `count` manual achievements of `slug` (recalcs via the signal)."""
+    achievement = Achievement.objects.get(slug=slug)
+    for _ in range(count):
+        UserAchievement.objects.create(
+            user=user, achievement=achievement, source_type="manual"
+        )
+
+
+def _reload(user):
+    """Re-fetch the user so cached_property badge state is discarded."""
+    return type(user).objects.get(pk=user.pk)
+
+
+def _published_entry(author, index):
+    """A visible entry suitable for both recent and ranked card origins."""
+    from news.models import Entry
+
+    published_at = timezone.now() - timedelta(minutes=index)
+    return Entry.objects.create(
+        title=f"Post {index}",
+        slug=f"profile-query-post-{index}",
+        author=author,
+        moderator=author,
+        approved_at=published_at,
+        publish_at=published_at,
+        summary="A test post.",
+    )
+
+
+def _badge_queries(call):
+    """Return a call's value and the number of UserBadge queries it issued."""
+    with CaptureQueriesContext(connection) as queries:
+        value = call()
+    badge_query_count = sum(
+        'FROM "badges_userbadge"' in query["sql"] for query in queries
+    )
+    return value, badge_query_count
+
+
+def test_no_badges_yields_no_featured_badge(plain_user):
+    """A fresh user has nothing to feature and an empty card list."""
+    assert display.held_badges(plain_user) == []
+    assert display.featured_badge(plain_user) is None
+    assert display.badge_cards(plain_user) == []
+    assert plain_user.featured_badge is None
+
+
+def test_featured_badge_and_card_list(plain_user):
+    """The featured badge and the card list expose real earned badges."""
+    _grant(plain_user, "library-authoring")  # bronze (threshold 1)
+    plain_user = _reload(plain_user)
+
+    featured = display.featured_badge(plain_user)
+    assert featured["name"] == "Library Author"
+    assert featured["icon"] == BadgeToken.TIER_1  # bronze -> tier-1
+
+    cards = display.badge_cards(plain_user)
+    assert cards[0]["icon"] == BadgeToken.TIER_1
+    assert cards[0]["name"] == "Library Author"
+    assert cards[0]["earned_date"] is not None
+
+
+@pytest.mark.parametrize(
+    ("rank", "token"),
+    [
+        (TierRank.BRONZE, BadgeToken.TIER_1),
+        (TierRank.SILVER, BadgeToken.TIER_2),
+        (TierRank.GOLD, BadgeToken.TIER_3),
+        (TierRank.PLATINUM, BadgeToken.TIER_4),
+        (TierRank.DIAMOND, BadgeToken.TIER_5),
+    ],
+)
+def test_rank_maps_to_the_component_token_of_the_same_height(rank, token):
+    """Diamond is the top rank, so it draws the component's top badge."""
+    assert display.TIER_TOKENS[rank] == token
+
+
+def test_token_numbers_climb_with_the_rank_ladder():
+    """The reason the mapping above is what it is, asserted on its own.
+
+    The component's assets are numbered rather than named after a metal, so the
+    number *is* the ladder - and a mapping that does not climb with the ranks
+    would show a lower-ranked member the higher-looking medal.
+    """
+    assert [display.TIER_TOKENS[rank] for rank in TierRank] == sorted(
+        display.TIER_TOKENS.values()
+    )
+
+
+def test_badge_card_renders_its_semantic_asset_and_award_date(plain_user):
+    """The card hands the component a token and a date the template formats.
+
+    A ``date`` rather than a preformatted string: the project renders dates
+    through Django's ``DATE_FORMAT`` everywhere else, so a string here would pin
+    this one card to a format nothing else uses.
+    """
+    achievement = Achievement.objects.get(slug="library-review")
+    badge = achievement.badges.get()
+    diamond = badge.tiers.get(rank=TierRank.DIAMOND)
+    awarded_at = timezone.datetime(2025, 3, 7, 14, 30, tzinfo=timezone.UTC)
+    user_badge = UserBadge.objects.create(
+        user=plain_user,
+        badge=badge,
+        tier=diamond,
+        awarded_at=awarded_at,
+    )
+
+    card = display.badge_card(user_badge)
+    rendered = render_to_string("v3/includes/_badges_card.html", {"badges": [card]})
+
+    assert card["earned_date"] == date(2025, 3, 7)
+    assert "img/v3/badges/tier-5.png" in rendered
+    assert "img/v3/badges/tier-4.png" not in rendered
+    assert date_format(date(2025, 3, 7)) in rendered
+
+
+@override_settings(TIME_ZONE="America/New_York")
+def test_badge_card_dates_the_award_in_the_project_timezone(plain_user):
+    """A late-evening award keeps the day it happened on, not the UTC day.
+
+    ``TIME_ZONE`` is UTC today, which makes the naive reading look correct; this
+    pins the boundary so configuring a real timezone cannot shift every badge
+    awarded after 7pm to the next day.
+    """
+    badge = Achievement.objects.get(slug="library-review").badges.get()
+    user_badge = UserBadge.objects.create(
+        user=plain_user,
+        badge=badge,
+        tier=badge.tiers.get(rank=TierRank.BRONZE),
+        # 8:30pm in New York, already the 8th in UTC.
+        awarded_at=timezone.datetime(2025, 3, 8, 1, 30, tzinfo=timezone.UTC),
+    )
+
+    assert display.badge_card(user_badge)["earned_date"] == date(2025, 3, 7)
+
+
+def test_featured_badge_picks_the_top_tier(plain_user):
+    """With several tiers earned, the highest one is featured."""
+    badge = Achievement.objects.get(slug="library-review").badges.first()
+    # Reviewer tiers: bronze=1, silver=2, gold=3. Three achievements -> gold.
+    _grant(plain_user, "library-review", count=3)
+    plain_user = _reload(plain_user)
+
+    assert display.held_badges(plain_user)[0].tier.rank == TierRank.GOLD
+    assert (
+        UserBadge.objects.filter(
+            user=plain_user, badge=badge, revoked_at__isnull=True
+        ).count()
+        == 3
+    )
+
+
+def test_rank_beats_threshold_across_badge_types(plain_user):
+    """A higher rank wins even when another badge has a larger threshold.
+
+    Reviewer diamond needs only 5 achievements while commits silver needs 12,
+    so sorting by raw threshold would wrongly feature the silver.
+    """
+    _grant(plain_user, "library-review", count=5)  # reviewer diamond
+    _grant(plain_user, "code-commits", count=12)  # commits silver
+    plain_user = _reload(plain_user)
+
+    held = display.held_badges(plain_user)
+    assert held[0].tier.rank == TierRank.DIAMOND
+    orders = [TierRank(badge.tier.rank).order for badge in held]
+    assert orders == sorted(orders, reverse=True)
+
+
+def test_replaced_tier_does_not_duplicate_a_rank(plain_user):
+    """Grandfathering can leave two rows for one rank; show the rank once.
+
+    Retiring a tier deliberately keeps the badges awarded against it, so a user
+    who also qualifies under the replacement holds both rows and the badges card
+    would list the same medal twice.
+    """
+    from badges.models import BadgeTier
+    from badges.services import recalculate_badges
+
+    achievement = Achievement.objects.get(slug="library-review")
+    _grant(plain_user, "library-review", count=5)
+    badge = achievement.badges.first()
+    bronze = badge.tiers.get(rank=TierRank.BRONZE)
+    bronze.is_active = False
+    bronze.save(update_fields=["is_active"])
+    BadgeTier.objects.create(badge=badge, rank=TierRank.BRONZE, threshold=5)
+    recalculate_badges(plain_user.pk, achievement.pk)
+    plain_user = _reload(plain_user)
+
+    ranks = [held.tier.rank for held in display.held_badges(plain_user)]
+
+    assert len(ranks) == len(set(ranks))
+    assert ranks.count(TierRank.BRONZE) == 1
+
+
+def test_hide_badges_suppresses_every_public_accessor(plain_user):
+    """hide_badges empties everything the public profile can reach."""
+    _grant(plain_user, "library-authoring")
+    plain_user = _reload(plain_user)
+    assert plain_user.featured_badge is not None
+
+    plain_user.hide_badges = True
+    plain_user.save(update_fields=["hide_badges"])
+    plain_user = _reload(plain_user)
+
+    assert display.held_badges(plain_user) == []
+    assert display.featured_badge(plain_user) is None
+    assert display.badge_cards(plain_user) == []
+    assert plain_user.featured_badge is None
+    assert plain_user.to_v3_profile_dict()["badge"] is None
+
+
+def test_hide_badges_can_be_bypassed_for_the_owner(plain_user):
+    """include_hidden lets the owner still see badges they have hidden."""
+    _grant(plain_user, "library-authoring")
+    plain_user.hide_badges = True
+    plain_user.save(update_fields=["hide_badges"])
+    plain_user = _reload(plain_user)
+
+    assert display.featured_badge(plain_user, include_hidden=True)["icon"] == (
+        BadgeToken.TIER_1
+    )
+    assert len(display.badge_cards(plain_user, include_hidden=True)) == 1
+
+
+def test_revoked_badges_are_not_displayed(plain_user):
+    """A revoked badge disappears from the profile without being deleted."""
+    _grant(plain_user, "library-authoring")
+    UserBadge.objects.filter(user=plain_user).update(revoked_at="2026-01-01T00:00:00Z")
+    plain_user = _reload(plain_user)
+
+    assert display.held_badges(plain_user) == []
+    assert UserBadge.objects.filter(user=plain_user).exists()
+
+
+def test_held_badges_uses_the_prefetch_cache(plain_user, django_assert_num_queries):
+    """Callers rendering many users must be able to avoid a query each."""
+    from users.models import User
+
+    _grant(plain_user, "library-authoring")
+
+    user = User.objects.prefetch_related(display.active_badges_prefetch()).get(
+        pk=plain_user.pk
+    )
+    with django_assert_num_queries(0):
+        assert len(display.held_badges(user)) == 1
+        assert display.featured_badge(user)["icon"] == BadgeToken.TIER_1
+
+
+def test_news_author_prefetch_covers_the_whole_card(
+    plain_user, django_assert_num_queries
+):
+    """A news page's author cards must cost no query each once prefetched.
+
+    ``Prefetch("author", ...)`` looks like it does this and does not: the same
+    queryset select_relates the author, so Django finds the foreign key cached,
+    skips the prefetch, and drops the nested badge prefetch with it. Asserted
+    against the view's own tuple, through the function that reads it, because the
+    failure is silent - the page renders correctly and just queries per card.
+    """
+    from news.models import Entry
+    from news.views import EntryDetailView
+
+    _grant(plain_user, "library-authoring")
+    for index in range(3):
+        Entry.objects.create(
+            title=f"Post {index}",
+            slug=f"post-{index}",
+            author=plain_user,
+            publish_at=timezone.now(),
+        )
+
+    entries = list(
+        Entry.objects.select_related("author").prefetch_related(
+            *EntryDetailView.AUTHOR_PREFETCH
+        )
+    )
+
+    assert len(entries) == 3
+    with django_assert_num_queries(0):
+        cards = [entry.author.to_v3_profile_dict() for entry in entries]
+    assert {card["badge_label"] for card in cards} == {"Library Author"}
+
+
+def test_community_recent_post_badge_query_is_constant(plain_user):
+    """The community page loads author badges once, not once per post card."""
+    from core.views import build_recent_community_posts
+
+    _grant(plain_user, "library-authoring")
+    _published_entry(plain_user, 0)
+
+    one_card, one_badge_query = _badge_queries(build_recent_community_posts)
+
+    for index in range(1, 4):
+        author = baker.make("users.User", email=f"community-{index}@example.com")
+        _grant(author, "library-authoring")
+        _published_entry(author, index)
+    four_cards, four_badge_queries = _badge_queries(build_recent_community_posts)
+
+    assert one_badge_query == four_badge_queries == 1
+    assert len(one_card) == 1
+    assert len(four_cards) == 4
+    assert {card["author"]["badge_label"] for card in four_cards} == {"Library Author"}
+
+
+def test_homepage_ranked_post_badge_query_is_constant(plain_user):
+    """The V3 homepage loads ranked-post author badges in one query."""
+    from ak.homepage import build_community_posts
+
+    _grant(plain_user, "library-authoring")
+    _published_entry(plain_user, 0)
+
+    one_card, one_badge_query = _badge_queries(build_community_posts)
+
+    for index in range(1, 4):
+        author = baker.make("users.User", email=f"homepage-{index}@example.com")
+        _grant(author, "library-authoring")
+        _published_entry(author, index)
+    four_cards, four_badge_queries = _badge_queries(build_community_posts)
+
+    assert one_badge_query == four_badge_queries == 1
+    assert len(one_card) == 1
+    assert len(four_cards) == 4
+    assert {card["author"]["badge_label"] for card in four_cards} == {"Library Author"}
+
+
+def test_library_intro_badge_query_is_constant(library_version, plain_user):
+    """The homepage library intro prefetches its User authors and maintainers."""
+    from libraries.utils import build_library_intro_context
+
+    _grant(plain_user, "library-authoring")
+    library_version.authors.add(plain_user)
+
+    one_card, one_badge_query = _badge_queries(
+        lambda: build_library_intro_context(library_version)
+    )
+
+    for index in range(1, 4):
+        user = baker.make("users.User", email=f"library-intro-{index}@example.com")
+        _grant(user, "library-authoring")
+        relation = library_version.authors if index % 2 else library_version.maintainers
+        relation.add(user)
+    four_cards, four_badge_queries = _badge_queries(
+        lambda: build_library_intro_context(library_version)
+    )
+
+    assert one_badge_query == four_badge_queries == 1
+    assert len(one_card["authors"]) == 1
+    assert len(four_cards["authors"]) == 4
+    assert {card["badge_label"] for card in four_cards["authors"]} == {"Library Author"}
+
+
+def test_library_detail_user_badge_query_is_constant(library_version, plain_user):
+    """The detail-page User origins prefetch badges before card conversion."""
+    from libraries.mixins import ContributorMixin
+
+    _grant(plain_user, "library-authoring")
+    library_version.authors.add(plain_user)
+    mixin = ContributorMixin()
+
+    def author_cards():
+        authors = mixin.get_related(library_version, "authors")
+        return [author.to_v3_profile_dict("Author") for author in authors]
+
+    one_card, one_badge_query = _badge_queries(author_cards)
+
+    for index in range(1, 4):
+        user = baker.make("users.User", email=f"library-detail-{index}@example.com")
+        _grant(user, "library-authoring")
+        library_version.authors.add(user)
+    four_cards, four_badge_queries = _badge_queries(author_cards)
+
+    assert one_badge_query == four_badge_queries == 1
+    assert len(one_card) == 1
+    assert len(four_cards) == 4
+    assert {card["badge_label"] for card in four_cards} == {"Library Author"}
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_own_profile_page_shows_hidden_badges(plain_user, tp):
+    """The owner's own v3 profile still renders badges they have hidden."""
+    _grant(plain_user, "library-authoring")
+    plain_user.hide_badges = True
+    plain_user.save(update_fields=["hide_badges"])
+
+    tp.client.force_login(plain_user)
+    response = tp.get(tp.reverse("profile-account"))
+
+    tp.response_200(response)
+    assert response.context["user_info"]["featured_badge"]["icon"] == BadgeToken.TIER_1
+    assert len(response.context["profile_badges"]) == 1
+
+
+def test_v3_profile_dict_without_badges(plain_user):
+    """A badgeless user renders no badge rather than a placeholder medal."""
+    profile = plain_user.to_v3_profile_dict()
+
+    assert profile["badge"] is None
+    assert profile["badge_label"] == ""
+
+
+def test_v3_profile_dict_carries_the_badge_label(plain_user):
+    """_user_profile.html shows the badge label on hover, so it must be set."""
+    _grant(plain_user, "library-authoring")
+    plain_user = _reload(plain_user)
+
+    profile = plain_user.to_v3_profile_dict()
+
+    assert profile["badge"] == BadgeToken.TIER_1
+    assert profile["badge_label"] == "Library Author"
+    assert "badge_url" not in profile
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_v3_news_list_renders_a_real_badge_for_the_sidebar_user(plain_user, tp):
+    """The sidebar card showed a hardcoded "Bug Catcher" label for everyone."""
+    _grant(plain_user, "library-authoring")
+    tp.client.force_login(plain_user)
+
+    response = tp.get(tp.reverse("news"))
+
+    tp.response_200(response)
+    body = response.content.decode()
+    assert "Bug Catcher" not in body
+    assert "Library Author" in body
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_v3_news_list_renders_no_badge_without_one(plain_user, tp):
+    """A badgeless user gets no badge chip rather than a placeholder label."""
+    tp.client.force_login(plain_user)
+
+    response = tp.get(tp.reverse("news"))
+
+    tp.response_200(response)
+    assert "user-card__badge" not in response.content.decode()
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_own_profile_page_renders_without_badges(plain_user, tp):
+    """The empty state must render; featured_badge is None, not a blank dict."""
+    tp.client.force_login(plain_user)
+
+    response = tp.get(tp.reverse("profile-account"))
+
+    tp.response_200(response)
+    assert response.context["user_info"]["featured_badge"] is None
+    assert response.context["profile_badges"] == []
+    assert "badges-card__empty" in response.content.decode()

--- a/badges/tests/test_seed_data.py
+++ b/badges/tests/test_seed_data.py
@@ -3,7 +3,8 @@
 ``Achievement.slug`` is an open field by design (admins may add manual-only
 types), so the slugs the codebase hard-codes are only safe if something checks
 they still exist. These tests are that check: they cover the seams between
-``badges.enums``, ``badges.seed_data`` and ``badges.sources``.
+``badges.enums``, ``badges.seed_data``, ``badges.sources`` and the map in
+``badges.display`` that turns a tier rank into a rendered asset.
 """
 
 import os
@@ -16,6 +17,7 @@ from django.db.models import Count
 from model_bakery import baker
 
 from badges import sources
+from badges.display import TIER_TOKENS
 from badges.enums import AchievementSlug, BadgeLabel, TierRank
 from badges.models import Achievement, Badge, BadgeTier
 from badges.seed_data import SEED_CATALOGUE, seed_catalogue
@@ -103,6 +105,11 @@ def test_automatic_slugs_are_derived_from_the_iterators():
     assert sources.AUTOMATIC_SLUGS == [
         slug.value for slug in sources.BACKFILL_ITERATORS
     ]
+
+
+def test_tier_token_map_covers_every_rank():
+    """A rank missing from the map would raise when a user earns that tier."""
+    assert set(TIER_TOKENS) == set(TierRank)
 
 
 @pytest.mark.django_db

--- a/core/views.py
+++ b/core/views.py
@@ -33,6 +33,7 @@ from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
 from waffle import flag_is_active
 
+from badges.display import active_badges_prefetch
 from core.templatetags.custom_static import large_static
 from config.settings import ENABLE_DB_CACHE
 from libraries.constants import LATEST_RELEASE_URL_PATH_STR
@@ -141,6 +142,18 @@ class CalendarView(V3Mixin, TemplateView):
 
 class BoostDevelopmentView(CalendarView):
     template_name = "boost_development.html"
+
+
+def build_recent_community_posts():
+    """The four recent post cards, with their authors' active badges loaded."""
+    entries = (
+        Entry.objects.published()
+        .filter(deleted_at__isnull=True)
+        .select_related("author", "author__displayed_profile_role_library")
+        .prefetch_related(active_badges_prefetch("author__badges"))
+        .order_by("-publish_at")[:4]
+    )
+    return [entry.to_v3_post_card_dict() for entry in entries]
 
 
 class CommunityView(MailingListCardMixin, V3Mixin, TemplateView):
@@ -308,14 +321,7 @@ class CommunityView(MailingListCardMixin, V3Mixin, TemplateView):
                 },
             )
         )
-        recent_entries = (
-            Entry.objects.published()
-            .filter(deleted_at__isnull=True)
-            .select_related("author", "author__displayed_profile_role_library")
-            .order_by("-publish_at")[:4]
-        )
-
-        ctx["posts"] = [entry.to_v3_post_card_dict() for entry in recent_entries]
+        ctx["posts"] = build_recent_community_posts()
         ctx["news_url"] = self.request.build_absolute_uri(reverse("news"))
         ctx["contribute_url"] = self.request.build_absolute_uri(
             "/doc/contributor-guide/contributors-faq.html"
@@ -1636,15 +1642,15 @@ class V3ComponentDemoView(V3Mixin, TemplateView):
                     "checked": True,
                 },
                 {
-                    "value": "diamond",
+                    "value": "platinum",
                     "icon": BadgeToken.TIER_4,
-                    "icon_alt": "Diamond badge",
+                    "icon_alt": "Platinum badge",
                     "checked": False,
                 },
                 {
-                    "value": "platinum",
+                    "value": "diamond",
                     "icon": BadgeToken.TIER_5,
-                    "icon_alt": "Platinum badge",
+                    "icon_alt": "Diamond badge",
                     "checked": False,
                 },
                 {
@@ -1668,13 +1674,13 @@ class V3ComponentDemoView(V3Mixin, TemplateView):
                 {
                     "value": "star-tier-4",
                     "icon": BadgeToken.STAR_TIER_4,
-                    "icon_alt": "Diamond star",
+                    "icon_alt": "Platinum star",
                     "checked": False,
                 },
                 {
                     "value": "star-tier-5",
                     "icon": BadgeToken.STAR_TIER_5,
-                    "icon_alt": "Platinum star",
+                    "icon_alt": "Diamond star",
                     "checked": False,
                 },
                 {

--- a/libraries/mixins.py
+++ b/libraries/mixins.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.html import format_html
 
+from badges.display import active_badges_prefetch
 from core.models import RenderedContent
 from libraries.constants import (
     LATEST_RELEASE_URL_PATH_STR,
@@ -283,7 +284,7 @@ class ContributorMixin:
             raise ValueError("relation must be maintainers or authors.")
         if exclude_ids:
             qs = qs.exclude(id__in=exclude_ids)
-        qs = list(qs)
+        qs = list(qs.prefetch_related(active_badges_prefetch()))
         patch_commit_authors(qs)
         return qs
 

--- a/libraries/utils.py
+++ b/libraries/utils.py
@@ -15,7 +15,7 @@ from dateutil.relativedelta import relativedelta
 
 from dateutil.parser import ParserError, parse
 from django.conf import settings
-from django.db.models import Count, F, QuerySet
+from django.db.models import Count, F, QuerySet, prefetch_related_objects
 from django.db.models.functions import Lower
 from django.urls import reverse
 from django.utils import timezone as django_timezone
@@ -606,6 +606,10 @@ def build_library_intro_context(
     maintainers = list(library_version.maintainers.exclude(id__in=author_ids))
 
     combined = (authors + maintainers)[:max_authors]
+    if combined:
+        from badges.display import active_badges_prefetch
+
+        prefetch_related_objects(combined, active_badges_prefetch())
     roles = {}
     for user in combined:
         roles[user.id] = "Author" if user.id in author_ids else "Maintainer"

--- a/news/views.py
+++ b/news/views.py
@@ -43,6 +43,7 @@ from wagtail.images.models import Image
 from wagtail.models import Page
 from waffle import flag_is_active
 
+from badges.display import active_badges_prefetch
 from core.context_processors import edit_profile_url
 from core.mixins import V3Mixin
 from pages.blocks import NEWS_BLOCK, BLOG_BLOCK, LINK_BLOCK, VIDEO_BLOCK
@@ -263,7 +264,14 @@ class EntryDetailView(V3Mixin, DetailView):
     template_name = "news/detail.html"
     v3_template_name = "news/v3/detail.html"
 
-    AUTHOR_PREFETCH = ("author__maintainers",)
+    # Each author card reads the author's badges; without the prefetch that is
+    # one extra query per card, and a detail page renders up to five. Asked for
+    # through the path, because these querysets also select_related the author -
+    # see ``badges.display.active_badges_prefetch``.
+    AUTHOR_PREFETCH = (
+        "author__maintainers",
+        active_badges_prefetch("author__badges"),
+    )
 
     def get_queryset(self):
         qs = super().get_queryset()

--- a/templates/v3/includes/_badge_v3.html
+++ b/templates/v3/includes/_badge_v3.html
@@ -7,8 +7,8 @@
     tier-1 = bronze   (entry / 2 years)
     tier-2 = silver   (5 years)
     tier-3 = gold     (10 years)
-    tier-4 = diamond  (15 years)
-    tier-5 = platinum (20+ years / top)
+    tier-4 = platinum (15 years)
+    tier-5 = diamond  (20+ years / top)
 
   Props:
     token       (required) — one of:

--- a/templates/v3/posts_list.html
+++ b/templates/v3/posts_list.html
@@ -38,7 +38,7 @@
         {% if request.user.is_authenticated %}
           {% with u=request.user %}
             {% url 'v3-news-create' as create_url %}
-            {% include 'v3/includes/_user_card.html' with username=u.display_name avatar_url=u.avatar_url badge_name='Bug Catcher' badge_icon_src=u.badge_url member_since=u.year_joined role=u.role flag_emoji=u.flag_emoji cta_url=create_url cta_label='Create Post' only %}
+            {% include 'v3/includes/_user_card.html' with username=u.display_name avatar_url=u.avatar_url badge_name=u.featured_badge.name badge=u.featured_badge.icon member_since=u.year_joined role=u.role flag_emoji=u.flag_emoji cta_url=create_url cta_label='Create Post' only %}
           {% endwith %}
         {% else %}
           {% include 'v3/includes/_user_card.html' with logged_out=True cta_url='#' cta_label='Create Post' only %}

--- a/templates/v3/user_profile_page.html
+++ b/templates/v3/user_profile_page.html
@@ -19,7 +19,7 @@
   <div class="user-profile__container">
     <div class="user-profile__profile-card-row">
       {% with user_info as user %}
-      {% include 'v3/includes/_user_card.html' with username=user.user_name avatar_url=user.avatar_url member_since=user.member_since role=user.role flag_emoji=user.flag_emoji compact=True %}
+      {% include 'v3/includes/_user_card.html' with username=user.user_name avatar_url=user.avatar_url badge_name=user.featured_badge.name badge=user.featured_badge.icon member_since=user.member_since role=user.role flag_emoji=user.flag_emoji compact=True %}
       {% endwith %}
       <div class="user-profile__button-group">
         {% for link in top_links %}
@@ -52,17 +52,21 @@
         grid has a single child for `.user-profile__col:only-child` to widen.
         An empty column would otherwise leave the bio at half width beside a
         blank gap.
+
+        The badges card renders on the member's own page even with nothing in
+        it: its empty state is what tells them badges exist and how to earn
+        them. A visitor sees the card only once there is a badge to show.
       {% endcomment %}
-      {% if achievements_data.achievements or badges or posts or account_connections_none_connected %}
+      {% if profile_is_owner or achievements_data.achievements or profile_badges or posts or account_connections_none_connected %}
       <div class="user-profile__col">
         {% if achievements_data.achievements %}
         <div class="user-profile__achievements">
           {% include "v3/includes/_achievement_card.html" with achievements=achievements_data.achievements %}
         </div>
         {% endif %}
-        {% if badges %}
+        {% if profile_is_owner or profile_badges %}
         <div class="user-profile__badges">
-          {% include "v3/includes/_badges_card.html" with cta_url="#" cta_label="Explore available badges and how to earn them" badges=badges %}
+          {% include "v3/includes/_badges_card.html" with cta_url="#" cta_label="Explore available badges and how to earn them" badges=profile_badges %}
         </div>
         {% endif %}
         {% if posts %}

--- a/users/mixins.py
+++ b/users/mixins.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlparse
 
+from badges import display as badge_display
 from core.context_processors import edit_profile_url
 
 
@@ -83,9 +84,10 @@ class V3UserProfileContextMixin:
         """Context for the read-only v3 profile view.
 
         Renders real user data. Sections with no underlying data (GitHub
-        activity, mailing list activity, posts, achievements, badges) are
-        left out of the context so the template omits them entirely. The
-        bio section is always rendered, falling back to an empty state."""
+        activity, mailing list activity, posts, achievements) are left out
+        of the context so the template omits them entirely. The bio section
+        is always rendered, falling back to an empty state."""
+        is_owner = user == self.request.user
         return {
             "user_info": {
                 "user_name": user.display_name,
@@ -95,9 +97,20 @@ class V3UserProfileContextMixin:
                 # only ever right on the owner's own view of their page.
                 # Serving it to a visitor would publish the very role the
                 # opt-out exists to withhold; they get `role`, which honours it.
-                "role": (user.public_role if user == self.request.user else user.role),
+                "role": (user.public_role if is_owner else user.role),
                 "flag_emoji": user.flag_emoji,
+                # include_hidden only for the owner, for the same reason as
+                # `role`: a member who hid their badges still sees them on
+                # their own page, and a visitor never does.
+                "featured_badge": badge_display.featured_badge(
+                    user, include_hidden=is_owner
+                ),
             },
+            "profile_badges": badge_display.badge_cards(user, include_hidden=is_owner),
+            # The recognition cards render on the owner's own page even when
+            # empty, because their empty states are the way in to the badge and
+            # achievement dialogs. A visitor sees them only with real data.
+            "profile_is_owner": is_owner,
             # Library contributions grouped by role, rendered as the
             # contributions section of the bio card. An empty dict means no
             # contributions, and the card omits the section.

--- a/users/models.py
+++ b/users/models.py
@@ -29,7 +29,6 @@ from core.validators import (
     large_file_max_size_validator,
     downscale_image_file_size_validator,
 )
-from core.templatetags.custom_static import large_static
 
 logger = logging.getLogger(__name__)
 
@@ -596,12 +595,14 @@ class User(BaseUser):
 
     def to_v3_profile_dict(self, role=None):
         """Dict shape consumed by `v3/includes/_user_profile.html`."""
+        featured = self.featured_badge
         return {
             "name": self.display_name or str(self),
             "profile_url": None,
             "role": role if role is not None else self.role,
             "avatar_url": self.get_avatar_url(),
-            "badge": None,
+            "badge": featured["icon"] if featured else None,
+            "badge_label": featured["name"] if featured else "",
             "bio": None,
         }
 
@@ -638,13 +639,17 @@ class User(BaseUser):
         return self.get_avatar_url()
 
     @cached_property
-    def badge_url(self):
-        """
-        This is a placeholder value
+    def featured_badge(self):
+        """The user's publicly visible headline badge as a dict, or ``None``.
 
-        TODO: Replace this value
+        Templates read this as an attribute, which is the only reason it lives
+        here; everything about how badges are selected and rendered is in
+        ``badges.display``. Views that need the owner's hidden badges call
+        ``badges.display`` directly with ``include_hidden``.
         """
-        return large_static("img/v3/badges/badge-gold-medal.png")
+        from badges.display import featured_badge
+
+        return featured_badge(self)
 
     def _effective_role(self, ignore_hidden=False):
         """The (role_type, library) currently displayed, or (None, None).

--- a/users/tests/test_v3_profile_public.py
+++ b/users/tests/test_v3_profile_public.py
@@ -53,15 +53,20 @@ def test_public_profile_renders_biography_as_markdown(user, tp):
 
 @waffle.testutils.override_flag("v3", active=True)
 def test_public_profile_hides_every_section_with_no_data(user, tp):
-    """A profile with no content is the bio card alone: every other section is
-    left out entirely rather than rendered as an empty shell."""
+    """A profile with no content leaves its data sections out entirely rather
+    than rendering them as empty shells.
+
+    The badges card is the documented exception on the owner's own page: its
+    empty state is how a member learns badges exist and how to earn them, so it
+    renders with no badges held - see
+    `badges.tests.test_profile.test_own_profile_page_renders_without_badges`.
+    """
     with tp.login(user):
         response = tp.get("profile-account")
     content = response.content.decode()
     assert "user-profile__bio" in content
     for section_class in (
         "user-profile__achievements",
-        "user-profile__badges",
         "user-profile__github",
         "user-profile__mailing-list",
         "user-profile__posts",


### PR DESCRIPTION
Not a duplicate, Github thought the previous one (#2614) was closed since the branches changed order in the PR stack, so I'm reopening this.

# Issue: #2558 

⚠️ Base branch is `julia/badge-selection`

## Summary & Context

The user-visible half. Real badges replace the placeholder gold medal everywhere a badge is
rendered: the profile page, the profile card, news author cards, the post list and the community
page.

`badges/display.py` is the whole presentation boundary. The v3 badge templates take a component
token and a label, never a model instance, so the rank-to-asset mapping lives there rather than on
the user model.

- **Figma link**: <!-- user_profile_page / posts_and_post_creation -->
- **Link to components/page:** 
- - [http://localhost:8000/users/me/](http://localhost:8000/users/me/) 
- - [http://localhost:8000/news/](http://localhost:8000/news/) 
- - [http://localhost:8000/community/](http://localhost:8000/community/)

## Changes

- **`badges/display.py`**
  - `held_badges` - the member's active badges, highest **rank** first, each rank once. Retiring a
    tier keeps the badges already awarded against it, so a member who also qualifies under its
    replacement holds the same rank twice; both rows are real history but only one is a badge to
    show.
  - `featured_badge` / `badge_cards` / `badge_card`.
  - `TIER_TOKENS` - bronze/silver/gold/platinum/diamond to `badge-tier-1..5`, **diamond at the
    top**. A test asserts the token numbers climb with the rank ladder so the pair cannot drift
    apart again.
  - `active_badges_prefetch(lookup)` - the prefetch every multi-card page needs.
- **`hide_badges` fails closed.** `held_badges` returns an empty list when the member has hidden
  their badges; only the owner's own views pass `include_hidden`.
- **`User.featured_badge`** replaces the `badge_url` placeholder. It lives on the model only
  because templates read it as an attribute; everything about selection and rendering is in
  `badges.display`.
- **`users/profile_cards.py`**: emits `badge` / `badge_label`. It previously emitted `badge_url`
  while `_user_profile.html` reads `author.badge`, so news author cards rendered **no badge at
  all** even once real data existed. That is a defect on `develop`, fixed here because it is the
  same feature.
- **Award dates** are `date` objects rendered through Django's `DATE_FORMAT`, taken through
  `timezone.localtime` so an evening award is not dated to the next day west of UTC. There is a
  test under `TIME_ZONE="America/New_York"` pinning it.
- **N+1 prefetches** at all four call sites that render more than one card: `ak/homepage.py`,
  `core/views.py` (community), `news/views.py` (post detail), `libraries/mixins.py` and
  `libraries/utils.py` (contributor lists). Each has a constant-query regression test. The
  querysets that `select_related` the author ask for badges **through the path**
  (`author__badges`), because `Prefetch("author", queryset=...)` is silently dropped when the FK
  is already cached.
- **Fixes an inverted tier ladder on `develop`**: `core/views.py`'s v3 examples page labelled
  tier-4 "Diamond" and tier-5 "Platinum" on both the badge and star sets. Platinum is tier 4,
  diamond is tier 5. The same inversion in the `_badge_v3.html` header comment and the
  profile-edit mock is corrected too.

## ‼️ Risks & Considerations ‼️

- **Every page that renders a user card is touched.** The risk is a missed prefetch rather than a
  wrong badge; each call site has a `django_assert_num_queries` test, so a regression fails
  loudly.
- `featured_badge` is a `cached_property`. A view that awards a badge and re-renders the same
  user instance in one request would show the stale value. Nothing does that today.
- **Which badge is "featured" is not yet the member's choice** - it is simply the highest-ranked
  one. Letting them pick is a separate ticket
  Separate ticket.
- Badge **progress and locked states** on the profile are also a separate ticket
  Separate ticket. This PR renders what a member has,
  not what they could earn.
- `templates/v3/user_profile_page.html` switches from the `demo_badges` mock to `profile_badges`.
  The `core/views.py` examples page keeps its `demo_*` fixtures, correctly.

## Screenshots
(Will add them shortly)

## Peer-review testing steps

**Setup.** `just migrate`, `docker compose up`, and turn the **v3** flag on for everyone at
`/admin/waffle/flag/` - every template here is a v3 one. For step 8 you also need `DEBUG_TOOLBAR=True`
in `.env` and a restart.

1. **Award yourself a badge by hand.** `/admin/badges/userachievement/add/` - your user, achievement
   **Library Authoring**, and a note (it is required for a manual grant). Save. Bronze is one grant, so
   `/admin/badges/userbadge/` shows **Library Author / Bronze** immediately.
2. **The profile.** `/users/me/` - the placeholder gold medal is gone and Bronze is on the card. The
   badges card lists it once, with the award date. Cross-check that date against *Awarded at* in the
   admin: they must be the same day, which is the timezone fix.
3. **Only the highest badge is featured.** Add a second Library Authoring grant (duplicate manual
   grants are intended, counts accumulate). Reload `/users/me/`: the card now shows **Silver**, while
   the badges card lists Bronze *and* Silver. The card shows one badge, the list shows the ladder.
4. **Order and grandfathering.** Grant yourself two more (four in total) so you hold Gold. The badges
   card lists Gold, Silver, Bronze in that order, highest rank first. Now raise Gold's threshold to 6 on
   `/admin/badges/badge/`: the admin says it retired the old tier and created a replacement, and your
   Gold **stays** on the profile even though you no longer meet the new number. That is the
   grandfathering working as intended, not a stale render. (One rank showing twice is the case the
   dedup in `held_badges` guards; it needs rows the admin will not create for you, so it is covered by
   test rather than by hand.)
5. **Author cards elsewhere.** With a published post authored by you, open `/news/`, the post detail
   page, `/community/` and the homepage. Your author card carries the same badge on all four. On the
   base branch the news author card renders no badge at all even with real data, so this is a fix to
   confirm, not just a check.
6. **Contributor lists.** Add yourself to **Authors** on a library's *latest* version at
   `/admin/libraries/libraryversion/` (the contributor cards read the version, not the library), then
   open `/library/<version>/<library>/`: those cards carry badges too.
7. **hide_badges fails closed.** Tick **Hide badges on your profile** at `/users/me/?edit=true`. Your
   own profile still shows them, because the owner's view passes `include_hidden`. Then open
   `/community/`, `/news/` and your post's detail page in a **logged-out** window: your card there has
   no badge at all.
8. **No N+1.** With the debug toolbar open, note the SQL count on `/community/`, `/news/` and a post
   detail page. Grant badges to several more members whose cards appear on those pages, reload, and the
   count must be unchanged. A count that climbs with the number of cards is the regression these
   prefetches exist to prevent.
9. **The ladder is the right way up.** `/v3/demo/components/` (staff only) - tier-4 is **Platinum** and
   tier-5 is **Diamond**, on both the badge set and the star set. It was inverted on the base branch.
10. **Dark mode** on every page above, then **mobile width** on the profile and the post list.
11. **No JavaScript.** Disable it and reload `/users/me/` and `/community/`: badges are server-rendered
    and must all still be there.
12. **Revocation is visible.** Revoke your **Gold** row from `/admin/badges/userbadge/` (the action asks
    for a note). `/users/me/` falls back to Silver on the card, Gold leaves the badges list, and nothing
    else moves.

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [ ] UI implementation matches Figma design
- [ ] Tested in light and dark mode
- [ ] Responsive / mobile verified
- [x] No hardcoded colors, spacing or typography - the badge component is unchanged, only its data
- [x] Test without JavaScript - badges are server-rendered
- [x] No console errors or warnings

### Backend
- [x] Every multi-card call site has a constant-query test
