### PR TITLE
Render v3 boostlook inside docs iframes

### DIFF
--- a/static/css/v3/header.css
+++ b/static/css/v3/header.css
@@ -31,8 +31,20 @@ body.v3 .header {
   right: 0;
 }
 
-body.v3 .v3-container > .w-full {
+body.v3 .v3-container > .w-full,
+body.v3 .docs-iframe-page > .w-full {
   padding-top: calc(var(--header-height, 48px) + 2 * var(--space-medium));
+}
+
+/* Full-width docs pages (templates/docsiframe.html) replace .v3-container, so
+   they also need its width cap — otherwise the iframe runs edge to edge while
+   the header stays centred, and the two visibly disagree above 1440px. Matches
+   .header's own max-width so the doc and the header share a left edge. */
+body.v3 .docs-iframe-page {
+  width: 100%;
+  max-width: 1440px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 /* ── Shared control surface ────────────────────── */

--- a/static/js/v3/boostlook-docs.js
+++ b/static/js/v3/boostlook-docs.js
@@ -1,0 +1,260 @@
+/**
+ * Boostlook documentation behaviour, vendored for the docs iframe.
+ *
+ * Source: boostlook/boostlook-v3.rb (the `scripts` heredoc). Upstream injects
+ * this at doc build time, but the published library docs were built before it
+ * existed, so the site supplies it instead. Keep in sync with that file, the
+ * same way static/css/v3/boostlook-v3.css is kept in sync with boostlook-v3.css.
+ *
+ * Two independent branches, picked by the shape of the navigation tree:
+ *
+ *   AsciiDoctor docs  — the collapsible TOC upstream bakes in at build time.
+ *                       Published library docs predate it, so serve it here.
+ *
+ *   Antora docs       — normally self-sufficient via _/js/site.js. The bundle
+ *                       deployed to S3 predates the nav-toggle work in
+ *                       website-v2-docs, so it binds toggles without ever
+ *                       creating them. This backfills that one step, ported
+ *                       from antora-ui/src/js/01-nav.js. It self-disables the
+ *                       moment a current bundle is published (see the guard),
+ *                       and should be deleted once that happens.
+ *
+ * Upstream's theme block is deliberately omitted: it self-disables inside an
+ * iframe, and the host page already drives the theme via theme_handling.js.
+ */
+(function () {
+  // Runs on DOM ready, so it works whether this is loaded from <head> or body.
+  function isAsciiDoctorToc() {
+    var toc = document.querySelector('#toc');
+    if (!toc) return false;
+    // Antora builds `.nav-list` here and drives it from its own bundle;
+    // AsciiDoctor builds `ul.sectlevel*`. Only the latter is ours to enhance.
+    if (toc.querySelector('.nav-list')) return false;
+    return !!toc.querySelector('ul[class^=sectlevel]');
+  }
+
+  function staleAntoraNav() {
+    var menu = document.querySelector('.nav-container [data-panel=menu]');
+    if (!menu) return null;
+    // A current bundle builds these itself; if any exist, stand down entirely.
+    if (menu.querySelector('.nav-item-toggle')) return null;
+    return menu.querySelector('.nav-list > .nav-list') ? menu : null;
+  }
+
+  // Ported from website-v2-docs/antora-ui/src/js/01-nav.js. Antora emits a
+  // child nav-list as a *sibling* of its parent <li> when an entry is both an
+  // xref and a parent, so the tree has to be re-nested before it can collapse.
+  function backfillAntoraToggles(menu) {
+    var find = function (from, sel) { return [].slice.call(from.querySelectorAll(sel)); };
+    var stateKey = function () {
+      var title = document.querySelector('.nav-menu .title');
+      return 'nav-open-sections:' + (title ? title.textContent.trim() : 'default');
+    };
+    var labelOf = function (item) {
+      var text = item.querySelector('.nav-text');
+      if (text) return text.textContent.trim();
+      var link = item.querySelector(':scope > .nav-link');
+      return link ? link.textContent.trim() : null;
+    };
+    var save = function () {
+      var open = [];
+      find(menu, '.nav-item.is-active').forEach(function (item) {
+        var l = labelOf(item);
+        if (l) open.push(l);
+      });
+      try { window.localStorage.setItem(stateKey(), JSON.stringify(open)); } catch (e) {}
+    };
+
+    find(menu, '.nav-list > .nav-list').forEach(function (orphanList) {
+      var prevLi = orphanList.previousElementSibling;
+      if (!prevLi || prevLi.tagName !== 'LI') return;
+      prevLi.classList.add('nav-item');
+      var toggle = document.createElement('button');
+      toggle.type = 'button';
+      toggle.className = 'nav-item-toggle';
+      toggle.setAttribute('aria-label', 'Toggle section');
+      toggle.setAttribute('aria-expanded', 'false');
+      prevLi.insertBefore(toggle, prevLi.firstChild);
+      prevLi.appendChild(orphanList);
+    });
+
+    try {
+      var saved = JSON.parse(window.localStorage.getItem(stateKey()));
+      if (saved) {
+        find(menu, '.nav-item').forEach(function (item) {
+          var l = labelOf(item);
+          if (l && saved.indexOf(l) !== -1) item.classList.add('is-active');
+        });
+      }
+    } catch (e) {}
+
+    find(menu, '.nav-item-toggle').forEach(function (btn) {
+      var li = btn.parentElement;
+      var childList = li.querySelector(':scope > .nav-list');
+      li.style.cursor = 'pointer';
+      li.addEventListener('click', function (e) {
+        if (e.target.closest('.nav-link') || (childList && childList.contains(e.target))) return;
+        var open = li.classList.toggle('is-active');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        save();
+      });
+    });
+  }
+
+  function boot() {
+    var antoraMenu = staleAntoraNav();
+    if (antoraMenu) return backfillAntoraToggles(antoraMenu);
+    if (!isAsciiDoctorToc()) return;
+
+    (function () {
+      var html = document.documentElement;
+      html.classList.add('toc-visible', 'toc-pinned');
+      html.classList.remove('toc-hidden');
+    })();
+
+    /*
+     * Collapsible TOC — mirrors the Antora nav-tree (01-nav.js): parent items
+     * get .nav-item + a .nav-item-toggle caret, branches are collapsed by
+     * default (.is-active expands them), the current section's path is
+     * expanded, open sections persist, and the section in view is highlighted
+     * via .is-active-link. Caret/collapse styling lives in boostlook-v3.css.
+     */
+    (function () {
+      function init() {
+        var toc = document.querySelector('#toc');
+        if (!toc) return;
+
+        var labelOf = function (li) {
+          var a = li.querySelector(':scope > a');
+          return a ? a.textContent.trim() : null;
+        };
+        var setOpen = function (li, open) {
+          li.classList.toggle('is-active', open);
+          var btn = li.querySelector(':scope > .nav-item-toggle');
+          if (btn) btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        };
+        var expandPath = function (li) {
+          for (var n = li; n && n !== toc; n = n.parentNode) {
+            if (n.classList && n.classList.contains('nav-item')) setOpen(n, true);
+          }
+        };
+
+        // Decorate every parent item with .nav-item + a caret toggle.
+        Array.prototype.forEach.call(toc.querySelectorAll('li'), function (li) {
+          if (!li.querySelector(':scope > ul')) return;
+          li.classList.add('nav-item');
+          var btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'nav-item-toggle';
+          btn.setAttribute('aria-label', 'Toggle section');
+          btn.setAttribute('aria-expanded', 'false');
+          li.insertBefore(btn, li.firstChild);
+        });
+
+        var navItems = Array.prototype.slice.call(toc.querySelectorAll('.nav-item'));
+
+        // Persist open sections (like Antora's nav-open-sections).
+        var KEY = 'boostlook-toc-open:' + (document.title || 'doc');
+        var save = function () {
+          try {
+            localStorage.setItem(KEY, JSON.stringify(
+              navItems.filter(function (li) { return li.classList.contains('is-active'); })
+                .map(labelOf).filter(Boolean)
+            ));
+          } catch (e) {}
+        };
+        var hadSaved = false;
+        try {
+          var saved = JSON.parse(localStorage.getItem(KEY));
+          if (saved && saved.length) {
+            navItems.forEach(function (li) {
+              if (saved.indexOf(labelOf(li)) !== -1) setOpen(li, true);
+            });
+            hadSaved = true;
+          }
+        } catch (e) {}
+
+        // Click the row (not the link or a nested list) to toggle.
+        navItems.forEach(function (li) {
+          li.addEventListener('click', function (e) {
+            if (e.target.closest('a')) return;
+            var sub = li.querySelector(':scope > ul');
+            if (sub && sub.contains(e.target)) return;
+            setOpen(li, !li.classList.contains('is-active'));
+            save();
+          });
+        });
+
+        // Scroll-spy: highlight the section in view (.is-active-link). The
+        // .boostlook wrapper is the scroll container (html has overflow:hidden),
+        // and on mobile it's the window — so listen on every plausible scroller
+        // and measure with viewport-relative rects.
+        var links = Array.prototype.slice.call(toc.querySelectorAll('a[href^="#"]'));
+        var byId = {};
+        links.forEach(function (a) {
+          var id = decodeURIComponent(a.getAttribute('href').slice(1));
+          if (id && document.getElementById(id)) byId[id] = a;
+        });
+        var headings = Object.keys(byId).map(function (id) { return document.getElementById(id); });
+        var activeLi = null;
+        var spyLock = false, spyTimer; // ignore scroll-spy during click-driven scroll
+        var relock = function () {
+          spyLock = true;
+          clearTimeout(spyTimer);
+          spyTimer = setTimeout(function () { spyLock = false; }, 150);
+        };
+        var setActive = function () {
+          if (spyLock) return;
+          var line = 130, current = null;
+          headings.forEach(function (h) {
+            if (h.getBoundingClientRect().top - line <= 0) current = h;
+          });
+          if (!current && headings.length) current = headings[0];
+          links.forEach(function (a) { a.classList.remove('is-active-link'); });
+          if (current && byId[current.id]) {
+            byId[current.id].classList.add('is-active-link');
+            activeLi = byId[current.id].closest('li');
+          }
+        };
+        var ticking = false;
+        var onScroll = function () {
+          if (spyLock) { relock(); return; } // keep the lock through the click-scroll
+          if (!ticking) { ticking = true; requestAnimationFrame(function () { ticking = false; setActive(); }); }
+        };
+        [document.querySelector('.boostlook'),
+         document.querySelector('.article.toc2.toc-left'),
+         window].forEach(function (el) {
+          if (el) el.addEventListener('scroll', onScroll, { passive: true });
+        });
+        // A click highlights exactly the clicked link; lock the spy through the
+        // scroll that follows so it can't bump the highlight to the next heading.
+        links.forEach(function (a) {
+          a.addEventListener('click', function () {
+            relock();
+            links.forEach(function (l) { l.classList.remove('is-active-link'); });
+            a.classList.add('is-active-link');
+            var li = a.closest('li');
+            if (li) { activeLi = li; expandPath(li); }
+          });
+        });
+        setActive();
+
+        // On first load (no saved state) expand the current section's path so
+        // the tree isn't fully collapsed; otherwise honor what was open.
+        if (!hadSaved) {
+          var hashLink = location.hash && toc.querySelector('a[href="' + location.hash + '"]');
+          var startLi = (hashLink && hashLink.closest('li')) || activeLi || (navItems[0] || null);
+          if (startLi) expandPath(startLi);
+        }
+      }
+      if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+      else init();
+    })();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot);
+  } else {
+    boot();
+  }
+})();

--- a/templates/docs_libs_placeholder.html
+++ b/templates/docs_libs_placeholder.html
@@ -1,11 +1,22 @@
 {% extends 'base.html' %}
-{% load static %}
+{% load static waffle_tags %}
 
 {% block extra_head %}
   <link href="{% static 'css/styles.css' %}" rel="stylesheet" />
   {% comment %} <link rel="preload" data-modernizer="boost-legacy-docs-extra-head" href="{% static 'css/fonts.css' %}" rel="stylesheet" /> {% endcomment %}
   {% if not skip_use_boostlook %}
-    <link rel="preload" data-modernizer="boost-legacy-docs-extra-head" href="{% static 'css/boostlook.css' %}" rel="stylesheet" />
+    {% flag "v3" %}
+      <link data-modernizer="boost-legacy-docs-extra-head" href="{% static 'css/v3/boostlook-v3.css' %}" rel="stylesheet" />
+      {% comment %}
+        The v3 stylesheet styles states that JavaScript has to produce (collapsible
+        nav, scroll-spy). Antora docs get that from their own bundle; AsciiDoctor
+        library docs were published before boostlook started injecting it, so serve
+        it here. The script no-ops on anything that isn't an AsciiDoctor TOC.
+      {% endcomment %}
+      <script data-modernizer="boost-legacy-docs-extra-head" src="{% static 'js/v3/boostlook-docs.js' %}" defer></script>
+    {% else %}
+      <link data-modernizer="boost-legacy-docs-extra-head" href="{% static 'css/boostlook.css' %}" rel="stylesheet" />
+    {% endflag %}
   {% endif %}
   {% comment %}These style tweaks ensure that legacy doc pages are rendered decently. Specifically, the <img /> tag is heavily used in nav bar for tutorial navigation.<style data-modernizer="boost-legacy-docs-extra-head">
                                                                                                                                                                          img {

--- a/templates/docsiframe.html
+++ b/templates/docsiframe.html
@@ -2,7 +2,13 @@
 
 {% block main_content_wrapper %}
 {% if full_width %}
-  <div>
+  {% comment %}
+    docs-iframe-page reserves space for the v3 header, which is absolutely
+    positioned. The usual reservation hangs off .v3-container (see
+    static/css/v3/header.css), and this block replaces that wrapper, so the
+    doc would otherwise start underneath the header.
+  {% endcomment %}
+  <div class="docs-iframe-page">
 {% else %}
   <div class="max-w-7xl md:px-3 mx-auto transition-all">
 {% endif %}
@@ -136,6 +142,14 @@
             // Same page anchor - handle internally
             if (!pageUrl || window.location.href.includes(pageUrl)) {
               scrollToAnchor(iframeDoc, anchorId);
+              // preventDefault above stops the browser writing the fragment, so
+              // put it on the parent URL ourselves — otherwise the address bar
+              // never reflects the section and headings can't be linked to.
+              // replaceState, not pushState: nothing re-scrolls on popstate, so
+              // history entries here would be inert.
+              try {
+                history.replaceState(null, '', '#' + anchorId);
+              } catch (e) { /* non-blocking: scrolling already worked */ }
             } else {
               // Different page with anchor - use parent navigation
               parent.window.location.href = href;


### PR DESCRIPTION
# Render boostlook 2.0 for documentation 

## Summary & Context

Documentation pages have been rendering in the old design for flagged users since #2411. `templates/docs_libs_placeholder.html` overrides `{% block extra_head %}` without `{{ block.super }}`, so it never reaches the `{% flag "v3" %}` branch in `base.html` and always links legacy `boostlook.css`. Docs render inside an iframe, so the outer page loads the v3 build correctly and devtools looks right unless you select the frame, which is why this went unnoticed.

Once the stylesheet was loading, four more bugs on the same pages became visible. They were already there, just hidden while the documentation was still rendering in the old design. This PR fixes all five.

- **Link to page:** `localhost:8000/doc/libs/1_89_0/libs/charconv/doc/html/charconv.html` and `localhost:8000/doc/user-guide/getting-started.html`, with the `v3` flag active

## Changes

**Docs iframe loads the legacy stylesheet.** Serve `boostlook-v3.css` behind the same flag `base.html` uses.

**Document heading hidden behind the site header.** The header is absolutely positioned and the space reserved for it hangs off `.v3-container`, which `docsiframe.html` replaces. The docs wrapper now reserves the same space. Heading sits at 196px against a header ending at 175px.

**Docs not aligned with the header above 1440px.** Same root cause: the replaced wrapper also carried the width cap, so the iframe ran edge to edge while the header stayed centred. At 1920px the header was at 240 to 1680 and the iframe at 0 to 1920. Both now share an edge at 1440, 1920 and 2560.

**Contents links do not update the URL.** The iframe wrapper calls `preventDefault()` and scrolls manually, so the fragment was never written and sections could not be linked to. Loading a URL with a fragment already worked, it just never received one.

**Navigation styled but not interactive.** The stylesheet styles states that JavaScript has to create. Library docs never had boostlook's script baked in, and the Antora bundle deployed to S3 binds nav toggles without creating them. `static/js/v3/boostlook-docs.js`, vendored from `boostlook-v3.rb`, supplies both. Charconv gets 25 collapsible sections, the user guide gets 7.

## ‼️ Risks & Considerations ‼️

With the flag off, output is byte-identical to develop across five surfaces and three `?modernize=` modes. The only differences when diffed were debug toolbar request ids and CPU timings.

One thing to know for later rather than for review: `static/js/v3/boostlook-docs.js` is copied from `boostlook-v3.rb`, so this repo hand-syncs two files from boostlook instead of one. Its Antora half is guarded to stand down as soon as website-v2-docs publishes a current UI bundle, verified as producing 7 toggles either way and never 14, and should be deleted then.

## Testing

Requires the `v3` flag. Worth comparing each against the same URL with the flag off.

- `/doc/libs/1_89_0/libs/charconv/doc/html/charconv.html`: heading clear of the site header, contents list collapses
- `/doc/user-guide/getting-started.html`: tabs switch panels, navigation collapses, admonitions styled
- Either page above 1440px: documentation and site header share a left edge
- Click a contents entry: the URL gains the fragment, and reloading that URL lands on the section
- Toggle dark mode: the theme reaches inside the iframe

271 tests pass in `core/tests/`.

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [ ] UI implementation matches Figma design (n/a, this restores the boostlook design rather than implementing a new one)
- [x] Tested in light and dark mode
- [ ] Responsive / mobile verified (not yet, desktop widths 1440 / 1920 / 2560 only)
- [ ] Accessibility checked (toggles carry `aria-label` and `aria-expanded`, keyboard navigation not yet verified)
- [x] Ensure design tokens are used for colors, spacing, typography (the CSS change uses `--header-height` and `--space-medium`)
- [x] Test without JavaScript (the layout and stylesheet fixes are CSS only; navigation enhancement is progressive)
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced documentation navigation with collapsible sections, remembered open states, current-section highlighting, and scroll tracking.
  * Added support for improving legacy documentation navigation structures.
  * Same-page documentation links now preserve the selected section in the browser URL.

* **Improvements**
  * Full-width documentation pages are centered and aligned with the header.
  * Documentation assets now load based on the selected visual theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->