### PR TITLE
Story #2638 :: Missing profile image file causes a 500 on every page that renders an avatar (locally)

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -391,8 +391,8 @@ class User(BaseUser):
 
     def get_hq_image_url(self):
         # convenience method for templates
-        if self.hq_image and self.hq_image_render:
-            with suppress(AttributeError, MissingSource, FileNotFoundError, OSError):
+        with suppress(AttributeError, MissingSource, FileNotFoundError, OSError):
+            if self.hq_image and self.hq_image_render:
                 return getattr(self.hq_image_render, "url", None)
 
     @property

--- a/users/models.py
+++ b/users/models.py
@@ -358,8 +358,8 @@ class User(BaseUser):
 
     def get_thumbnail_url(self):
         # convenience method for templates
-        if self.profile_image and self.image_thumbnail:
-            with suppress(AttributeError, MissingSource, FileNotFoundError, OSError):
+        with suppress(AttributeError, MissingSource, FileNotFoundError, OSError):
+            if self.profile_image and self.image_thumbnail:
                 return getattr(self.image_thumbnail, "url", None)
 
     def get_avatar_url(self):

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -1,5 +1,7 @@
+import io
 from pathlib import Path
 
+from PIL import Image
 import pytest
 
 from django.contrib.auth import get_user_model
@@ -10,6 +12,15 @@ from pytest_django.asserts import assertQuerySetEqual
 from ..models import Preferences
 
 User = get_user_model()
+
+
+def _png_upload(filename):
+    """In-memory PNG, matching the shape the user fixtures upload."""
+    file = io.BytesIO()
+    file.name = filename
+    Image.new("RGBA", size=(100, 100), color=(155, 0, 0)).save(file, "png")
+    file.seek(0)
+    return file
 
 
 def test_regular_user(user):
@@ -102,6 +113,27 @@ def test_get_avatar_url_falls_back_when_file_missing(user):
     user.delete_cached_thumbnail()
 
     assert user.get_avatar_url() == ""
+
+
+def test_get_hq_image_url_returns_url_when_file_exists(user):
+    """The happy path: a stored high-quality image resolves to a render URL."""
+    user.hq_image.save("hq-user.png", _png_upload("hq-user.png"))
+
+    assert user.get_hq_image_url() == user.hq_image_render.url
+
+
+def test_get_hq_image_url_returns_none_when_file_missing(user):
+    """`hq_image_render` raises from the `if` condition just like the thumbnail.
+
+    `users/templatetags/avatar_tags.py` calls `get_hq_image_url` on the same
+    render paths as `get_thumbnail_url`, so a missing high-quality image has to
+    degrade the same way or the avatar still 500s.
+    """
+    user.hq_image.save("hq-user.png", _png_upload("hq-user.png"))
+    Path(user.hq_image.path).unlink()
+    user.delete_cached_hq_render()
+
+    assert user.get_hq_image_url() is None
 
 
 def test_claim(user):

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from django.contrib.auth import get_user_model
@@ -73,6 +75,33 @@ def test_user_model_image_file_size(user):
     # This should raise a ValidationError for file size
     with pytest.raises(ValidationError):
         user.full_clean()
+
+
+def test_get_thumbnail_url_returns_url_when_file_exists(user):
+    """The happy path: a stored profile image resolves to a thumbnail URL."""
+    assert user.get_thumbnail_url() == user.image_thumbnail.url
+    assert user.get_avatar_url() == user.image_thumbnail.url
+
+
+def test_get_thumbnail_url_returns_none_when_file_missing(user):
+    """A `profile_image` naming a file absent from storage must not raise.
+
+    `image_thumbnail` is an imagekit `ImageSpecField`; evaluating it for
+    truthiness generates the thumbnail, which opens the source file and
+    raises `FileNotFoundError` when the object is gone from storage.
+    """
+    Path(user.profile_image.path).unlink()
+    user.delete_cached_thumbnail()
+
+    assert user.get_thumbnail_url() is None
+
+
+def test_get_avatar_url_falls_back_when_file_missing(user):
+    """`get_avatar_url` degrades to the empty string that triggers initials."""
+    Path(user.profile_image.path).unlink()
+    user.delete_cached_thumbnail()
+
+    assert user.get_avatar_url() == ""
 
 
 def test_claim(user):


### PR DESCRIPTION
# Issue: #2638 

## Summary & Context

If a user's `profile_image` (or `hq_image`) points at a file that isn't actually in storage, rendering their avatar throws a 500. This is a **local dev environment issue in practice**: local databases are seeded from a dump that references real production/staging filenames, but the actual media files were never copied into local storage, so the app tries to open a source file that genuinely isn't there. Staging and production keep their uploaded files in sync with the database, so this doesn't come up there day-to-day. The fix makes a missing file fall back to the initials avatar instead of crashing.

- **Figma link**: n/a - backend fix, no design change
- **Link to components/page:** localhost:8000/ (any page rendering a user avatar)

## Changes

- `users/models.py` - `get_thumbnail_url()` and `get_hq_image_url()` now catch a missing image file and return `None` instead of raising
- `users/tests/test_models.py` - tests covering both methods with the file present and missing

## ‼️ Risks & Considerations ‼️

- Fixes a bug that shows up constantly in local dev (seeded DB, missing local media files) and is only a rare edge case in staging/production (a genuinely orphaned upload).
- Exception handling is broadened in both methods, so a genuinely broken storage backend would now also fail silently into a fallback avatar rather than raising.

## Peer-review testing steps

### QA testing steps

1. Not applicable - this only reproduces with a local database/media mismatch, so there's nothing to click through on staging.

### Developer testing steps

1. Run `docker compose exec web python -m pytest users/tests/test_models.py -k "thumbnail or avatar or hq_image"` - should pass.
2. Point a local user's `profile_image` at a filename that doesn't exist in `media/`, then load a page that renders their avatar - should render the initials circle with a 200, not a 500.
3. Restore the original `profile_image` value.
