### PR TITLE
Story #2301 :: Task: Fix Hero Button Hover State Transparency Issue 

### DIFF
--- a/static/css/v3/semantics.css
+++ b/static/css/v3/semantics.css
@@ -59,7 +59,7 @@
      SURFACE SEMANTIC COLORS
      ============================================ */
   --color-surface-brand-accent-default: var(--color-primary-orange-mustard);
-  --color-surface-brand-accent-hovered: #FFA000BF;
+  --color-surface-brand-accent-hovered: #FFB840;
   --color-surface-error-strong: var(--color-error-strong);
   --color-surface-error-weak: var(--color-error-weak);
   --color-surface-mid: var(--color-primary-grey-100);

--- a/static/css/v3/themes.css
+++ b/static/css/v3/themes.css
@@ -45,7 +45,7 @@ html.dark {
   --color-stroke-weak: #f7f7f81a;
 
   /* Surface */
-  --color-surface-brand-accent-hovered: #ffa000d9;
+  --color-surface-brand-accent-hovered: #c67f0a;
   --color-surface-error-strong: var(--color-error-mid);
   --color-surface-error-weak: #fdf2f217;
   --color-surface-mid: var(--color-primary-grey-900);


### PR DESCRIPTION
# Issue: #2301

**Branch:** `teo/2301-hero-button-hover-state-transparency` · **Base:** `origin/develop`

## Summary & Context

`--color-surface-brand-accent-hovered` was defined as an 8-digit hex with an alpha channel (`#FFA000BF` light, `#ffa000d9` dark), so the hero button let the page bleed through on hover instead of shifting shade. Figma defines `Surface/Brand Accent/Hovered` as two solid colours, one per theme, so the fix is at the token layer rather than on the button.

- **Figma link**: https://www.figma.com/design/VhZHw3RudFNMzfPEEYchE9/UI-Kit---Foundations-Delivery?node-id=55-205
- **Link to components/page:**
  - [http://localhost:8000/](http://localhost:8000/)
  - [http://localhost:8000/v3/demo/components/](http://localhost:8000/v3/demo/components/)

## Changes

- **`static/css/v3/semantics.css`** - `--color-surface-brand-accent-hovered` is now the solid `#FFB840` instead of `#FFA000BF`.
- **`static/css/v3/themes.css`** - the dark override is now the solid `#c67f0a` instead of `#ffa000d9`.

## ‼️ Risks & Considerations ‼️

- The token is shared: `.btn.btn-hero.btn-primary`, the feedback widget, the examples section and the wysiwyg toolbar all pick up the new hover colour. All four are accent-button hovers, so the change is intended in each, but they are worth a glance.

## Screenshots

Before | After
-- | --
Hover washes out to a translucent orange over the page background | Light hover is a solid `#FFB840`, dark hover a solid `#c67f0a`
<img width="1155" height="552" alt="image" src="https://github.com/user-attachments/assets/bdefe47a-2d5d-4247-9d41-61368218d9eb" />|<img width="1500" height="588" alt="image" src="https://github.com/user-attachments/assets/19f1d0ce-afd4-4f51-ba00-63f714f347ab" />
<img width="1388" height="796" alt="image" src="https://github.com/user-attachments/assets/146b21ec-3798-4fdd-935a-df72137ef4e0" />|<img width="969" height="539" alt="image" src="https://github.com/user-attachments/assets/e67c0bc1-1aeb-42a6-88ed-388b25eee5f7" />


## Peer-review testing steps

1. Enable the `v3` waffle flag.
2. Open the homepage and hover the primary hero button ("Get Started").
3. In light mode the fill goes to a solid lighter mustard, with no page content visible through it.
4. Toggle dark mode and hover again: the fill goes to a solid darker mustard.
5. Optionally open the components demo page as staff, where both states render side by side via `data-hover`.
6. Check the accent hover on the feedback widget and the wysiwyg toolbar still looks right.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the brand accent hover color for improved consistency in light and dark themes.
  - Replaced translucent orange hover states with solid, theme-appropriate colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->