### PR TITLE
Add copy button to the install card command row

### DIFF
--- a/static/css/v3/install-card.css
+++ b/static/css/v3/install-card.css
@@ -142,6 +142,32 @@
 .install-card__dropdown .dropdown__label {
   display: none;
 }
+/* Copy button: hidden by default. The per-option rules in _install_card.html's
+   generated <style> reveal the one matching the checked radio, and only once
+   install-card.js has added .js-copy-enabled — a copy button is useless
+   without JS, so it shouldn't be shown at all. */
+.install-card__copy {
+  display: none;
+}
+/* .code-block__copy pins itself absolute top/right, which lands on top of the
+   dropdown. In this card it's a flex item sitting between the command and the
+   dropdown instead, per Figma. */
+.install-card__command .install-card__copy {
+  position: static;
+  flex-shrink: 0;
+  /* Top-aligned like the dropdown, not centred: the row grows when a long
+     command wraps, and a centred icon would slide down away from the dropdown.
+     The 40px trigger centres at 20px, so a 16px icon needs 12px above it —
+     which is --space-medium, the same offset the command's first line uses. */
+  align-self: flex-start;
+  margin-block-start: var(--space-medium);
+  /* The row's gap (--space-xl) was set when it had two children. With the copy
+     button between the command and the dropdown that gap now applies twice, which
+     reads as too much space beside the dropdown. Figma specifies 9.33px here;
+     --space-default (8px) is the closest token — there is nothing between 8 and
+     12 in the scale. The command keeps its distance because it flex-grows. */
+  margin-inline-end: calc(var(--space-default) - var(--space-xl));
+}
 
 /* Tab panel switching */
 .install-card__radio--pkg:checked

--- a/static/js/code-block.js
+++ b/static/js/code-block.js
@@ -39,12 +39,13 @@
     // this: it pre-renders every option's command and hides all but the selected
     // one, so reading the first .code-block__inner would copy the wrong command
     // as soon as the user changes the dropdown. Buttons without the attribute
-    // fall back to reading the block, unchanged.
+    // fall back to reading the block, unchanged. Presence, not truthiness: an
+    // empty data-copy-text means "nothing to copy", and falling back there would
+    // silently copy the first option's command instead.
     const codeEl = block.querySelector(".code-block__inner code");
