### PR TITLE
Story 2618: size the library hero according to illustration presence

### DIFF
--- a/core/mock_data.py
+++ b/core/mock_data.py
@@ -387,9 +387,9 @@ proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         "button_label": "See license details",
     }
 
-    hero_legacy_image_url_light = ""  # TEMP-2618
+    hero_legacy_image_url_light = large_static("img/v3/home-page/heros.png")
 
-    hero_legacy_image_url_dark = ""  # TEMP-2618
+    hero_legacy_image_url_dark = large_static("img/v3/home-page/heros_light.png")
 
     hero_image_url = large_static("img/v3/home-page/home-page-foreground.png")
     hero_image_url_light = large_static("img/v3/home-page/home-page-foreground.png")

--- a/core/mock_data.py
+++ b/core/mock_data.py
@@ -387,9 +387,9 @@ proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         "button_label": "See license details",
     }
 
-    hero_legacy_image_url_light = large_static("img/v3/home-page/heros.png")
+    hero_legacy_image_url_light = ""  # TEMP-2618
 
-    hero_legacy_image_url_dark = large_static("img/v3/home-page/heros_light.png")
+    hero_legacy_image_url_dark = ""  # TEMP-2618
 
     hero_image_url = large_static("img/v3/home-page/home-page-foreground.png")
     hero_image_url_light = large_static("img/v3/home-page/home-page-foreground.png")

--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -394,10 +394,11 @@
 }
 
 /* ───────────────────────────────────────────────────────────────────────────
-   Foreground frame — SHARED by the home hero and the community hero (full-bleed,
-   bottom-anchored, baked-in-position art). Applied via class `hero-fg` in both
-   _hero_home.html and _hero_library.html (the latter gated by `fullbleed_fg`).
-   Library-detail keeps its own small-box `.hero__image` below.
+   Foreground frame — SHARED by the home, community and flagship-library heroes
+   (full-bleed, bottom-anchored, baked-in-position art). Applied via class
+   `hero-fg` in both _hero_home.html and _hero_library.html (the latter gated by
+   `fullbleed_fg`). The small-box `.hero__image` below still serves the heroes that
+   pass no `fullbleed_fg` (library empty state, example gallery).
    ─────────────────────────────────────────────────────────────────────────── */
 .hero-fg {
   position: absolute;
@@ -615,6 +616,9 @@
   margin-left: var(--space-large);
   max-width: 662px;
   flex: 1;
+  /* The foreground frame is absolutely positioned, so it paints over in-flow
+     content unless the content is lifted. */
+  z-index: 1;
 }
 
 .hero__meta {
@@ -862,6 +866,16 @@ html.dark .hero__links .btn-icon-library:hover {
      --release    release detail: taller block, full-bleed foreground over the
                   release scene (solid surface only when no image is supplied)
    ═══════════════════════════════════════════════════════════════════════════ */
+
+/* Flagship library: Figma draws the illustration as a 1440x480 layer filling the
+   hero, animals right-anchored (x=321), with the text laid over it. The shipped
+   art is a 488x416 crop of just the animals, so `contain` scales it to the block's
+   full height and `right bottom` pins it to the corner the design anchors it to.
+   Height now comes from the block, so the art can no longer overhang the hero
+   background the way the old fixed 488x416 box did in the tablet band. */
+.hero--library .hero-fg__img {
+  object-position: right bottom;
+}
 
 /* Community: background focal point + tuned per-breakpoint sizing (independent of
    other library heroes, which keep the base `cover`). */

--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -609,6 +609,20 @@
   min-height: var(--hero-block-height-no-image);
 }
 
+/* Tablet, no illustration: the tablet page frame starts the cards 18px above the
+   hero component's own bottom edge, so the band reads looser than the design.
+   Trim only the block's bottom padding — the content above it does not move, the
+   hero's bottom edge just comes up to meet the cards. 32px rather than Figma's
+   literal 30px: 30 is not on the spacing scale, and 32 is what the mobile block
+   already uses, so the gap steps 48 -> 32 -> 32 across the breakpoints. */
+@media (min-width: 768px) and (max-width: 1279px) {
+  :root { --hero-block-height-no-image: 350px; }
+
+  .hero--no-image .hero__block {
+    padding-bottom: 32px;
+  }
+}
+
 .hero__content {
   display: flex;
   flex-direction: column;

--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -51,12 +51,17 @@
 
   /* Block height — layout, not art (Figma 480/400/600). Stays after override removal. */
   --hero-block-height: 480px;
+
+  /* Floor for a hero with no illustration (Figma 368/368/natural). */
+  --hero-block-height-no-image: 368px;
 }
 @media (max-width: 1279px) {
   :root { --hero-block-height: 400px; }
 }
 @media (max-width: 767px) {
   :root { --hero-block-height: 600px; }
+  /* 0 so the mobile block is sized purely by its content, per spec. */
+  :root { --hero-block-height-no-image: 0px; }
 }
 
 /* ── B) CURRENT-ART OVERRIDES — remove when on-spec art ships ──────────────── */
@@ -593,8 +598,14 @@
   padding-top: var(--space-hero-padding-top);
 }
 
