### PR TITLE
Task 2674: display three lines in page header instead of four

### DIFF
--- a/static/css/v3/learn-cards.css
+++ b/static/css/v3/learn-cards.css
@@ -18,7 +18,7 @@
     gap: var(--space-default);
 }
 
-@media (max-width: 1280px) {
+@media (max-width: 1279px) {
     .learn-card__row {
         flex-direction: column;
     }

--- a/static/css/v3/learn-page.css
+++ b/static/css/v3/learn-page.css
@@ -136,16 +136,12 @@
   }
 }
 
-/* Tablet only: the design stacks the three sentences one per line, but the
-   header's 50% cap swings from 361px to 616px across this range, so no font
-   size makes natural wrapping land on the sentence breaks. Force the breaks and
-   step the size down to fit the narrowest column. Desktop and mobile keep their
-   natural wrapping. */
+/* Tablet: the design stacks the three sentences one per line at 64px, which is
+   already the base size here - only the breaks need forcing, since natural
+   wrapping lands mid-sentence. Below 812px the longest sentence (382px) exceeds
+   the 50% column and wraps to a fourth line; the narrowest tablet we target is
+   820px. Desktop and mobile keep natural wrapping. */
 @media (min-width: 768px) and (max-width: 1279px) {
-  .learn-page-header h1 {
-    font-size: var(--font-size-2xl);
-  }
-
   .learn-page-header h1 span {
     display: block;
   }

--- a/static/css/v3/learn-page.css
+++ b/static/css/v3/learn-page.css
@@ -87,7 +87,7 @@
   grid-area: e;
 }
 
