### PR TITLE
Story 2584: Webpage Integration Account Connection Card

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -75,6 +75,7 @@ from users.views import (
     DeleteUserView,
     CancelDeletionView,
     DeleteImmediatelyView,
+    DisconnectSocialAccountView,
 )
 from versions.api import ImportVersionsView, VersionViewSet
 from versions.converters import BoostVersionSlugConverter
@@ -153,6 +154,11 @@ urlpatterns = (
         path("accounts/", include("allauth.urls")),
         path("users/me/", CurrentUserProfileView.as_view(), name="profile-account"),
         path("users/me/delete/", DeleteUserView.as_view(), name="profile-delete"),
+        path(
+            "users/me/disconnect-social/<str:platform>/",
+            DisconnectSocialAccountView.as_view(),
+            name="profile-disconnect-social",
+        ),
         path(
             "users/me/cancel-delete/",
             CancelDeletionView.as_view(),

--- a/templates/v3/includes/_account_connections_card.html
+++ b/templates/v3/includes/_account_connections_card.html
@@ -5,12 +5,13 @@
   Variables:
     heading       (str, optional)  — card heading, default "Account connections"
     connections   (list of dict)   — connection items, each with:
-      .platform       (str)  — icon key: "github" or "google"
-      .label          (str)  — display name, e.g. "GitHub"
-      .connected      (bool) — whether the account is linked
-      .status_text    (str)  — status label, e.g. "Connected" or "Not connected"
-      .action_label   (str)  — button text, e.g. "Manage" or "Connect"
-      .action_url     (str)  — button destination URL
+      .platform         (str)  — icon key: "github" or "google"
+      .label            (str)  — display name, e.g. "GitHub"
+      .connected        (bool) — whether the account is linked
+      .status_text      (str)  — status label, e.g. "Connected" or "Not connected"
+      .action_label     (str)  — button text, e.g. "Manage" or "Connect"
+      .action_url       (str)  — button destination URL
+      .disconnect_text  (str)  — text displayed in the disconnect modal
 
   Usage:
     {% include "v3/includes/_account_connections_card.html" with heading="Account connections" connections=account_connections %}
@@ -34,3 +35,11 @@
     {% endfor %}
   </ul>
 </div>
+
+{% for conn in connections %}
+  {% url 'profile-disconnect-social' platform=conn.platform as disconnect_url %}
+  <form action="{{disconnect_url|add:"?redirect_url='/users/me/?edit=True'"}}" method="POST">
+    {% csrf_token %}
+    {% include 'v3/includes/_dialog.html' with dialog_id="disconnect-"|add:conn.platform title="Disconnect "|add:conn.label|add:" ?" description=conn.disconnect_text primary_style="error" primary_label="Disconnect" secondary_label="Cancel" submit=True only %}
+  </form>
+{% endfor %}

--- a/templates/v3/includes/_account_connections_card.html
+++ b/templates/v3/includes/_account_connections_card.html
@@ -37,8 +37,7 @@
 </div>
 
 {% for conn in connections %}
-  {% url 'profile-disconnect-social' platform=conn.platform as disconnect_url %}
-  <form action="{{disconnect_url|add:"?redirect_url='/users/me/?edit=True'"}}" method="POST">
+  <form action="{{conn.disconnect_url}}" method="POST">
     {% csrf_token %}
     {% include 'v3/includes/_dialog.html' with dialog_id="disconnect-"|add:conn.platform title="Disconnect "|add:conn.label|add:"?" description=conn.disconnect_text primary_style="error" primary_label="Disconnect" secondary_label="Cancel" submit=True only %}
   </form>

--- a/templates/v3/includes/_account_connections_card.html
+++ b/templates/v3/includes/_account_connections_card.html
@@ -40,6 +40,6 @@
   {% url 'profile-disconnect-social' platform=conn.platform as disconnect_url %}
   <form action="{{disconnect_url|add:"?redirect_url='/users/me/?edit=True'"}}" method="POST">
     {% csrf_token %}
-    {% include 'v3/includes/_dialog.html' with dialog_id="disconnect-"|add:conn.platform title="Disconnect "|add:conn.label|add:" ?" description=conn.disconnect_text primary_style="error" primary_label="Disconnect" secondary_label="Cancel" submit=True only %}
+    {% include 'v3/includes/_dialog.html' with dialog_id="disconnect-"|add:conn.platform title="Disconnect "|add:conn.label|add:"?" description=conn.disconnect_text primary_style="error" primary_label="Disconnect" secondary_label="Cancel" submit=True only %}
   </form>
 {% endfor %}

--- a/templates/v3/includes/_dialog.html
+++ b/templates/v3/includes/_dialog.html
@@ -16,6 +16,7 @@
     submit          (optional): Renders primary button as a "submit", to allow dialog to be part of a form
     primary_url     (optional): URL for primary button. Defaults to "" (renders as <button>).
     secondary_url   (optional): URL for secondary button. Defaults to "#" (closes the dialog).
+    submit          (optional): If this value is True, the primary button will be type submit.
 
   Accessibility:
     - role="dialog", aria-modal="true", aria-labelledby / aria-describedby

--- a/templates/v3/user_profile_edit.html
+++ b/templates/v3/user_profile_edit.html
@@ -240,7 +240,7 @@ flushed rather than leaking onto the next page. {% endcomment %}
           </form>
         </div>
         <div class="user-profile-edit__connections-card">
-          {% include 'v3/includes/_account_connections_card.html' with connections=account_connections_mixed %}
+          {% include 'v3/includes/_account_connections_card.html' with connections=account_connections %}
         </div>
         <div class="basic-card card user-profile__delete-account">
           <div class="card__header">

--- a/templates/v3/user_profile_edit.html
+++ b/templates/v3/user_profile_edit.html
@@ -13,14 +13,6 @@
   <script type="module" src="{% static 'js/v3/wysiwyg-editor.js' %}"></script>
 {% endblock %}
 
-{% comment %} Section save state is shown on each submit button (see saved_sections)
-instead of the legacy toast; still iterate `messages` so any queued message is
-flushed rather than leaking onto the next page. {% endcomment %}
-{% block messages %}
-  <div id="messages" class="w-full text-center transition-opacity" x-data="{show: true}">
-    {% for message in messages %}{% endfor %}
-  </div>
-{% endblock messages %}
 
 {% block content %}
   <div class="user-profile__container">

--- a/users/models.py
+++ b/users/models.py
@@ -3,6 +3,7 @@ import logging
 from contextlib import suppress
 
 import requests
+from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
 from django.contrib.auth.models import (
     AbstractBaseUser,
@@ -608,6 +609,14 @@ class User(BaseUser):
         if not self.github_username:
             return None
         return f"https://github.com/{self.github_username}"
+
+    @property
+    def is_github_connected(self):
+        return SocialAccount.objects.filter(user=self, provider="github").exists()
+
+    @property
+    def is_google_connected(self):
+        return SocialAccount.objects.filter(user=self, provider="google").exists()
 
     @cached_property
     def name(self):

--- a/users/views.py
+++ b/users/views.py
@@ -9,6 +9,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import auth
 from django.contrib.messages.views import SuccessMessageMixin
 from django.http import HttpResponseRedirect, JsonResponse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.urls import reverse, reverse_lazy
 from django.views.generic import DetailView, FormView, View
 from django.views.generic.base import TemplateView
@@ -927,6 +928,12 @@ class DeleteImmediatelyView(LoginRequiredMixin, SuccessMessageMixin, FormView):
 class DisconnectSocialAccountView(LoginRequiredMixin, View):
     def post(self, *args, **kwargs):
         redirect_url = self.request.GET.get("redirect_url", "").strip("'")
+        if not url_has_allowed_host_and_scheme(redirect_url, allowed_hosts=None):
+            messages.error(
+                self.request, "An internal error has occurred. Please contact an admin."
+            )
+            return HttpResponseRedirect(reverse("home"))
+
         platform = kwargs.get("platform")
         if not platform:
             messages.error(self.request, "Platform must be specified.")

--- a/users/views.py
+++ b/users/views.py
@@ -2,6 +2,7 @@ import datetime
 
 from allauth.account import app_settings
 from allauth.socialaccount.adapter import get_adapter, DefaultSocialAccountAdapter
+from allauth.socialaccount.forms import DisconnectForm
 from allauth.socialaccount.models import SocialApp
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -253,12 +254,14 @@ class CurrentUserProfileView(
                 "label": label,
                 "status_text": "Connected" if connected else "Not Connected",
                 "action_label": "Manage" if connected else "Connect",
+                "connected": connected,
                 # If not connected, we provide the login url for the chosen platform
                 # else, this points to the name of the disconnect modal associated with this platform
                 "action_url": (
                     provider.get_login_url(
                         self.request,
                         **{auth.REDIRECT_FIELD_NAME: self.request.get_full_path()},
+                        process="connect",
                     )
                     if not connected
                     else f"#disconnect-{platform}"
@@ -923,11 +926,12 @@ class DeleteImmediatelyView(LoginRequiredMixin, SuccessMessageMixin, FormView):
 
 class DisconnectSocialAccountView(LoginRequiredMixin, View):
     def post(self, *args, **kwargs):
+        redirect_url = self.request.GET.get("redirect_url", "").strip("'")
         platform = kwargs.get("platform")
         if not platform:
-            raise ValueError("Platform must be specified.")
+            messages.error(self.request, "Platform must be specified.")
+            return HttpResponseRedirect(redirect_url)
 
-        redirect_url = self.request.GET.get("redirect_url", "").strip("'")
         if not redirect_url:
             redirect_url = reverse("home")
 
@@ -935,10 +939,20 @@ class DisconnectSocialAccountView(LoginRequiredMixin, View):
         try:
             sa = SocialAccount.objects.get(user=user, provider=platform)
         except SocialAccount.DoesNotExist:
-            raise ValueError(
-                "No social account between this user and platform exists on Boost."
+            messages.error(
+                self.request,
+                "No social account between this user and platform exists on Boost.",
             )
-        sa.delete()
-        print(self.request.build_absolute_uri(redirect_url))
+            return HttpResponseRedirect(redirect_url)
+
+        form = DisconnectForm(request=self.request, data={"account": sa.pk})
+        if form.is_valid():
+            form.save()
+        else:
+            messages.error(
+                self.request,
+                " ".join(form.non_field_errors())
+                or "An error has occurred while removing your connection. Please try again shortly.",
+            )
 
         return HttpResponseRedirect(redirect_url)

--- a/users/views.py
+++ b/users/views.py
@@ -257,7 +257,8 @@ class CurrentUserProfileView(
                 # else, this points to the name of the disconnect modal associated with this platform
                 "action_url": (
                     provider.get_login_url(
-                        {auth.REDIRECT_FIELD_NAME: self.request.get_full_path()}
+                        self.request,
+                        **{auth.REDIRECT_FIELD_NAME: self.request.get_full_path()},
                     )
                     if not connected
                     else f"#disconnect-{platform}"
@@ -926,7 +927,7 @@ class DisconnectSocialAccountView(LoginRequiredMixin, View):
         if not platform:
             raise ValueError("Platform must be specified.")
 
-        redirect_url = self.request.GET.get("redirect_url").strip("'")
+        redirect_url = self.request.GET.get("redirect_url", "").strip("'")
         if not redirect_url:
             redirect_url = reverse("home")
 

--- a/users/views.py
+++ b/users/views.py
@@ -2,6 +2,7 @@ import datetime
 
 from allauth.account import app_settings
 from allauth.socialaccount.adapter import get_adapter, DefaultSocialAccountAdapter
+from allauth.socialaccount.models import SocialApp
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import auth
@@ -234,10 +235,14 @@ class CurrentUserProfileView(
         is_gh_conn: bool = user.is_github_connected
         is_go_conn: bool = user.is_google_connected
 
-        def _get_connection_context_data(platform: str, connected: bool) -> dict:
+        def _get_connection_context_data(platform: str, connected: bool) -> dict | None:
             adapter: DefaultSocialAccountAdapter = get_adapter(self.request)
+            try:
+                provider = adapter.get_provider(self.request, platform)
+            except SocialApp.DoesNotExist:
+                return None
             if platform not in ["github", "google"]:
-                return {}
+                return None
             label = ""
             if platform == "github":
                 label = "GitHub"
@@ -251,7 +256,7 @@ class CurrentUserProfileView(
                 # If not connected, we provide the login url for the chosen platform
                 # else, this points to the name of the disconnect modal associated with this platform
                 "action_url": (
-                    adapter.get_provider(self.request, platform).get_login_url(
+                    provider.get_login_url(
                         {auth.REDIRECT_FIELD_NAME: self.request.get_full_path()}
                     )
                     if not connected
@@ -290,10 +295,7 @@ class CurrentUserProfileView(
                 {"tier": "4", "name": "Platinum"},
                 {"tier": "5", "name": "Diamond"},
             ],
-            "account_connections": [
-                _get_connection_context_data("github", is_gh_conn),
-                _get_connection_context_data("google", is_go_conn),
-            ],
+            "account_connections": [],
         }
         # Delete-account card: the modal schedules deletion, and once
         # scheduled the card swaps to a single "Cancel deletion" control.
@@ -311,6 +313,13 @@ class CurrentUserProfileView(
         )
         ctx["profile_delete_url"] = reverse("profile-delete")
         ctx["postorius_url"] = settings.POSTORIUS_URL
+
+        gh_conn_data = _get_connection_context_data("github", is_gh_conn)
+        go_conn_data = _get_connection_context_data("google", is_go_conn)
+        if gh_conn_data:
+            ctx["account_connections"].append(gh_conn_data)
+        if go_conn_data:
+            ctx["account_connections"].append(go_conn_data)
         return ctx
 
     def get_v3_context_data(self, **kwargs):
@@ -357,7 +366,10 @@ class CurrentUserProfileView(
     def get_social_accounts(self):
         account_data = []
         for account in SocialAccount.objects.filter(user=self.request.user):
-            provider_account = account.get_provider_account()
+            try:
+                provider_account = account.get_provider_account()
+            except SocialApp.DoesNotExist:
+                continue
             account_data.append(
                 {
                     "id": account.pk,

--- a/users/views.py
+++ b/users/views.py
@@ -1,13 +1,14 @@
 import datetime
 
 from allauth.account import app_settings
+from allauth.socialaccount.adapter import get_adapter, DefaultSocialAccountAdapter
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import auth
 from django.contrib.messages.views import SuccessMessageMixin
 from django.http import HttpResponseRedirect, JsonResponse
 from django.urls import reverse, reverse_lazy
-from django.views.generic import DetailView, FormView
+from django.views.generic import DetailView, FormView, View
 from django.views.generic.base import TemplateView
 from django.utils import timezone
 from django.conf import settings
@@ -230,6 +231,35 @@ class CurrentUserProfileView(
             )
         saved_section = self.request.GET.get("saved")
         user = self.request.user
+        is_gh_conn: bool = user.is_github_connected
+        is_go_conn: bool = user.is_google_connected
+
+        def _get_connection_context_data(platform: str, connected: bool) -> dict:
+            adapter: DefaultSocialAccountAdapter = get_adapter(self.request)
+            if platform not in ["github", "google"]:
+                return {}
+            label = ""
+            if platform == "github":
+                label = "GitHub"
+            else:
+                label = platform.capitalize()
+            return {
+                "platform": platform,
+                "label": label,
+                "status_text": "Connected" if connected else "Not Connected",
+                "action_label": "Manage" if connected else "Connect",
+                # If not connected, we provide the login url for the chosen platform
+                # else, this points to the name of the disconnect modal associated with this platform
+                "action_url": (
+                    adapter.get_provider(self.request, platform).get_login_url(
+                        {auth.REDIRECT_FIELD_NAME: self.request.get_full_path()}
+                    )
+                    if not connected
+                    else f"#disconnect-{platform}"
+                ),
+                "disconnect_text": f"This will remove the link between your Boost account and {label}. You can reconnect at any time.",
+            }
+
         ctx = {
             "user_profile_form": form,
             "SLACK_PROFILE_URL_PREFIX": SLACK_PROFILE_URL_PREFIX,
@@ -260,23 +290,9 @@ class CurrentUserProfileView(
                 {"tier": "4", "name": "Platinum"},
                 {"tier": "5", "name": "Diamond"},
             ],
-            "account_connections_mixed": [
-                {
-                    "platform": "github",
-                    "label": "GitHub",
-                    "connected": True,
-                    "status_text": "Connected",
-                    "action_label": "Manage",
-                    "action_url": "#",
-                },
-                {
-                    "platform": "google",
-                    "label": "Google",
-                    "connected": False,
-                    "status_text": "Not connected",
-                    "action_label": "Connect",
-                    "action_url": "#",
-                },
+            "account_connections": [
+                _get_connection_context_data("github", is_gh_conn),
+                _get_connection_context_data("google", is_go_conn),
             ],
         }
         # Delete-account card: the modal schedules deletion, and once
@@ -890,3 +906,26 @@ class DeleteImmediatelyView(LoginRequiredMixin, SuccessMessageMixin, FormView):
         user.delete_account(extended_scrub=flag_is_active(self.request, "v3"))
         auth.logout(self.request)
         return super().form_valid(form)
+
+
+class DisconnectSocialAccountView(LoginRequiredMixin, View):
+    def post(self, *args, **kwargs):
+        platform = kwargs.get("platform")
+        if not platform:
+            raise ValueError("Platform must be specified.")
+
+        redirect_url = self.request.GET.get("redirect_url").strip("'")
+        if not redirect_url:
+            redirect_url = reverse("home")
+
+        user = self.request.user
+        try:
+            sa = SocialAccount.objects.get(user=user, provider=platform)
+        except SocialAccount.DoesNotExist:
+            raise ValueError(
+                "No social account between this user and platform exists on Boost."
+            )
+        sa.delete()
+        print(self.request.build_absolute_uri(redirect_url))
+
+        return HttpResponseRedirect(redirect_url)

--- a/users/views.py
+++ b/users/views.py
@@ -268,6 +268,7 @@ class CurrentUserProfileView(
                     else f"#disconnect-{platform}"
                 ),
                 "disconnect_text": f"This will remove the link between your Boost account and {label}. You can reconnect at any time.",
+                "disconnect_url": f"{reverse('profile-disconnect-social', kwargs={"platform": platform})}?redirect_url={reverse("profile-account")}?edit=True",
             }
 
         ctx = {
@@ -927,7 +928,9 @@ class DeleteImmediatelyView(LoginRequiredMixin, SuccessMessageMixin, FormView):
 
 class DisconnectSocialAccountView(LoginRequiredMixin, View):
     def post(self, *args, **kwargs):
-        redirect_url = self.request.GET.get("redirect_url", "").strip("'")
+        redirect_url = self.request.GET.get("redirect_url", "").strip("'") or reverse(
+            "home"
+        )
         if not url_has_allowed_host_and_scheme(redirect_url, allowed_hosts=None):
             messages.error(
                 self.request, "An internal error has occurred. Please contact an admin."
@@ -938,9 +941,6 @@ class DisconnectSocialAccountView(LoginRequiredMixin, View):
         if not platform:
             messages.error(self.request, "Platform must be specified.")
             return HttpResponseRedirect(redirect_url)
-
-        if not redirect_url:
-            redirect_url = reverse("home")
 
         user = self.request.user
         try:


### PR DESCRIPTION
# Issue: #2584 

## Summary & Context
Adds functional requirements to the account connections card for use on the user profile edit page. Automatically 

- **Figma link**: <!-- Add link to relevant Figma design here --> https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=7489-30378&m=dev
- **Link to components/page:** <!-- e.g. localhost:8000/news/add --> localhost:8000/users/me/?edit=True

## Changes

- Linked existence of Social Accounts to display properties of the Account Connections Card
- Added link functionality from django-allauth to Account Connections Card
- Add new view to allow for removal of social account links

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*
* It is not currently possible to test linking a social account on the local development environment, as the OAuth cannot be linked to localhost, so that functionality can only be tested by QA. 
* For local testing of the disconnect/card states, an existing social Account can be linked to the developers user account in the Django admin

## Screenshots

<!-- Before | After
-- | -- -->

<!-- Desktop Light Mode | Desktop Dark Mode | Mobile
-- | -- | -- -->

Fill States

No accounts:
<img width="688" height="178" alt="image" src="https://github.com/user-attachments/assets/73ee55cc-a83c-4c2a-a173-409153f7d15b" />

Only Github:
<img width="688" height="178" alt="image" src="https://github.com/user-attachments/assets/87ca3f8a-5678-404e-a752-8614a1f30ad6" />

Both:
<img width="688" height="178" alt="image" src="https://github.com/user-attachments/assets/42721cd4-fdcc-4bae-b680-c49f5767b5fa" />

Removal Modal:
<img width="705" height="184" alt="image" src="https://github.com/user-attachments/assets/d8839a1a-1844-4949-9ab8-e243e30e8c6d" />



## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to connect or disconnect GitHub and Google accounts from profile settings.
  * Connection statuses now update dynamically, showing available actions for each provider.
  * Added confirmation dialogs before disconnecting an account.
  * Preserved the option to return to the previous page after managing a connection.
  * Providers that are unavailable are no longer displayed as connection options.
  * Added clear feedback when an account cannot be disconnected or a request contains errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->