-    const text =
-      btn.dataset.copyText ||
-      (codeEl ? codeEl.textContent || codeEl.innerText : "") ||
-      "";
+    const text = btn.hasAttribute("data-copy-text")
+      ? btn.dataset.copyText
+      : (codeEl ? codeEl.textContent || codeEl.innerText : "") || "";
     if (!text) return;
 
     function showCopiedFeedback() {

--- a/static/js/code-block.js
+++ b/static/js/code-block.js
@@ -35,9 +35,17 @@
     const btn = ev.currentTarget;
     const block = btn.closest(".code-block");
     if (!block) return;
+    // A button may carry its own text via data-copy-text. The install card needs
+    // this: it pre-renders every option's command and hides all but the selected
+    // one, so reading the first .code-block__inner would copy the wrong command
+    // as soon as the user changes the dropdown. Buttons without the attribute
+    // fall back to reading the block, unchanged.
     const codeEl = block.querySelector(".code-block__inner code");
-    if (!codeEl) return;
-    const text = codeEl.textContent || codeEl.innerText || "";
+    const text =
+      btn.dataset.copyText ||
+      (codeEl ? codeEl.textContent || codeEl.innerText : "") ||
+      "";
+    if (!text) return;
 
     function showCopiedFeedback() {
       setCopiedState(btn, "true");

--- a/static/js/install-card.js
+++ b/static/js/install-card.js
@@ -10,6 +10,16 @@
  * Supports multiple install cards on the same page via querySelectorAll.
  */
 document.addEventListener("DOMContentLoaded", function () {
+  // Reveal the copy buttons only when JS is available to serve them. The CSS
+  // keeps .install-card__copy hidden until this class is present, so a no-JS
+  // visitor never sees a copy icon that cannot work. Same approach as
+  // _downloads_table_card.html.
+  document
+    .querySelectorAll("[data-install-card-wrapper]")
+    .forEach(function (wrapper) {
+      wrapper.classList.add("js-copy-enabled");
+    });
+
   document.querySelectorAll("[data-install-card]").forEach(function (card) {
     initInstallCard(card);
   });

--- a/templates/v3/includes/_install_card.html
+++ b/templates/v3/includes/_install_card.html
@@ -65,6 +65,11 @@
   </div>
 </section>
 {# Per-option visibility rules (generated from data, complements static rules in install-card.css) #}
+{% comment %}
+  Copy buttons match on data-copy-option, not data-option: the bare
+  [data-option] rule below would otherwise match them too, showing the button
+  with display:block and bypassing the .js-copy-enabled gate.
+{% endcomment %}
 <style>
   {% for opt in install_card_pkg_managers %}
     /* Showing the matching command */
@@ -84,6 +89,9 @@
     #{{ card_id }}-pkg-{{ opt.value }}:checked ~ .code-block .dropdown__item[for="{{ card_id }}-pkg-{{ opt.value }}"]:hover {
       color: var(--color-text-link-accent);
   }
+    .js-copy-enabled #{{ card_id }}-pkg-{{ opt.value }}:checked ~ .code-block .install-card__copy[data-copy-option="{{ card_id }}-pkg-{{ opt.value }}"] {
+      display: flex;
+    }
   {% endfor %}
 
   {% for opt in install_card_system_install %}
@@ -103,6 +111,9 @@
     }
     #{{ card_id }}-sys-{{ opt.value }}:checked ~ .code-block .dropdown__item[for="{{ card_id }}-sys-{{ opt.value }}"]:hover {
       color: var(--color-text-link-accent);
+    }
+    .js-copy-enabled #{{ card_id }}-sys-{{ opt.value }}:checked ~ .code-block .install-card__copy[data-copy-option="{{ card_id }}-sys-{{ opt.value }}"] {
+      display: flex;
     }
   {% endfor %}
 </style>

--- a/templates/v3/includes/_install_card_tab_content_body.html
+++ b/templates/v3/includes/_install_card_tab_content_body.html
@@ -39,6 +39,24 @@
        data-option="{{ card_id }}-{{ prefix }}-{{ opt.value }}"><code class="nohighlight">{{ opt.command }}</code></pre>
   {% endfor %}
 
