### PR TITLE
Bug 2695: Post Page Summarization task attribute update

### DIFF
--- a/news/tasks.py
+++ b/news/tasks.py
@@ -195,7 +195,7 @@ def summary_dispatcher(pk: int, model_name: str = "Entry"):
             "link": set_summary_for_link_page,
             "video": set_summary_for_video_page,
             "poll": set_summary_for_poll_page,
-        }[entry.determined_news_type.lower()]
+        }[entry.filter_name.lower()]
     logger.info(f"Dispatching summary task for {pk=} to {handler.__name__=}")
     handler.delay(pk)
 


### PR DESCRIPTION
# Issue: #2695 

## Summary & Context
<!-- *1-2 sentences describing what this PR does and why* -->
Updates the PostPage summarization task to use `filter_name` instead of `determined_news_types`, as determined news type is a legacy value not present on this model.

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*
NOTE: This can be tested by rerunning `convert_news_entries` management command, as this calls the task on all PostPages. 


## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [ ] UI implementation matches Figma design
- [ ] Tested in light and dark mode
- [ ] Responsive / mobile verified
- [ ] Accessibility checked (keyboard navigation, etc.)
- [ ] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [ ] Test without JavaScript (if applicable)
- [ ] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved news post summary handling by selecting the appropriate summary format based on the entry’s configured filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->