### PR TITLE
Story #2545 :: Task: Community Page Updates 

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -176,7 +176,7 @@ class CommunityView(MailingListCardMixin, V3Mixin, TemplateView):
                 "cta_text": f"Join Slack {SLACK_MEMBER_COUNT} members",
                 "cta_url": "https://cppalliance.org/slack/",
                 "author": {
-                    "name": "Character Name",
+                    "name": "Ethan Mercer",
                     "role": "Contributor",
                     "avatar_url": large_static(
                         "img/v3/community-page/avatar-beaver-character.png"
@@ -189,7 +189,7 @@ class CommunityView(MailingListCardMixin, V3Mixin, TemplateView):
                 "cta_text": "Subscribe now",
                 "cta_url": "https://lists.boost.org/mailman3/lists/boost.lists.boost.org/",
                 "author": {
-                    "name": "Character Name",
+                    "name": "Sofia Delgado",
                     "role": "Author",
                     "avatar_url": large_static(
                         "img/v3/community-page/avatar-mouse-character.png"
@@ -202,7 +202,7 @@ class CommunityView(MailingListCardMixin, V3Mixin, TemplateView):
                 "cta_text": "Report it on GitHub",
                 "cta_url": "https://github.com/boostorg/boost",
                 "author": {
-                    "name": "Character Name",
+                    "name": "Lars Hoffmann",
                     "role": "Maintainer",
                     "avatar_url": large_static(
                         "img/v3/community-page/avatar-cheetah-character.png"
@@ -215,7 +215,7 @@ class CommunityView(MailingListCardMixin, V3Mixin, TemplateView):
                 "cta_text": "Visit Reddit",
                 "cta_url": "https://www.reddit.com/user/boostlibs/",
                 "author": {
-                    "name": "Character Name",
+                    "name": "Priya Nambiar",
                     "role": "Contributor",
                     "avatar_url": large_static(
                         "img/v3/community-page/avatar-fish-character.png"

--- a/core/views.py
+++ b/core/views.py
@@ -327,7 +327,6 @@ class CommunityView(MailingListCardMixin, V3Mixin, TemplateView):
             "<ul>"
             "<li>Contribution statistics</li>"
             "<li>Progress towards next badge</li>"
-            "<li>Recent activity feed</li>"
             "</ul>"
         )
         ctx["create_account_card_preview_url"] = large_static(

--- a/templates/v3/includes/_create_account_card.html
+++ b/templates/v3/includes/_create_account_card.html
@@ -28,7 +28,6 @@
         <ul>
           <li>Contribution statistics</li>
           <li>Progress towards next badge</li>
-          <li>Recent activity feed</li>
         </ul>
       {% endif %}
     </div>


### PR DESCRIPTION
# Issue: #2545

## Summary & Context

Replaces the four "Character Name" placeholders on the community help cards with the names from the Figma spec, and drops the "Recent activity feed" bullet from the contributions card. Both strings live in `CommunityView.get_v3_context_data`, not in the templates, so the card partial only needed its default-content fallback kept in sync.

- **Figma link**: see below
- **Link to components/page:** [http://localhost:8000/community/latest/](http://localhost:8000/community/latest/)

I couldn't find the characters names almost anywhere in Figma. Only by searching the keyword "Ethan" across all files I found the following (hidden component, I had to copy and paste it in a Figma file of my own to see it). I'm basing myself off of this.
<img width="2222" height="558" alt="image" src="https://github.com/user-attachments/assets/4f114ac4-0f66-4d90-9481-8927771dd8dd" />


## Changes

- **`core/views.py`** - help card authors are now Ethan Mercer, Sofia Delgado, Lars Hoffmann and Priya Nambiar, matching the Figma bubble order and roles.
- **`core/views.py`** - removed the `Recent activity feed` list item from `create_account_card_body_html`.
- **`templates/v3/includes/_create_account_card.html`** - same item removed from the partial's default content, so the examples page and any caller without `body_html` match.

## ‼️ Risks & Considerations ‼️

- Copy-only change behind the `v3` flag; no schema, query or URL touched.
- The cached Figma node for the contributions card still lists "Recent activity feed"; the removal follows the ticket text, which is newer than the cache.

## Screenshots

Before | After
-- | --
<img width="1414" height="373" alt="image" src="https://github.com/user-attachments/assets/a2613919-e248-4a79-aadc-29c4f7710319" />| <img width="1447" height="379" alt="image" src="https://github.com/user-attachments/assets/27cf8947-c8c3-4ae9-b7a5-4dafdea5b770" />
<img width="477" height="486" alt="image" src="https://github.com/user-attachments/assets/b7a2d056-390d-443b-956c-7a3c44900668" />|<img width="460" height="465" alt="image" src="https://github.com/user-attachments/assets/8852cb8e-8fbe-4728-a8c9-055751ee2b1d" />

## Peer-review testing steps

1. With the `v3` flag on, open `/community/latest/`.
2. In the "What do you need help with?" card, confirm the four bubbles read Ethan Mercer (Contributor), Sofia Delgado (Author), Lars Hoffmann (Maintainer), Priya Nambiar (Contributor), in that order.
3. In the "Contribute to earn badges..." card, confirm the list is only "Contribution statistics" and "Progress towards next badge".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated community help-card author names to display specific contributor, author, and maintainer names.
  * Removed “Recent activity feed” from the account-creation card preview and fallback content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->