+  {% comment %}
+    Copy buttons — one per option, each carrying its own command text so the
+    shared code-block.js handler never has to work out which <pre> is visible.
+    Revealed by the same radio-driven rules that reveal the matching command,
+    and only once install-card.js has added js-copy-enabled to the wrapper.
+  {% endcomment %}
+  {% for opt in options %}
+  <button type="button"
+          class="code-block__copy install-card__copy"
+          data-copy-option="{{ card_id }}-{{ prefix }}-{{ opt.value }}"
+          data-copy-text="{{ opt.command }}"
+          data-copied="false"
+          aria-label="Copy command to clipboard">
+    <span class="code-block__copy-icon code-block__copy-icon--copy" aria-hidden="true">{% include "includes/icon.html" with icon_name="copy" icon_class="code-block__copy-svg" icon_size=16 icon_viewbox="0 0 16 16" %}</span>
+    <span class="code-block__copy-icon code-block__copy-icon--check" aria-hidden="true">{% include "includes/icon.html" with icon_name="check" icon_class="code-block__copy-svg" icon_size=16 %}</span>
+  </button>
+  {% endfor %}
+
   {# Dropdown #}
   <details class="dropdown install-card__dropdown">
     <summary class="dropdown__trigger"


### PR DESCRIPTION
# Issue: #2333

## Summary & Context

Adds the copy button to the Install Card's command row. Figma has it between the command text and the method dropdown; the implementation had no button at all, so the command had to be selected by hand.

- **Figma link**: [Website Deliverables, node `1245-11757`](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1245-11757&t=KYEdqRilBbKZ8Q3G-4)
- **Link to components/page:** `localhost:8000/` (hero card) and `localhost:8000/community/` (in the page body, and the one visible at mobile widths)

## Changes

- **`_install_card_tab_content_body.html`** — one copy button per option inside the existing `.code-block`, between the commands and the dropdown. Each carries its own command in `data-copy-text`. Icon markup matches `_code_block.html`.
- **`_install_card.html`** — the generated `<style>` gains one rule per option to reveal the matching button, next to the rules that already reveal the matching command and label.
- **`install-card.css`** — hides the button by default and makes it a flex item between the command and the dropdown. `.code-block__copy` positions itself absolute top/right, which would land it on the dropdown.
- **`code-block.js`** — the click handler prefers `btn.dataset.copyText` when present, falling back to reading the block as before.
- **`install-card.js`** — adds `js-copy-enabled` to each card wrapper on init, so the button only appears when JS is there to serve it. Same approach as `_downloads_table_card.html`.

No new colour, spacing or typography values. The icon colour comes from `--color-icon-secondary`, already `#71737B` light and `#CACBCE` dark.

## ‼️ Risks & Considerations ‼️

**`code-block.js` is shared** with docs-page code blocks, `_code_block_card.html` and `_code_blocks_story.html`. The change is additive, so buttons without `data-copy-text` take the existing path unchanged, but it's worth one regression click on a docs code block.

**One button per option, not one per card.** The card pre-renders every command and hides all but the selected one, so a single button reading the first `.code-block__inner` would copy the wrong command after any dropdown change. The first option is `checked` by default, so that bug looks completely fine on load and only shows up once someone uses the dropdown.

**`data-copy-option`, not `data-option`.** The bare `[data-option="…"]` rule already in the generated `<style>` would match a copy button sharing that attribute, showing it with `display: block` and skipping the `.js-copy-enabled` gate.

**Reset `aria-label` wording.** `setCopiedState` in the shared `code-block.js` hardcodes "Copy code to clipboard", so after the first copy this button says "code" rather than "command". Flagging rather than fixing, since parameterising it widens the diff on a shared file. Happy to change it if you'd rather.

## Screenshots

Before | After
-- | --
<img width="480" alt="before" src="https://github.com/user-attachments/assets/27491b66-826b-41bb-a769-e5c5d9dbdc19"> | <img width="480" alt="after" src="https://github.com/user-attachments/assets/fe376e15-daa1-49aa-9011-f96b88a7dc19">

Desktop Light Mode | Desktop Dark Mode | Mobile
-- | -- | --
<img width="320" alt="desktop light" src="https://github.com/user-attachments/assets/fe376e15-daa1-49aa-9011-f96b88a7dc19"> | <img width="320" alt="desktop dark" src="https://github.com/user-attachments/assets/06ac1d31-1de4-4cd3-9727-420a915eed06"> | <img width="320" alt="mobile" src="https://github.com/user-attachments/assets/917d1758-3b4d-455a-a461-d884e37ed506">

Long command wrapping, with the icon staying level with the dropdown instead of sliding down as the row grows:

<img width="640" alt="long command" src="https://github.com/user-attachments/assets/072b6afa-2399-45c3-abb7-59919b7cbaaf">

<sub>The clipping in the mobile shot is pre-existing: the community page already overflows horizontally at 430px, and the right edge measures the same with and without this branch.</sub>

## Peer-review testing steps

1. Enable the `v3` waffle flag and open `/`.
2. Open the `Conan ▾` dropdown, pick a different option, then copy and paste. You should get the selected command. This is the one that fails if the handler reads the first command rather than the button's own text.
3. Repeat on the **System Install** tab, which is a separate code block with its own buttons.
4. Check the icon flips to a check and reverts after ~2s.
5. `/community/` — same card, different `card_id`, and the one that stays visible at mobile widths (the hero card is hidden below 1280px).
6. Keyboard: Tab to the button, then Enter and Space.
7. Disable JavaScript and confirm the button is absent rather than present-and-dead.
8. Regression: copy from any docs-page code block.

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy buttons to installation command cards for each available package manager or system option.
  * Copy controls appear only when JavaScript is available and the corresponding option is selected.
  * Added visual feedback through copy and confirmation icons.

* **Bug Fixes**
  * Improved copy behavior so explicitly provided command text is used correctly, including empty values.
  * Prevented empty commands from triggering clipboard actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->