### PR TITLE
Fix nested site header when navigating the user guide

### DIFF
--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -535,3 +535,47 @@ def test_redirect_to_library_detail_view_with_cookie(tp):
     response = tp.get("redirect-to-library-view", library_slug="algorithm")
     tp.response_302(response)
     assert response["Location"] == "/library/1.86.0/algorithm/"
+
+
+@pytest.mark.parametrize("sec_fetch_dest", ["iframe", "frame"])
+def test_user_guide_iframe_request_is_not_modernized(request_factory, sec_fetch_dest):
+    """A guide page loading into a frame is returned as-is.
+
+    Nav inside the guide navigates the iframe itself. Without the
+    Sec-Fetch-Dest guard the response is another full page, header and all,
+    rendered inside the existing frame.
+    """
+    from core.views import UserGuideTemplateView
+
+    content = b"<html><body>guide page</body></html>"
+    view = UserGuideTemplateView()
+    view.request = request_factory.get(
+        "/doc/user-guide/index.html", headers={"sec-fetch-dest": sec_fetch_dest}
+    )
+    view.content_dict = {"content": content, "content_type": "text/html"}
+
+    with patch("core.views.modernize_legacy_page") as mock_modernize:
+        assert view.process_content(content) == content
+
+    mock_modernize.assert_not_called()
+
+
+@pytest.mark.parametrize("headers", [{}, {"sec-fetch-dest": "document"}])
+def test_user_guide_top_level_request_is_modernized(request_factory, headers):
+    """A top-level guide request still gets wrapped in the v3 iframe shell."""
+    from core.views import UserGuideTemplateView
+
+    content = b"<html><body>guide page</body></html>"
+    view = UserGuideTemplateView()
+    view.request = request_factory.get("/doc/user-guide/index.html", headers=headers)
+    view.content_dict = {"content": content, "content_type": "text/html"}
+
+    with patch(
+        "core.views.modernize_legacy_page", return_value="<p>modernized</p>"
+    ) as mock_modernize, patch(
+        "core.views.render_to_string", return_value="wrapped page"
+    ) as mock_render:
+        assert view.process_content(content) == "wrapped page"
+
+    mock_modernize.assert_called_once()
+    assert mock_render.call_args_list[-1].args[0] == "docsiframe.html"

--- a/core/views.py
+++ b/core/views.py
@@ -1143,8 +1143,16 @@ class UserGuideTemplateView(BaseStaticContentTemplateView):
         content_type = self.content_dict.get("content_type")
         modernize = self.request.GET.get("modernize", "med").lower()
 
-        if not is_managed_content_type(content_type) or not is_valid_modernize_value(
-            modernize
+        if (
+            not is_managed_content_type(content_type)
+            or not is_valid_modernize_value(modernize)
+            # Guide nav lives inside the iframe, and docsiframe.html only
+            # injects <base target="_parent"> once the frame's load event
+            # fires (seconds, with Antora's fonts). A click before that
+            # navigates the frame, and without this the response is another
+            # full page, header and all, inside the existing frame.
+            # DocLibsTemplateView guards this for framesets like serialization.
+            or get_is_iframe_destination(self.request.headers)
         ):
             # eventually check for more things, for example ensure this HTML
             # was not generate from Antora builders.


### PR DESCRIPTION
## Summary & Context
Bug fix. On any user guide page, clicking a sidebar link in the first few seconds after load drew the entire site a second time inside the doc frame: another header, another version alert, another iframe around the guide. Clicking again nested it further.

- **Figma link**: n/a
- **Link to components/page:** localhost:8000/doc/user-guide/building-with-cmake.html

### Steps to reproduce (before this change)
1. Load localhost:8000/doc/user-guide/building-with-cmake.html
2. Click any entry in the guide's left sidebar within roughly three seconds of the page appearing
3. Expected: the next guide page loads at the top level, with one site header
4. Actual: it loads inside the frame that is already there, with a second site header and version alert scrolling inside the doc area

### Root cause
The guide's nav lives inside the doc iframe. `docsiframe.html` injects `<base target="_parent">` so clicks escape to the top window, but it does that from the iframe's `onload` handler, and `load` waits on every subresource in the frame: Antora's fonts and stylesheets plus the CDN scripts the placeholder pulls in. Measured locally, the sidebar becomes clickable around 200ms in and the base tag arrives 3.6 to 7.4 seconds later. A click inside that window navigates the frame itself, so the browser fetched the next guide page as the frame's own document, `process_content()` wrapped it in the v3 shell exactly as it does for a top level request, and the shell landed inside the frame that already had one.

### The fix
`UserGuideTemplateView.process_content()` now takes its existing early exit when `get_is_iframe_destination()` is true, returning the untouched legacy HTML. `DocLibsTemplateView` has carried the same clause since the docs retrieval refactor, so this brings the guide view in line with it rather than adding a new mechanism.

## Changes

- `UserGuideTemplateView.process_content()` returns the raw legacy page when `Sec-Fetch-Dest` is `iframe` or `frame`, instead of wrapping it in the v3 shell again.
- Four parametrized tests in `core/tests/test_views.py`: `iframe` and `frame` destinations come back byte for byte with `modernize_legacy_page` never called, and a top level request (no header, or `document`) still renders `docsiframe.html`. Deleting the guard fails only the two frame cases.

## ‼️ Risks & Considerations ‼️

Verified in Chrome against a local server. After the fix, an in-frame navigation returns the bare doc, the top level page keeps its single header, and a normal click once the base tag has landed still navigates the top window as before.

`Sec-Fetch-Dest` is set by the browser, so curl and the bare Django test client keep taking the modernizing path. Any test for this has to set the header itself, which the new cases do.

The library docs are unaffected either way. They already had this clause, and on the boostlook single page libs it is dormant: charconv has zero relative cross page links, 95 same page anchors that get scrolled rather than navigated, and its base tag lands about 35ms in. Where the clause does earn its keep on that side is the old frameset docs, since `libs/serialization/doc/index.html` asks for two child frames on every load.

No template, CSS or JS changes, and no change to what a top level request returns.

## Self-review Checklist
- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guide content behavior when opened within an iframe, preventing unnecessary full-page wrapping and modernization.
  * Preserved standard modernization and page wrapping for top-level guide requests.

* **Tests**
  * Added coverage for iframe, frame, top-level, and unspecified request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->