### PR TITLE
Fix Firefox underline link rendering (#2297)

### DIFF
--- a/core/tests/test_v3_underline_css.py
+++ b/core/tests/test_v3_underline_css.py
@@ -1,0 +1,137 @@
+"""Guards the cross-browser underline invariant from #2297.
+
+Firefox derives underline thickness and position from the font's own metrics
+whenever those properties are left to the browser. For Mona Sans that seats the
+line inside the descenders, and `text-decoration-skip-ink` then carves a gap
+around every g/p/y, so the underline renders as disconnected fragments and
+heavier than in Chromium.
+
+`static/css/v3/foundations.css` pins the three properties once for every v3
+anchor. These tests fail if a component rule takes that decision back, which is
+the only way the bug can return. They read the stylesheets as text rather than
+rendering anything, so they cost nothing and run in CI with everything else.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+V3_CSS = Path(__file__).resolve().parents[2] / "static" / "css" / "v3"
+
+# Vendored from the boostlook repo and updated wholesale, so it is not ours to
+# hold to this rule.
+EXCLUDED = {"boostlook-v3.css"}
+
+# The declarations that hand the decision back to the browser. A percentage is
+# included because Figma exports these as percentages of the font size, which
+# land on fractional pixels (7.5% of 14px = 1.05px) and round per engine.
+HANDS_BACK_CONTROL = re.compile(
+    r"""
+    (?:text-decoration-thickness|text-underline-offset)\s*:\s*
+        (?:auto|[\d.]+%)
+    | text-underline-position\s*:\s*from-font
+    | text-decoration-skip-ink\s*:\s*auto
+    """,
+    re.VERBOSE,
+)
+
+# `text-decoration` is a shorthand and resets text-decoration-thickness to
+# `auto`. In a :hover or :focus rule it outranks the shared rule, so the bug
+# comes back on hover only, which is the hardest variant to notice. The -line
+# longhand carries the same intent without the reset.
+UNDERLINE_SHORTHAND = re.compile(r"(?<!-)\btext-decoration\s*:\s*[^;]*underline")
+STATE_SELECTOR = re.compile(r":(?:hover|focus|focus-visible|active|visited)")
+
+
+def _without_comments(text):
+    """Blank out /* ... */ comments, preserving newlines so line numbers hold.
+
+    Needed because foundations.css's own warning comment names the very values
+    these tests ban, and would otherwise match.
+    """
+    return re.sub(
+        r"/\*.*?\*/",
+        lambda m: re.sub(r"[^\n]", " ", m.group(0)),
+        text,
+        flags=re.DOTALL,
+    )
+
+
+def _stylesheets():
+    return sorted(p for p in V3_CSS.glob("*.css") if p.name not in EXCLUDED)
+
+
+def _rules(path):
+    """Yield (selector, body) for each rule in a stylesheet.
+
+    Deliberately naive: a regex, not a parser. It is enough for flat component
+    stylesheets and keeps the test dependency-free.
+    """
+    source = _without_comments(path.read_text())
+    for match in re.finditer(r"([^{}]+)\{([^{}]*)\}", source):
+        selector = match.group(1).strip().split("\n")[-1].strip()
+        yield selector, match.group(2)
+
+
+def test_stylesheets_are_discoverable():
+    """A silent glob miss would make every test below pass for the wrong reason."""
+    sheets = _stylesheets()
+    assert len(sheets) > 20, f"only found {len(sheets)} v3 stylesheets in {V3_CSS}"
+    assert (V3_CSS / "foundations.css") in sheets
+
+
+def test_shared_underline_rule_is_present():
+    """The other tests only make sense if the rule they defer to still exists."""
+    foundations = (V3_CSS / "foundations.css").read_text()
+    for prop, value in (
+        ("text-decoration-skip-ink", "none"),
+        ("text-decoration-thickness", "1px"),
+        ("text-underline-offset", "2px"),
+    ):
+        assert re.search(rf"{prop}\s*:\s*{value}", foundations), (
+            f"foundations.css no longer pins {prop}: {value}. If the shared rule "
+            f"moved, point these tests at its new home rather than deleting them."
+        )
+
+
+@pytest.mark.parametrize("path", _stylesheets(), ids=lambda p: p.name)
+def test_no_rule_hands_underline_geometry_back_to_the_browser(path):
+    """No v3 rule may set these to `auto`, a percentage, or `from-font`.
+
+    Any of them reopens #2297 for that component alone, which is why this is
+    worth a test rather than a comment.
+    """
+    offenders = [
+        (i, line.strip())
+        for i, line in enumerate(
+            _without_comments(path.read_text()).splitlines(), start=1
+        )
+        if HANDS_BACK_CONTROL.search(line)
+    ]
+    assert not offenders, (
+        f"{path.name} hands underline geometry back to the browser:\n"
+        + "\n".join(f"  line {i}: {text}" for i, text in offenders)
+        + "\n\nLeave these three properties to the shared rule in foundations.css."
+    )
+
+
+@pytest.mark.parametrize("path", _stylesheets(), ids=lambda p: p.name)
+def test_state_rules_do_not_reset_thickness_via_the_shorthand(path):
+    """A :hover rule using the `text-decoration` shorthand resets thickness.
+
+    It outranks the shared rule, so the underline goes heavy on hover only. Use
+    `text-decoration-line` instead, or pin the thickness in the same rule.
+    """
+    offenders = [
+        selector
+        for selector, body in _rules(path)
+        if STATE_SELECTOR.search(selector)
+        and UNDERLINE_SHORTHAND.search(body)
+        and "text-decoration-thickness" not in body
+    ]
+    assert not offenders, (
+        f"{path.name} resets text-decoration-thickness on a state rule:\n"
+        + "\n".join(f"  {s}" for s in offenders)
+        + "\n\nUse `text-decoration-line: underline`, which does not reset it."
+    )

--- a/core/tests/test_v3_underline_css.py
+++ b/core/tests/test_v3_underline_css.py
@@ -43,6 +43,14 @@ HANDS_BACK_CONTROL = re.compile(
 UNDERLINE_SHORTHAND = re.compile(r"(?<!-)\btext-decoration\s*:\s*[^;]*underline")
 STATE_SELECTOR = re.compile(r":(?:hover|focus|focus-visible|active|visited)")
 
+# The shared rule's three declarations, and the selector that has to carry them.
+SHARED_RULE_SELECTOR = "body.v3 a"
+SHARED_RULE_DECLARATIONS = (
+    ("text-decoration-skip-ink", "none"),
+    ("text-decoration-thickness", "1px"),
+    ("text-underline-offset", "2px"),
+)
+
 
 def _without_comments(text):
     """Blank out /* ... */ comments, preserving newlines so line numbers hold.
@@ -66,12 +74,13 @@ def _rules(path):
     """Yield (selector, body) for each rule in a stylesheet.
 
     Deliberately naive: a regex, not a parser. It is enough for flat component
-    stylesheets and keeps the test dependency-free.
+    stylesheets and keeps the test dependency-free. The selector keeps its whole
+    comma-separated list on one line, because dropping any part of it would hide
+    a `:hover` that appears in a lead selector rather than the last one.
     """
     source = _without_comments(path.read_text())
     for match in re.finditer(r"([^{}]+)\{([^{}]*)\}", source):
-        selector = match.group(1).strip().split("\n")[-1].strip()
-        yield selector, match.group(2)
+        yield " ".join(match.group(1).split()), match.group(2)
 
 
 def test_stylesheets_are_discoverable():
@@ -82,17 +91,37 @@ def test_stylesheets_are_discoverable():
 
 
 def test_shared_underline_rule_is_present():
-    """The other tests only make sense if the rule they defer to still exists."""
-    foundations = (V3_CSS / "foundations.css").read_text()
-    for prop, value in (
-        ("text-decoration-skip-ink", "none"),
-        ("text-decoration-thickness", "1px"),
-        ("text-underline-offset", "2px"),
-    ):
-        assert re.search(rf"{prop}\s*:\s*{value}", foundations), (
-            f"foundations.css no longer pins {prop}: {value}. If the shared rule "
-            f"moved, point these tests at its new home rather than deleting them."
+    """The other tests only make sense if the rule they defer to still exists.
+
+    All three declarations have to sit in one rule that reaches v3 anchors.
+    Finding them scattered across the file would not pin anything, so this walks
+    the rule bodies rather than searching the stylesheet as a whole.
+    """
+    candidates = []
+    for selector, body in _rules(V3_CSS / "foundations.css"):
+        if SHARED_RULE_SELECTOR not in selector:
+            continue
+        missing = [
+            f"{prop}: {value}"
+            for prop, value in SHARED_RULE_DECLARATIONS
+            if not re.search(rf"{prop}\s*:\s*{value}\b", body)
+        ]
+        if not missing:
+            return
+        candidates.append((selector, missing))
+
+    detail = (
+        "\n".join(
+            f"  `{selector}` is missing {', '.join(missing)}"
+            for selector, missing in candidates
         )
+        or f"  no rule in foundations.css selects `{SHARED_RULE_SELECTOR}`"
+    )
+    raise AssertionError(
+        "foundations.css no longer pins the underline geometry in a single rule "
+        f"for `{SHARED_RULE_SELECTOR}`:\n" + detail + "\n\nIf the shared rule "
+        "moved, point these tests at its new home rather than deleting them."
+    )
 
 
 @pytest.mark.parametrize("path", _stylesheets(), ids=lambda p: p.name)
@@ -100,14 +129,14 @@ def test_no_rule_hands_underline_geometry_back_to_the_browser(path):
     """No v3 rule may set these to `auto`, a percentage, or `from-font`.
 
     Any of them reopens #2297 for that component alone, which is why this is
-    worth a test rather than a comment.
+    worth a test rather than a comment. The whole stylesheet is scanned in one
+    pass, not line by line, so a declaration wrapped after its colon cannot slip
+    through.
     """
+    source = _without_comments(path.read_text())
     offenders = [
-        (i, line.strip())
-        for i, line in enumerate(
-            _without_comments(path.read_text()).splitlines(), start=1
-        )
-        if HANDS_BACK_CONTROL.search(line)
+        (source.count("\n", 0, m.start()) + 1, " ".join(m.group(0).split()))
+        for m in HANDS_BACK_CONTROL.finditer(source)
     ]
     assert not offenders, (
         f"{path.name} hands underline geometry back to the browser:\n"

--- a/static/css/v3/auth-page.css
+++ b/static/css/v3/auth-page.css
@@ -142,8 +142,6 @@
   letter-spacing: -0.12px;
   color: var(--color-text-primary);
   text-decoration: underline;
-  text-decoration-skip-ink: auto;
-  text-underline-offset: auto;
   width: fit-content;
 }
 

--- a/static/css/v3/banner.css
+++ b/static/css/v3/banner.css
@@ -29,9 +29,6 @@
 .banner__message a {
     text-decoration-line: underline;
     text-decoration-style: solid;
-    text-decoration-skip-ink: auto;
-    text-decoration-thickness: auto;
-    text-underline-offset: auto;
 }
 
 .banner__icon, .banner__close-icon {

--- a/static/css/v3/buttons.css
+++ b/static/css/v3/buttons.css
@@ -189,7 +189,7 @@
 }
 
 .btn-card-link:hover {
-  text-decoration: underline;
+  text-decoration-line: underline;
 }
 
 .btn-card-link .btn-icon {

--- a/static/css/v3/content.css
+++ b/static/css/v3/content.css
@@ -97,7 +97,7 @@ a:hover .content-detail-icon:not(.content-detail-icon--contained) {
   text-decoration-skip-ink: none;
 }
 
-.content-detail-icon__cta:hover {
+a.content-detail-icon__cta:hover {
   text-decoration-line: underline;
   /* Match .learn-card__link:hover. Without this the hover was inert, since the
      link is already underlined at rest. */

--- a/static/css/v3/content.css
+++ b/static/css/v3/content.css
@@ -98,12 +98,15 @@ a:hover .content-detail-icon:not(.content-detail-icon--contained) {
 }
 
 .content-detail-icon__cta:hover {
-  text-decoration: underline;
+  text-decoration-line: underline;
+  /* Match .learn-card__link:hover. Without this the hover was inert, since the
+     link is already underlined at rest. */
+  color: var(--color-text-link-accent);
 }
 .content-detail-icon__cta,
 .content-detail-icon__cta:focus,
 .content-detail-icon__cta:focus-visible {
-  text-decoration: underline;
+  text-decoration-line: underline;
   text-decoration-skip-ink: none;
 }
 

--- a/static/css/v3/foundations.css
+++ b/static/css/v3/foundations.css
@@ -162,6 +162,30 @@ html.v3 code {
 .border-error { border-color: var(--color-stroke-error); }
 .border-link-accent { border-color: var(--color-stroke-link-accent); }
 
+/* ==========================================================================
+   Underline links (#2297)
+   Left at `auto`, Firefox derives underline thickness and position from the
+   font's own metrics. For Mona Sans that seats the line inside the descenders,
+   and `skip-ink` then carves a gap around every g/p/y, so the underline renders
+   as disconnected fragments and heavier than in Chromium.
+
+   These three properties are inert unless a decoration is actually drawn, so
+   setting them on every v3 anchor is safe and covers links added later. Keep the
+   specificity low so a component can still override deliberately, and do not
+   reintroduce `auto`, a percentage, or `text-underline-position: from-font` in a
+   component rule: any of those puts the bug back for that component only.
+   ========================================================================== */
+body.v3 a,
+/* Non-anchor elements that carry their own underline. .learn-card__link is a
+   span inside the anchor, so the selector above does not reach it. */
+body.v3 .learn-card__link,
+body.v3 .btn-underline,
+body.v3 .dropdown__item--selected {
+  text-decoration-skip-ink: none;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
 /* Container for v3 content */
 .v3-container {
   width: 100%;

--- a/static/css/v3/foundations.css
+++ b/static/css/v3/foundations.css
@@ -180,7 +180,8 @@ body.v3 a,
    span inside the anchor, so the selector above does not reach it. */
 body.v3 .learn-card__link,
 body.v3 .btn-underline,
-body.v3 .dropdown__item--selected {
+body.v3 .dropdown__item--selected,
+body.v3 .mailing-list-modal__select-all {
   text-decoration-skip-ink: none;
   text-decoration-thickness: 1px;
   text-underline-offset: 2px;

--- a/static/css/v3/join-card.css
+++ b/static/css/v3/join-card.css
@@ -27,9 +27,12 @@
   text-decoration-line: underline;
   text-decoration-style: solid;
   text-decoration-skip-ink: none;
-  text-decoration-thickness: auto;
-  text-underline-offset: auto;
-  text-underline-position: from-font;
+}
+
+/* Matches .learn-card__link:hover and .content-detail-icon__cta:hover. The link
+   is underlined at rest, so colour is the only affordance left to change. */
+.join-card__start-here:hover {
+  color: var(--color-text-link-accent);
 }
 
 .join-card__title-block {

--- a/static/css/v3/learn-cards.css
+++ b/static/css/v3/learn-cards.css
@@ -87,10 +87,6 @@
     letter-spacing: -0.14px;
     text-decoration-line: underline;
     text-decoration-style: solid;
-    text-decoration-skip-ink: auto;
-    text-decoration-thickness: 7.5%;
-    text-underline-offset: 15.2%;
-    text-underline-position: auto;
     color: var(--color-text-primary);
 }
 

--- a/static/css/v3/library-item.css
+++ b/static/css/v3/library-item.css
@@ -47,7 +47,7 @@
 }
 
 a.library-item__name:hover {
-  text-decoration: underline;
+  text-decoration-line: underline;
 }
 
 .library-item p {

--- a/static/css/v3/mailing-list-card.css
+++ b/static/css/v3/mailing-list-card.css
@@ -94,7 +94,7 @@
 }
 
 .mailing-list-modal__select-all:hover {
-  text-decoration: underline;
+  text-decoration-line: underline;
 }
 
 .mailing-list-modal__list-card {

--- a/static/css/v3/markdown-card.css
+++ b/static/css/v3/markdown-card.css
@@ -41,7 +41,6 @@
     color: var(--color-text-link-accent);
     text-decoration: underline;
     text-decoration-skip-ink: none;
-    text-underline-position: from-font;
 }
 
 .markdown-card__body {

--- a/static/css/v3/post-detail.css
+++ b/static/css/v3/post-detail.css
@@ -101,7 +101,6 @@
 .post-detail__external-url a {
   color: var(--color-text-secondary);
   text-decoration: underline;
-  text-underline-position: from-font;
 }
 
 .post-detail__body img {

--- a/static/css/v3/v3-examples-section.css
+++ b/static/css/v3/v3-examples-section.css
@@ -283,7 +283,7 @@ html.dark .v3-examples-section__toc {
 }
 
 .v3-examples-section__toc-link:hover {
-  text-decoration: underline;
+  text-decoration-line: underline;
 }
 
 .v3-examples-section-horizontal-container {


### PR DESCRIPTION
# Issue: #2297

## Summary & Context

Underlined links rendered differently in Firefox: the line sat inside the descenders, got chopped into fragments around every `g`/`p`/`y`, and came out heavier than in Chromium.

The cause is `auto`. Left at `auto`, Firefox derives underline thickness and position from the font's own metrics, and for Mona Sans that seats the line low enough that `text-decoration-skip-ink` carves a gap at every descender. Chromium's `auto` sits lower, so it has nothing to carve.

- **Figma link**: n/a. This is a cross-browser rendering fix, no design change. The target is the existing Chromium rendering.
- **Link to components/page:** `localhost:8000/accounts/login/` ("Forgot password"), `localhost:8000/learn/` (card links and the category "Start here"), `localhost:8000/` (join cards)

## Changes

#### One shared rule
- **`foundations.css`** — pins `text-decoration-skip-ink`, `-thickness` and `text-underline-offset` for every v3 anchor, plus `.learn-card__link` (a span inside its anchor, so `a` does not reach it), `.btn-underline` and `.dropdown__item--selected`. These three properties are inert unless a decoration is actually drawn, so applying them broadly is safe and covers links added later.

#### Removed 12 declarations that would have overridden it
- **`auth-page.css`, `banner.css`, `join-card.css`, `learn-cards.css`** — the `thickness: auto` / `offset: auto` pairs, and two `skip-ink: auto` that contradicted the shared rule.
- **`learn-cards.css`** — `text-decoration-thickness: 7.5%` and `text-underline-offset: 15.2%`. Figma exports these as percentages of the font size, which land on fractional pixels (7.5% of 14px = 1.05px) and round differently per engine.
- **`join-card.css`, `markdown-card.css`, `post-detail.css`** — `text-underline-position: from-font`, which is what asks the browser to use the font's own metric in the first place.

#### Shorthand to longhand in six state rules
- **`buttons.css`, `content.css` (×2), `library-item.css`, `mailing-list-card.css`, `v3-examples-section.css`** — `text-decoration: underline` becomes `text-decoration-line: underline`. The shorthand resets `text-decoration-thickness` to `auto`, and a `:hover` rule outranks the shared rule, so the bug returned on hover only.

#### Two inert hovers
- **`content.css`** — `.content-detail-icon__cta:hover` declared only the underline the link already had, so hovering did nothing. Now takes the accent colour.
- **`join-card.css`** — `.join-card__start-here` had no `:hover` rule at all. Same fix.

No token, template or JS changes. No new colour, spacing or typography values.

## ‼️ Risks & Considerations ‼️

**Two of these changes are not about Firefox.** The inert hovers above are real bugs but browser-independent; I found them while testing the same elements. Happy to split them into a separate PR if you would rather keep this one strictly cross-browser.

**`skip-ink: none` means underlines now run through descenders** rather than breaking around them. That is what makes both engines agree, and it matches what `join-card.css` and `content.css` already did, but it is a deliberate look worth a designer's eye.

**The shared rule is broad by design.** It targets every v3 anchor at low specificity so components can still override deliberately. The comment in `foundations.css` warns against reintroducing `auto`, a percentage, or `from-font` in a component rule, since any of those reopens the bug for that component alone.

**`.btn-underline` is untested.** It is covered by the rule but I could not find it rendered on any served page, so it is untested rather than verified.

**15 more underlined selectors across v3 still have no hover feedback.** Some correctly should not: `.header__nav-link--active` and `.dropdown__item--selected` are state indicators rather than affordances. Deciding which need one is a design question and deliberately out of scope here.

## Peer-review testing steps

Open each in **both Firefox and Chrome**, side by side. Hard-refresh; the change is CSS and a cached stylesheet will show the old behaviour.

1. `/accounts/login/` — "Forgot password" and the sign-up link. This is the page in the issue's screenshot. The underline should be one continuous 1px line, same weight in both browsers.
2. `/accounts/signup/` — the sign-in link. This one previously had no underline properties set at all.
3. `/learn/` — the card links and the category "Start here" links. Hover each: the colour should change to accent blue, and the underline weight should not change.
4. `/` — the three join-card "Start here" links. Hover should change colour; previously it did nothing.
5. `/libraries/latest/` — hover a library name. The underline should *appear* on hover. That is the intended affordance, not a bug.
6. `/releases/1.88.0/` — the link inside the amber version alert banner.
7. Check all of the above in dark mode too.

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Style

* Standardized underline rendering across links and interactive elements.
* Improved consistency for hover, focus, and accent-color states.
* Simplified browser-dependent underline positioning and thickness behavior.
* Added consistent underline treatment for key v3 content and mailing-list controls.
* Improved scrolling and spacing within Markdown cards.
* Refined authentication and banner link presentation.

## Tests

* Added coverage to help prevent future cross-browser underline rendering regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->