### PR TITLE
fix: align the release hero to the right

### DIFF
--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -105,6 +105,17 @@
   }
 }
 
+/* Release: the scene is right-aligned by design. */
+@media (min-width: 900px) {
+  .hero--release .hero__block {
+    position: static;
+  }
+
+  .hero--release .hero-fg__img {
+    object-position: right bottom;
+  }
+}
+
 /* The art frame is absolutely positioned, so it paints over the content unless
    the content is lifted. Both are flex children of .hero__block, so z-index
    applies without needing position. Community does the same. Without this the


### PR DESCRIPTION
# Issue: #2665

## Summary & Context
<!-- *1-2 sentences describing what this PR does and why* -->

- **Figma link**: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=12121-16265&m=dev
- **Link to components/page:** http://localhost:8000/releases/latest/

## Changes

- Given the design of this specific hero, we align it to the right of the edge.

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*

## Screenshots

### Before
<img width="3830" height="1032" alt="image" src="https://github.com/user-attachments/assets/7f649ca0-380c-4d15-81cc-f8b33c4c3533" />


### After
<img width="1682" height="555" alt="image" src="https://github.com/user-attachments/assets/e210b997-6a53-4622-9a99-3c67dfa8cc57" />
<img width="1058" height="375" alt="image" src="https://github.com/user-attachments/assets/ca7acc1a-ec9b-49a7-bdda-911bcf3f5f71" />
<img width="416" height="629" alt="image" src="https://github.com/user-attachments/assets/7abdd713-807a-43d7-bb63-602a4ee0cac8" />
<img width="2577" height="803" alt="image" src="https://github.com/user-attachments/assets/ddef23d6-3e16-42c8-bdbf-7714583dc5e3" />
<img width="701" height="792" alt="image" src="https://github.com/user-attachments/assets/c562a95a-83ac-49af-b925-005539f3b33a" />



## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [ ] UI implementation matches Figma design
- [ ] Tested in light and dark mode
- [ ] Responsive / mobile verified
- [ ] Accessibility checked (keyboard navigation, etc.)
- [ ] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [ ] Test without JavaScript (if applicable)
- [ ] No console errors or warnings
