### PR TITLE
Story #2606 :: Task: Standardize M and D Button Placement Across Breakpoints on Library Subpage  

### DIFF
--- a/static/css/v3/branch-buttons.css
+++ b/static/css/v3/branch-buttons.css
@@ -6,7 +6,7 @@
 .branch-buttons {
   display: flex;
   align-items: center;
-  gap: var(--space-s);
+  gap: var(--space-default);
 }
 
 .branch-button {
@@ -68,19 +68,17 @@
   border-radius: var(--border-radius-s);
 }
 
-/* Sub-page hero: far right, bottom-aligned with the actions row; right edge
-   inset to line up with the content cards below. */
-.hero__block > .branch-buttons {
+.hero__links > .branch-buttons {
+  position: absolute;
+  right: var(--space-large);
   align-self: flex-end;
   flex-shrink: 0;
-  margin-right: var(--space-large);
 }
 
-/* Mobile: stacks below the actions row, left-aligned with the cards. */
 @media (max-width: 767px) {
-  .hero__block > .branch-buttons {
-    align-self: flex-start;
-    margin-right: 0;
-    margin-top: var(--space-large);
+  .hero__links > .branch-buttons {
+    position: static;
+    flex-basis: 100%;
+    margin-top: calc(var(--space-large) - var(--space-s));
   }
 }

--- a/templates/v3/includes/_hero_library.html
+++ b/templates/v3/includes/_hero_library.html
@@ -18,7 +18,7 @@
     hero_background_image_url (optional) — Background image URL for the hero container.
     extra_classes      (optional) — Extra modifier classes for the hero <section>, e.g. "hero--community" (community) or "hero--release" (release detail).
     is_flagship_lib    (optional) — Boolean value stating whether or not this is the hero for a flagship library. If it isn't, styles are a bit different.
-    show_branch_buttons (optional) — Boolean. If truthy, renders the small Master/Develop version-switch buttons (v3/includes/_branch_buttons.html) at the far right of the actions/links row. Off by default so the buttons only appear on library sub-pages, not other heroes (community, release, examples).
+    show_branch_buttons (optional) — Boolean. If truthy, renders the small Master/Develop version-switch buttons (v3/includes/_branch_buttons.html) as the last item of the actions/links row: far right of the hero and bottom-aligned with that row on desktop and tablet, on their own line below it on mobile. Off by default so the buttons only appear on library sub-pages, not other heroes (community, release, examples).
 
   If none of category_tags/version_tag/first_boost_version are passed, the tags
   row is hidden. If none of doc_url/source_url/slack_url/github_url are passed,
@@ -57,7 +57,7 @@
           {% endif %}
         </div>
       </div>
-      {% if doc_url or source_url or slack_url or github_url or rss_url %}
+      {% if doc_url or source_url or slack_url or github_url or rss_url or show_branch_buttons %}
       <div class="hero__links">
         {% if doc_url %}
         {% include "v3/includes/_button.html" with icon_position="right" label="Documentation" url=doc_url style="icon-library" icon_name="documentation" icon_size=16 icon_viewbox="0 0 16 16" %}
@@ -73,6 +73,9 @@
         {% endif %}
         {% if rss_url %}
         {% include "v3/includes/_button.html" with icon_position="right" label="RSS" url=rss_url style="icon-library" icon_name="rss" icon_size=16 icon_viewbox="0 0 16 16" %}
+        {% endif %}
+        {% if show_branch_buttons %}
+        {% include "v3/includes/_branch_buttons.html" %}
         {% endif %}
       </div>
       {% endif %}
@@ -97,9 +100,6 @@
       {% endwith %}
     </div>
     {% endwith %}
-    {% endif %}
-    {% if show_branch_buttons %}
-    {% include "v3/includes/_branch_buttons.html" %}
     {% endif %}
   </div>
   {% include "v3/includes/_version_alert.html" %}


### PR DESCRIPTION
# Issue: #2606

## Summary & Context
Putting the `M` and `D` buttons for master and development branches in a better position in the library page.

- **Figma link**: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=7611-61938&m=dev
- **Link to components/page:** [http://localhost:8040/library/1.92.0/align/](http://localhost:8040/library/1.92.0/align/) (example library, you can see it in others as well, also in the main libraries page)

## Changes

- **`templates/v3/includes/_hero_library.html`** - branch buttons moved from `.hero__block` into `.hero__links`, as its last child.
- **`templates/v3/includes/_hero_library.html`** - the actions row now also renders when `show_branch_buttons` is set but no link URLs are passed.
- **`static/css/v3/branch-buttons.css`** - desktop/tablet: absolutely positioned at `right: var(--space-large)` of the hero block, `align-self: flex-end` so the flex static position bottom-aligns them with the actions row.
- **`static/css/v3/branch-buttons.css`** - mobile: back in flow, `flex-basis: 100%` puts them on their own line 16px below the actions row, left aligned.
- **`static/css/v3/branch-buttons.css`** - gap between the two buttons is now `--space-default` (8px desktop/tablet, 6px mobile), per the Figma component (66px / 64px total width).

## Screenshots

Before | After
-- | --
<img width="1556" height="486" alt="image" src="https://github.com/user-attachments/assets/b3617b54-4a23-4c13-a369-d30c8628491a" />|<img width="1517" height="497" alt="image" src="https://github.com/user-attachments/assets/8bbd5c17-f053-457a-b219-387b518370c6" />
<img width="524" height="433" alt="image" src="https://github.com/user-attachments/assets/b8ec9621-e84c-4d74-a473-4372042ddc2d" />|<img width="472" height="344" alt="image" src="https://github.com/user-attachments/assets/8174b90a-78cc-4fe4-96ed-56fe71406000" />

## Peer-review testing steps

1. With the `v3` waffle flag on, open `/library/1.92.0/asio/` (flagship, has the illustration) at 1440px.
2. Confirm the M and D buttons sit at the far right, with their bottom edge level with the Documentation/Source code row.
3. Resize to 1024px and confirm the same relationship holds against the last wrapped line of that row.
4. Resize below 768px and confirm they drop to their own line, left aligned, 16px under the actions row.
5. Repeat on `/library/1.92.0/align/` (no illustration) to check the no-image hero.
6. Toggle dark mode and confirm the buttons still read against the illustration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Branch buttons now appear within the hero action row for improved alignment.
  * Button placement adapts responsively across desktop and mobile layouts.

* **Style**
  * Updated spacing and positioning provide more consistent visual balance in the hero section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->