-@media (max-width: 1280px) {
+@media (max-width: 1279px) {
   /* Narrower layouts keep the original grid; the column wrappers dissolve so
      the cards are grid items again. */
   .card-masonry {
@@ -112,7 +112,7 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .card-row {
     grid-template-columns: repeat(1, 1fr);
   }
@@ -133,5 +133,20 @@
 
   .learn-page-header {
     max-width: none;
+  }
+}
+
+/* Tablet only: the design stacks the three sentences one per line, but the
+   header's 50% cap swings from 361px to 616px across this range, so no font
+   size makes natural wrapping land on the sentence breaks. Force the breaks and
+   step the size down to fit the narrowest column. Desktop and mobile keep their
+   natural wrapping. */
+@media (min-width: 768px) and (max-width: 1279px) {
+  .learn-page-header h1 {
+    font-size: var(--font-size-2xl);
+  }
+
+  .learn-page-header h1 span {
+    display: block;
   }
 }

--- a/templates/v3/includes/_learn_card.html
+++ b/templates/v3/includes/_learn_card.html
@@ -33,7 +33,7 @@ Inputs:
     </div>
     <div class="square-card-image">
       <picture>
-        <source media="(max-width: 1280px)" srcset="{{mobile_image_src}}">
+        <source media="(max-width: 1279px)" srcset="{{mobile_image_src}}">
         <img src="{{image_src}}" alt="{{image_alt}}">
       </picture>
     </div>

--- a/templates/v3/learn_page.html
+++ b/templates/v3/learn_page.html
@@ -14,7 +14,7 @@
 {% block content %}
   <div class="learn-page-container">
     <div class="learn-page-header py-large">
-      <h1>Start anywhere. Learn everything. Build anything.</h1>
+      <h1><span>Start anywhere.</span> <span>Learn everything.</span> <span>Build anything.</span></h1>
       <p>A complete, well-documented ecosystem of modern libraries-designed to grow with you.</p>
     </div>
     <div class="card-row py-large">


### PR DESCRIPTION
# Issue: #2674

## Summary & Context

The Learn page heading broke in the wrong places on tablet, wrapping to four lines instead of the three in the design. This puts each sentence on its own line on tablet, and fixes the sections below the heading falling back to the mobile layout at exactly 768px, and the learn cards stacking their image below the text at exactly 1280px.

- **Figma link**: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1644-63218&t=SCTJwIYfYXgCBiWg-4
- **Figma link (isolated section, verified against)**: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1644-63221&t=SI1O6OiGq7RFfR0E-4
- **Link to components/page:** `localhost:8000/learn/`

## Changes

- Wrapped each of the three sentences in the heading in a `<span>`, so the line breaks can be placed deliberately instead of falling wherever the text happens to run out of room.
- On tablet only (768–1279px), the heading now puts each sentence on its own line ~~and drops from 64px to 40px so the longest sentence fits the column~~. **The font size stays at 64px, which is what Figma specifies — only the breaks are forced.** Outside that range the spans stay inline, so desktop and mobile render exactly as they did before.
- Moved this page's mobile breakpoint from `max-width: 768px` to `max-width: 767px`, so 768px gets the tablet layout instead of the mobile one.
- Moved the learn card's breakpoint from `max-width: 1280px` to `1279px`, in both `learn-cards.css` and the `<picture>` tag in `_learn_card.html`, so at 1280px the card image sits to the right of the text and the desktop image is the one loaded.

## ‼️ Risks & Considerations ‼️

1. ⚠️ **This does not hold across the whole tablet range because the heading wraps to four lines below 812px.** ⚠️ At 64px the longest sentence, "Learn everything.", is 382px wide, and the header column is capped at 50% of the page, so it only has room from 812px up. Below that it wraps and you get four lines again. Worth knowing if anyone tests at 768px or 810px.

2. **Checked against Figma at 1024px** (the "Learn, Tablet, Light" frame) and it matches exactly: column 488px, heading block 192px tall, 64px, line height 1, letter spacing −0.64px, weight 400, `#050816`. Subtext also matches: 24px, line height 1.33, letter spacing −0.24px, `#585A64`.
 
3. **One thing does not match, and is not fixed here.** The gap between the heading and the subtext is 32px in code and 24px in Figma. Our `--space-xl` token is 32px while the design's `xl` is 24px. Changing it would affect desktop and mobile too, so I deliberately kept `--space-xl`.
 
4. **The 768px change affects the whole page, not just the heading.** At exactly 768px the cards, the Why Boost grid and the masonry section were all still using the mobile single-column layout. They now match 769px. Worth a look at the full page at 768px, not just the header. The same applies to the 1280px change: the learn cards were still stacking their image below the text there, and now match 1281px.
 
5. **Why not just change the font size.** Worth stating since it is the obvious fix: the heading column is capped at 50% of the page, so across the tablet range it grows from 361px to 616px. There is no font size that makes the text break on the sentences across a range that wide, which is what the first attempt did. The breaks have to be explicit.

6. **Hardcoded breakpoints.** The `768px` and `1279px` values are written out rather than pulled from a token. CSS does not allow variables inside media queries, and there is no build step here, so this is the only option.

| viewport                     | before                                 | after                                                 |
| ---------------------------- | -------------------------------------- | ----------------------------------------------------- |
| ≤767 (mobile)                | —                                      | unchanged                                             |
| ~~768~~ 768–810              | mobile layout, heading 2 lines         | tablet layout, ~~heading 3 lines~~ heading 4 lines ⚠️ |
| ~~769–1279~~ 812–1279 (tablet) | heading 2–4 lines, broken mid-sentence | heading 3 lines, one sentence each                    |
| 1280                         | card image below text                  | card image right of text                              |
| ≥1280 (desktop)              | —                                      | unchanged                                             |

## Screenshots

### Desktop

https://github.com/user-attachments/assets/43bf02e6-c6bf-4a50-af7c-8dcea7a0dd68

### Well Adjusted Tablet Sizes
#### iPad Air
<img width="685" height="905" alt="TabletiPadAir" src="https://github.com/user-attachments/assets/4b9905e1-2c9c-4dc2-ada4-5c5f4474aeac" />

#### iPad Pro
<img width="672" height="763" alt="TabletiPadPro" src="https://github.com/user-attachments/assets/0e2e112a-d2dd-46a7-9236-5d11bd87dd1a" />

#### Surface Pro
<img width="702" height="765" alt="TabletSurfacePro" src="https://github.com/user-attachments/assets/1acc37b2-f2b7-4e6c-88df-a57f2797201a" />

### ⚠️  FLAGGED Tablet Sizes ⚠️ 
#### iPad Mini
<img width="675" height="853" alt="TabletiPadMini" src="https://github.com/user-attachments/assets/64b58549-c9d4-4acc-adf6-69992c0d71ad" />

### Mobile

https://github.com/user-attachments/assets/0fa4802d-ec8e-42d7-9627-782eb5168ba1

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend

- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
    - Improved responsive layout behavior across Learn pages at tablet, mobile, and desktop breakpoints.
    - Updated Learn page headings for tablet screens, with clearer line breaks and appropriately scaled text.
    - Refined Learn card stacking and imagery transitions to prevent layout changes at the wrong viewport width.
    - Preserved existing heading wording while improving its presentation across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->