### PR TITLE
Fix clipped descenders in testimonial quotes

### DIFF
--- a/static/css/v3/testimonial-card.css
+++ b/static/css/v3/testimonial-card.css
@@ -45,7 +45,10 @@
     font-family: var(--font-sans);
     font-size: var(--font-size-xl);
     font-weight: var(--font-weight-regular);
-    line-height: var(--line-height-tight);
+    /* Figma says 100%, but at that size the clamp below slices the descenders
+       (#2520). 1.2 is the tightest step that clears them. Revisit if the
+       clamp goes. */
+    line-height: var(--line-height-default);
     letter-spacing: var(--letter-spacing-tight);
 
     /* 3-line clamp with ellipsis. */


### PR DESCRIPTION
# Issue: #2520

## Summary & Context

The testimonial quote sets `line-height: 1`, which is shorter than the line box Mona Sans VF needs, so the 3-line clamp slices the descenders off `y`, `g`, `p` and `q` on the last line. `--line-height-default` (1.2) gives them room.

- **Figma link**: the quote is specified `32px / 100%`. This deviates, see below.
- **Link to components/page:** `localhost:8000/` (the "What engineers are saying" card)

## Changes

- **`testimonial-card.css`**: `.testimonial-card__text` uses `var(--line-height-default)` instead of `var(--line-height-tight)`. No template, JS or token changes.

## ‼️ Risks & Considerations ‼️

**This deviates from Figma knowingly.** The spec is `32px / 100%`, so the current code is faithful to it. It works in Figma because the text frame grows to fit: the design's box is `392 x 160`, five lines at 32px, unclamped. We clamp to three and hide the rest, and `overflow: hidden` then cuts the descenders that a 100% line box leaves outside it. The spec cannot be honoured as written once a clamp is involved.

**If the clamp moved or went away, this file would not need touching.** That is a design call worth making before merge. 1.2 is the smallest change that fixes what QA filed: I checked each step of the scale against the clip edge at 6x, and it is the tightest that clears the descenders at both 32px and 24px.

**Padding does not work.** Line 3's descenders and line 4's ascenders occupy the same band, so widening the box reveals line 4 instead of just the descenders.

**The card gets taller**, 160px to 179px desktop and 112px to 126px mobile. `line-height` sets the whole line box and the extra space splits half above and half below, so descender room and looser spacing are the same knob. Still 3 lines and an ellipsis, never 4.

## Screenshots

Before | After
-- | --
<img width="480" alt="before" src="https://github.com/user-attachments/assets/ba5eb6e4-98cc-44e0-8016-aebe273e9bf1"> | <img width="480" alt="after" src="https://github.com/user-attachments/assets/44f7d22c-d767-4248-9257-518483fb7dcf">

<sub>Look at "expectations about quality and security": the `p`, `q` and `y` are flat-bottomed before, whole after.</sub>

Desktop Light Mode | Desktop Dark Mode | Mobile
-- | -- | --
<img width="320" alt="desktop light" src="https://github.com/user-attachments/assets/44f7d22c-d767-4248-9257-518483fb7dcf"> | <img width="320" alt="desktop dark" src="https://github.com/user-attachments/assets/bd194d3f-dcd7-4b8f-900f-9d41d8d67f0b"> | <img width="320" alt="mobile" src="https://github.com/user-attachments/assets/2f035325-562b-433f-9b8d-3ed7421e820a">

## Peer-review testing steps

1. Enable the `v3` waffle flag and open `/`.
2. Check `y`, `g`, `p` and `q` on the last line are whole rather than flat-bottomed.
3. Confirm it is still 3 lines with an ellipsis, and no sliver of a fourth shows below.
4. Repeat at 430px, and in dark mode.

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [ ] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings

<sub>Figma unticked deliberately, per the deviation above. Console is unchanged from develop: a Plausible "Ignoring Event: localhost" warning and a 404 for `moose-deadline.png` from the untouched `_event_card.html`.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved testimonial quote text spacing to prevent descenders from being clipped when displayed across three lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->