### PR TITLE
Story #2552 :: Webpage Integration: Library Related Posts on Library Sub Pages 

### DIFF
--- a/libraries/views.py
+++ b/libraries/views.py
@@ -24,7 +24,7 @@ from core.githubhelper import GithubAPIClient
 from core.mixins import V3Mixin
 from mailing_list.mixins import MailingListCardMixin
 from core.mock_data import SharedResources
-from news.services import get_latest_post_cards
+from news.services import get_library_post_cards
 from versions.exceptions import BoostImportedDataException
 from versions.models import Version
 
@@ -619,7 +619,8 @@ class LibraryDetail(
             version_str,
         )
 
-        context["library_posts"] = get_latest_post_cards(limit=3)
+        context["library_posts"] = get_library_post_cards(self.object.slug, limit=3)
+        context["library_posts_cta_url"] = reverse("news")
 
         this_release = _build_release_contributors(context)
         context["this_release_contributors"] = (

--- a/news/services.py
+++ b/news/services.py
@@ -1,3 +1,5 @@
+from pages.models import PostPage
+
 from .models import Entry
 
 # Display labels for a post's type "chip" (the small category label on post
@@ -69,13 +71,13 @@ def _get_wagtail_post_cards(limit: int) -> list[dict]:
 
     Stub for the planned migration of post content onto Wagtail pages (per the
     earlier discussion about authoring posts as pages rather than Entry models).
-    No post-style Wagtail page model exists yet, so this returns nothing and the
-    Learn/community/library surfaces fall back to Entry data only.
+    `PostPage` now exists, but the unfiltered surfaces (Learn, community,
+    homepage) still read Entry data only, so this returns nothing until that
+    cutover happens.
 
-    When the page model lands, query its published pages here and map each into
-    the post-card shape via a `_wagtail_page_to_post_card(page)` helper. Because
-    `get_latest_post_cards` already merges and re-sorts every source by date,
-    wiring this up requires no changes at the call sites.
+    To wire it up, query published `PostPage` rows here and map each one with
+    `_post_page_to_post_card`. Because `get_latest_post_cards` already merges
+    and re-sorts every source by date, that needs no changes at the call sites.
     """
     return []
 
@@ -93,3 +95,45 @@ def get_latest_post_cards(limit: int = 3) -> list[dict]:
     cards = _get_entry_post_cards(limit) + _get_wagtail_post_cards(limit)
     cards.sort(key=lambda card: card["date"], reverse=True)
     return cards[:limit]
+
+
+def _post_page_to_post_card(page: PostPage) -> dict:
+    author = page.author
+    return {
+        "title": page.title,
+        "url": page.get_absolute_url(),
+        "date": page.first_published_at,
+        "category": (
+            news_type_label(page.post_content_type) if page.post_content_type else ""
+        ),
+        "tag": "",
+        "author": author.to_v3_profile_dict() if author else None,
+    }
+
+
+def get_library_post_cards(library_slug: str, limit: int = 3) -> list[dict]:
+    """Return the latest posts tagged with `library_slug` as post-card dicts.
+
+    Posts are linked to a library through a `ContentTag` whose slug mirrors the
+    library slug (see the create-post view). Only Wagtail `PostPage` posts carry
+    that link; legacy news `Entry` rows have no library relation, so they are
+    deliberately excluded rather than shown unfiltered.
+
+    The filter goes through `tagged_items` rather than the `tags` manager: the
+    tag's parental key points at `wagtailcore.Page`, so filtering `tags__slug`
+    on a child page model builds a join against a `pages_postpage.id` column
+    that does not exist.
+
+    Returns an empty list when nothing is tagged, which is what hides the card.
+    """
+    if not library_slug:
+        return []
+
+    queryset = (
+        PostPage.objects.live()
+        .public()
+        .filter(tagged_items__tag__slug=library_slug)
+        .select_related("owner", "owner__displayed_profile_role_library")
+        .order_by("-first_published_at")[:limit]
+    )
+    return [_post_page_to_post_card(page) for page in queryset]

--- a/news/tests/test_services.py
+++ b/news/tests/test_services.py
@@ -1,0 +1,96 @@
+import pytest
+from django.utils.timezone import now
+from wagtail.models import Collection
+from wagtail.models import Locale
+from wagtail.models import Page
+
+from news.services import get_library_post_cards
+from pages.mixins import ContentTag
+from pages.models import PostIndexPage
+from pages.models import PostPage
+from pages.models import RoutableHomePage
+
+
+@pytest.fixture
+def post_index_page(db):
+    Locale.objects.get_or_create(language_code="en")
+    if not Collection.get_first_root_node():
+        Collection.add_root(name="Root")
+    root = Page.add_root(instance=Page(title="Root", slug="root"))
+    home = root.add_child(instance=RoutableHomePage(title="Home", slug="home"))
+    return home.add_child(instance=PostIndexPage(title="Posts", slug="posts"))
+
+
+@pytest.fixture
+def make_post_page(post_index_page, make_user):
+    def _make_it(title, tag_slugs=(), live=True, published_at=None, owner=None):
+        page = PostPage(
+            title=title,
+            owner=owner or make_user(email=f"{title.replace(' ', '-')}@example.com"),
+            live=live,
+            content=[("news", "<p>Body</p>")],
+            first_published_at=published_at or now(),
+        )
+        post_index_page.add_child(instance=page)
+        for slug in tag_slugs:
+            tag, _ = ContentTag.objects.get_or_create(
+                slug=slug, defaults={"name": slug}
+            )
+            page.tags.add(tag)
+        page.save()
+        return page
+
+    return _make_it
+
+
+class TestGetLibraryPostCards:
+    def test_returns_only_posts_tagged_with_the_library(self, make_post_page):
+        make_post_page("Tagged post", tag_slugs=["multi_array"])
+        make_post_page("Other library post", tag_slugs=["beast"])
+        make_post_page("Untagged post")
+
+        cards = get_library_post_cards("multi_array")
+
+        assert [card["title"] for card in cards] == ["Tagged post"]
+
+    def test_card_shape(self, make_post_page):
+        page = make_post_page("Tagged post", tag_slugs=["multi_array"])
+
+        (card,) = get_library_post_cards("multi_array")
+
+        assert card["title"] == "Tagged post"
+        assert card["url"] == page.get_absolute_url()
+        assert card["date"] == page.first_published_at
+        assert card["category"] == "News"
+        assert card["tag"] == ""
+        assert card["author"] == page.owner.to_v3_profile_dict()
+
+    def test_excludes_unpublished_posts(self, make_post_page):
+        make_post_page("Draft post", tag_slugs=["multi_array"], live=False)
+
+        assert get_library_post_cards("multi_array") == []
+
+    def test_newest_first_and_limited(self, make_post_page):
+        import datetime
+
+        base = now()
+        for index in range(4):
+            make_post_page(
+                f"Post {index}",
+                tag_slugs=["multi_array"],
+                published_at=base - datetime.timedelta(days=index),
+            )
+
+        cards = get_library_post_cards("multi_array", limit=3)
+
+        assert [card["title"] for card in cards] == ["Post 0", "Post 1", "Post 2"]
+
+    def test_no_matching_posts_returns_empty_list(self, make_post_page):
+        make_post_page("Other library post", tag_slugs=["beast"])
+
+        assert get_library_post_cards("multi_array") == []
+
+    def test_blank_slug_returns_empty_list(self, make_post_page):
+        make_post_page("Tagged post", tag_slugs=["multi_array"])
+
+        assert get_library_post_cards("") == []

--- a/static/css/v3/library-subpage.css
+++ b/static/css/v3/library-subpage.css
@@ -66,6 +66,10 @@ body:has(.is_flagship) .library-subpage-container {
 .card-masonry-bottom .item-a { grid-area: a; }
 .card-masonry-bottom .item-b { grid-area: b; }
 
+.card-masonry-bottom:not(:has(> .item-a)) {
+  grid-template-areas: "b . .";
+}
+
 /* ── Card max-width overrides ────────────────────────────────────────────── */
 
 /* Cards should fill their wrapper, ignoring their own max-width. */
@@ -139,5 +143,9 @@ body:has(.is_flagship) .library-subpage-container {
     grid-template-areas:
       "a"
       "b";
+  }
+
+  .card-masonry-bottom:not(:has(> .item-a)) {
+    grid-template-areas: "b";
   }
 }

--- a/templates/v3/libraries/library-subpage.html
+++ b/templates/v3/libraries/library-subpage.html
@@ -77,9 +77,11 @@
     {% endif %}
 
     <div class="card-masonry-bottom">
-      <div class="item-a">
-        {% include "v3/includes/_post_card.html" with heading="Latest "|add:object.display_name|add:" posts" items=library_posts variant="card" theme="teal" layout="horizontal" primary_cta_label="View all posts" primary_cta_url="/news/" %}
-      </div>
+      {% if library_posts %}
+        <div class="item-a">
+          {% include "v3/includes/_post_card.html" with heading="Latest "|add:object.display_name|add:" posts" items=library_posts variant="card" theme="teal" layout="horizontal" primary_cta_label="View all posts" primary_cta_url=library_posts_cta_url %}
+        </div>
+      {% endif %}
       <div class="item-b">
         {% include "v3/includes/_mailing_list_card.html" with subscribe_url=mailing_list_card_subscribe_url modal_subscribe_url=mailing_list_card_modal_subscribe_url list_id=mailing_list_card_list_id state=mailing_list_card_state user_email=mailing_list_card_user_email manage_url=mailing_list_card_manage_url subscription_count=mailing_list_card_subscription_count error_message=mailing_list_card_error_message mailing_lists=mailing_list_card_lists subscribed_ids=mailing_list_card_subscribed_ids %}
       </div>


### PR DESCRIPTION
**# Issue: #2552

## Summary & Context

The "Latest _[library]_ posts" card on the library subpage was showing the three
newest posts site-wide; it now shows only posts tagged with the library being
viewed, and disappears entirely when there are none. The library link lives on
Wagtail `PostPage` tags (a `ContentTag` whose slug mirrors the library slug, set
by the create-post flow), so legacy news `Entry` rows are out of scope - they
have no library relation at all.

- **Figma link**: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1750-46677
- **Link to components/page:** [http://localhost:8000/library/latest/beast/](http://localhost:8000/library/latest/beast/)

## Changes

- **`news/services.py`** - new `get_library_post_cards(library_slug, limit)` plus a `PostPage` to post-card mapper.
- **`libraries/views.py`** - library detail feeds the card from the new service and passes the CTA URL as context.
- **`templates/v3/libraries/library-subpage.html`** - the posts card is only rendered when there are posts; CTA URL comes from context instead of a hardcoded `/news/`.
- **`static/css/v3/library-subpage.css`** - bottom grid reflows so the mailing-list card does not sit in the third column when the posts card is absent.
- **`news/tests/test_services.py`** - new tests for tag filtering, draft exclusion, ordering, limit and empty cases.

## ‼️ Risks & Considerations ‼️

- Posts authored as legacy `Entry` rows never appear here, by design; only Wagtail `PostPage` posts carry a library tag.
- The filter goes through `tagged_items__tag__slug`, not `tags__slug`: the tag's parental key targets `wagtailcore.Page`, so the `tags` manager builds a join on a `pages_postpage.id` column that does not exist and raises `ProgrammingError`.
- The empty-state reflow uses `:has()`; browsers without it leave a blank first two columns rather than breaking the page.

## Screenshots

Multiple related posts
<img width="1553" height="1242" alt="image" src="https://github.com/user-attachments/assets/20814d46-b233-4329-b820-a43e130e8612" />

Two related posts
<img width="1505" height="832" alt="image" src="https://github.com/user-attachments/assets/97906c07-284f-4891-b16c-20e918ca9daf" />

Single related post
<img width="1558" height="844" alt="image" src="https://github.com/user-attachments/assets/5f58e1af-d9f8-4a3a-be46-1555efd8ca2c" />


## Peer-review testing steps

1. With the `v3` flag on, open `/library/latest/beast/` - the posts card should be gone (nothing is tagged yet).
2. Go to `/news/add/`, create a post and pick "Beast" under related libraries.
3. Approve/publish the resulting page in the Wagtail admin so it goes live.
4. Reload `/library/latest/beast/` - the card appears, headed "Latest Boost.Beast posts", listing that post.
5. Open a different library, for example `/library/latest/yap/` - no card, and the mailing-list card sits in the first column.
6. With the `v3` flag off, the legacy library page is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Library pages now display up to three latest posts relevant to that library.
  - “View all posts” links now direct visitors to the news page.
- **Bug Fixes**
  - Unpublished and unrelated posts are excluded from library recommendations.
  - The latest-posts section is hidden when no matching content is available.
  - Improved card layout behavior across desktop and mobile views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->