+/* No illustration means no art frame to hold open, so drop the 480/400 block
+   height to the fallback floor. `auto` + `min-height` rather than a fixed height
+   so a wrapped tag or link row grows the hero instead of spilling into the
+   content below. */
 .hero--no-image .hero__block {
   align-items: center;
+  height: auto;
+  min-height: var(--hero-block-height-no-image);
 }
 
 .hero__content {

--- a/static/css/v3/library-subpage.css
+++ b/static/css/v3/library-subpage.css
@@ -28,7 +28,11 @@
   box-sizing: border-box;
 }
 
-body:has(.is_flagship) .library-subpage-container {
+/* The top gap belongs to the illustrated hero, which Figma sets 24px clear of
+   the cards. An unillustrated hero ends flush, so it keeps the 0 top padding
+   above — keyed on the art rather than on flagship status, since a flagship
+   library without art gets the short hero too. */
+body:has(.hero:not(.hero--no-image)) .library-subpage-container {
   padding: var(--space-xlarge) var(--space-large);
 }
 
@@ -154,7 +158,7 @@ body:has(.is_flagship) .library-subpage-container {
     gap: var(--space-large);
   }
 
-  body:has(.is_flagship) .library-subpage-container {
+  body:has(.hero:not(.hero--no-image)) .library-subpage-container {
     padding: var(--space-large) var(--space-default);
   }
 

--- a/templates/v3/libraries/library-subpage.html
+++ b/templates/v3/libraries/library-subpage.html
@@ -15,7 +15,7 @@
 {% else %}
   {% with cpp_ver=library_version.get_cpp_standard_minimum_display|default:"C++03" %}
       {% if is_flagship_lib %}
-        {% include "v3/includes/_hero_library.html" with title=object.display_name description=library_version.description|default:object.description category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url is_flagship_lib=True hero_image_url_light=library_hero_image_url_light hero_image_url_dark=library_hero_image_url_dark show_branch_buttons=True %}
+        {% include "v3/includes/_hero_library.html" with title=object.display_name description=library_version.description|default:object.description category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url is_flagship_lib=True hero_image_url_light=library_hero_image_url_light hero_image_url_dark=library_hero_image_url_dark extra_classes="hero--library" fullbleed_fg=True show_branch_buttons=True %}
       {% else %}
         {% include "v3/includes/_hero_library.html" with title=object.display_name description=library_version.description|default:object.description category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url show_branch_buttons=True %}
       {% endif %}


### PR DESCRIPTION
# Issue: #2618

## Summary & Context

The library hero used to reserve a tall, fixed slab of space for an illustration whether or not an illustration was actually there, leaving a large empty gap above the page content. This PR makes the hero's height depend on whether there is artwork to show, and reconfigures the illustration itself, which was being drawn as a small fixed-size box instead of filling the hero the way the design intends.

- **Figma link**:
  - [Hero component, desktop](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1651-41675)
  - Desktop: [with illustration](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1651-41094) · [without](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1644-82684)
  - Tablet: [with illustration](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1651-42405) · [without](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1651-41927)
  - Mobile: [with illustration](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1651-43467) · [without](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1651-42854)
- **Link to components/page:**
  - Flagship library (has an illustration): `http://localhost:8000/library/1.92.0/decimal/`
  - Non-flagship library (no illustration): `http://localhost:8000/library/1.92.0/accumulators/`

## Changes

- **Hero height now follows the artwork, not the "flagship" label.** A hero with no illustration drops to 368px on desktop and ~354px on tablet, and sizes to its own content on mobile. A hero *with* an illustration is untouched.
- **The gap between the hero and the cards below follows the artwork too.** It used to be applied to any flagship page. Now it is applied to any hero that actually has an illustration. 
- **The illustration now fills the hero instead of sitting in a fixed box.** 
- The hero text was lifted above the artwork layer so it stays readable now that the artwork covers the whole hero.
- **The tablet hero's bottom gap was tightened.** With no illustration, tablet left 48px between the links row and the cards below, where the design shows ~30px. Only the block's bottom padding is trimmed, so nothing above it moves — the hero's bottom edge simply comes up to meet the cards. The gap now steps **48px (desktop) → 32px (tablet) → 32px (mobile)**. Scoped to the no-illustration hero; the illustrated tablet hero is untouched.

## ‼️ Risks & Considerations ‼️

1. **THIS PR FOCUSES MAINLY ON THE CASE WHERE THERE IS NO IMAGE**: we currently don't have illustrations associated with the libraries and instead have a single legacy file. I'm basing this implementation on that particular image, but this will have to be addressed on a per library basis according to the proper illustration @henryajisegiri.

2. **This also changes non-flagship library pages on purpose:** the empty gap came from a single rule that applied to *every* library hero without artwork, so all 163 non-flagship libraries had the same defect. Fixing only flagship pages would have meant re-introducing the exact flagship/artwork coupling the ticket asks us to remove. **This is the main thing to sign off on**.

3. **You cannot see the main fix on a normal local run:** every flagship library is handed the same single shared illustration, which always exists, so the fallback never triggers. To review it, open any non-flagship library page. These show the fallback with no patching.

4. **Mobile behaviour for the flagship hero changed as a side effect:** moving the illustration onto the shared full-bleed frame also picks up that frame's mobile rule, which stacks the artwork below the text rather than boxing it. This is still awaiting a design decision and may need a follow-up adjustment.

5. **⚠️ THE FIGMA FILE IS NOT INTERNALLY CONSISTENT, AND THIS IS THE BIGGEST DRAG ON THIS TICKET.** The hero exists twice: as a reusable **component** (`Hero/library` / `Hero/community`) and as **instances placed inside the full-page frames**. The two disagree, and the page frames disagree with each other:

    - **Desktop**: component and page frame agree. Hero 368px, cards start at 368px, 48px below the links row. This is the only breakpoint that was consistent from the start.
    - **Tablet**: the page frame places the cards at y=350 while the hero instance is 368px tall, so **the cards overlap the hero by 18px**. That cannot be rendered in a browser, which is what marks it as a stray nudge rather than a decision. It implies a 30px gap, and **30px is not on the spacing scale**. I implemented **32px**, which is the nearest token, already used by the mobile block.
    - **Mobile**: on first measurement the frame had the hero stretched to 394px with cards at 394px, leaving 54px of dead space the component never asked for. On a later read the same frame had become 340px/340px, which matches the component *and* matches what we already shipped. 
    
6. **The illustration asset is smaller than the design's:** the design's illustration is a 1440×480 composition whose artwork spans about 78% of the hero width. The asset we ship is a 488×416 crop. It now correctly fills the hero's *height*, but covers about 39% of the width rather than 78%. 

## Screenshots
### No Flagship Desktop
<img width="763" height="795" alt="NoFlagshipDesktop" src="https://github.com/user-attachments/assets/30e6b6eb-d3e0-436e-9c3a-9055606d08d8" />

### No Flagship Tablet
<img width="660" height="757" alt="NoFlagshipTablet" src="https://github.com/user-attachments/assets/707130b8-b503-4601-be82-e396114502cc" />

### No Flagship Mobile
<img width="716" height="796" alt="NoFlagshipMobile" src="https://github.com/user-attachments/assets/43c7972b-cf8e-47e9-b435-88a4eb80f828" />

### Flagship Desktop
<img width="908" height="918" alt="FlagshipDesktop" src="https://github.com/user-attachments/assets/eb4d770f-a02c-4d73-9717-a29235a8364b" />

### Flagship Tablet
<img width="701" height="762" alt="FlagshipTablet" src="https://github.com/user-attachments/assets/6022d0dd-896c-4faa-9988-a3153334d728" />

### Flagship Mobile
<img width="733" height="795" alt="FlagshipMobile" src="https://github.com/user-attachments/assets/743cd29d-58c5-410e-84f2-5e965fa45ec3" />

### Peer testing

1. Run `docker compose up` at root.
2. Navigate to Libraries at http://localhost:8000/libraries/
3. On Libraries search bar, look for a flagship library like _Decimal_. Verify that the hero's height matches that of the illustration. 
4. On search bar, look for a non-flagship library like _Accumulators_. Verify that the large empty gap above the page content has been removed.

**NOTE**: You can access these libraries directly with the links provided at the top.

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design — verified by measuring rendered heights against the Figma frames at 1440 / 1024 / 390. Known deviations are in Risks (4), (5) and (6). Where the Figma component and the page frame disagree, this PR follows the component — see Risk (5).
- [x] Tested in light and dark mode — verified in dark mode; light mode still to confirm. The change is layout-only, so colours are not affected.
- [x] Responsive / mobile verified — desktop and tablet verified; mobile pending the design decision in Risk (4).
- [x] Accessibility checked (keyboard navigation, etc.) — no interactive elements were added or reordered.
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values — the new fallback height is a token (`--hero-block-height-no-image`) alongside the existing height token; no colours were touched.
- [x] Test without JavaScript (if applicable) — the change is stylesheet and template only, no JavaScript involved.
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved library hero layouts across desktop, tablet, and mobile screen sizes.
  * Updated illustrated hero positioning for a more consistent full-width presentation.
  * Adjusted spacing so library subpages respond appropriately to illustrated and non-illustrated heroes.
  * Improved layering and sizing for hero content and backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->