### PR TITLE
Story 2704: fix GitHub activity in public profiles

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -154,11 +154,6 @@ urlpatterns = (
         ),
         path("accounts/", include("allauth.urls")),
         path("users/me/", CurrentUserProfileView.as_view(), name="profile-account"),
-        path(
-            "users/me/github-activity/",
-            GithubActivityFragmentView.as_view(),
-            name="profile-github-activity",
-        ),
         path("users/me/delete/", DeleteUserView.as_view(), name="profile-delete"),
         path(
             "users/me/disconnect-social/<str:platform>/",
@@ -179,6 +174,11 @@ urlpatterns = (
         # Must stay last of the single-segment "users/..." routes: `slug`
         # matches "me" and "avatar" too, so every literal segment has to be
         # registered ahead of it.
+        path(
+            "users/<slug:routing_key>/github-activity/",
+            GithubActivityFragmentView.as_view(),
+            name="profile-github-activity",
+        ),
         path(
             "users/<slug:routing_key>/",
             PublicUserProfileView.as_view(),

--- a/users/mixins.py
+++ b/users/mixins.py
@@ -135,10 +135,12 @@ class V3UserProfileContextMixin:
             "bio": user.biography or None,
             "top_links": self.get_v3_profile_link_buttons(user),
         }
-        # Rendered on anyone's profile, not just your own. Omitted entirely
-        # without a linked GitHub account, so a profile with no data stays the
-        # bio card alone rather than showing an empty shell.
-        activity = github_activity_card_context(user)
-        if activity["data"]["linked"]:
+        # Rendered on anyone's profile, not just your own, and omitted entirely
+        # without a linked GitHub account so a profile with no data stays the
+        # bio card alone. include_hidden for the owner, for the same reason as
+        # `role` and the badges above: a member who hid their activity still
+        # sees it on their own page, and a visitor never does.
+        activity = github_activity_card_context(user, include_hidden=is_owner)
+        if activity and activity["data"]["linked"]:
             context["github_activity"] = activity
         return context

--- a/users/mixins.py
+++ b/users/mixins.py
@@ -135,13 +135,10 @@ class V3UserProfileContextMixin:
             "bio": user.biography or None,
             "top_links": self.get_v3_profile_link_buttons(user),
         }
-        # Owner-only: the card kicks a background refresh, and publishing it on
-        # a public profile would expose data that `hide_github_activity` is
-        # meant to withhold, an opt-out not yet wired up to rendering.
-        # Omitted entirely without a linked account, so a profile with no data
-        # stays the bio card alone.
-        if is_owner:
-            activity = github_activity_card_context(user)
-            if activity["data"]["linked"]:
-                context["github_activity"] = activity
+        # Rendered on anyone's profile, not just your own. Omitted entirely
+        # without a linked GitHub account, so a profile with no data stays the
+        # bio card alone rather than showing an empty shell.
+        activity = github_activity_card_context(user)
+        if activity["data"]["linked"]:
+            context["github_activity"] = activity
         return context

--- a/users/profile_cards.py
+++ b/users/profile_cards.py
@@ -136,9 +136,10 @@ def github_activity_bullets(data, login):
 def github_activity_card(user):
     """Build the context for the profile's GitHub activity card.
 
-    Never calls GitHub. Returns one of three states: a connect prompt when no
-    GitHub account is linked, an empty state while the first sync runs, or the
-    stored numbers.
+    Never calls GitHub. Returns the stored numbers, or an empty state while the
+    first sync runs. With no linked GitHub account there is nothing to show:
+    `linked` stays False and callers omit the section, so connecting is offered
+    by the account connections card rather than here.
     """
     state = github_activity_state(user)
     card = {
@@ -152,15 +153,10 @@ def github_activity_card(user):
     }
 
     if not state.linked:
-        card["markdown_text"] = (
-            "Connect your GitHub account to see your Boost activity here."
-        )
-        card["button_label"] = "Connect GitHub"
-        card["button_url"] = f"{reverse('github_login')}?process=connect"
         return card
 
     if state.activity is None or not state.activity.data:
-        card["markdown_text"] = "Fetching your Boost GitHub activity…"
+        card["markdown_text"] = "Fetching Boost GitHub activity…"
         return card
 
     # Every bullet is dropped when all counts are zero, which is the common case

--- a/users/profile_cards.py
+++ b/users/profile_cards.py
@@ -175,9 +175,18 @@ def github_activity_card(user):
     return card
 
 
-def github_activity_card_context(user, attempt=0):
+def github_activity_card_context(user, attempt=0, include_hidden=False):
     """Context for ``_github_activity_card.html``, shared by the profile page
-    and the fragment endpoint it polls."""
+    and the fragment endpoint it polls.
+
+    Returns None when the user has hidden their GitHub activity, unless
+    ``include_hidden`` is set.
+    Callers omit the section entirely rather than rendering it empty, the same
+    shape ``badges.display.held_badges`` uses for ``hide_badges``.
+    """
+    if user.hide_github_activity and not include_hidden:
+        return None
+
     attempt = max(0, attempt)
     # The poll address is per profile, so a visitor polling gets the numbers of
     # the profile they are on. An account with no routing key has no such

--- a/users/profile_cards.py
+++ b/users/profile_cards.py
@@ -179,11 +179,17 @@ def github_activity_card_context(user, attempt=0):
     """Context for ``_github_activity_card.html``, shared by the profile page
     and the fragment endpoint it polls."""
     attempt = max(0, attempt)
+    # The poll address is per profile, so a visitor polling gets the numbers of
+    # the profile they are on. An account with no routing key has no such
+    # address. The card then renders once without polling rather than pointing
+    # somewhere that 404s.
+    key = user.profile_routing_key
+    poll_url = reverse("profile-github-activity", args=[key.routing_key]) if key else ""
     return {
         "data": github_activity_card(user),
         "attempt": attempt,
         "next_attempt": attempt + 1,
-        "poll_exhausted": attempt >= GITHUB_ACTIVITY_POLL_MAX_ATTEMPTS,
-        "poll_url": reverse("profile-github-activity"),
+        "poll_exhausted": attempt >= GITHUB_ACTIVITY_POLL_MAX_ATTEMPTS or not poll_url,
+        "poll_url": poll_url,
         "poll_interval": GITHUB_ACTIVITY_POLL_INTERVAL_SECONDS,
     }

--- a/users/tests/test_github_activity_view.py
+++ b/users/tests/test_github_activity_view.py
@@ -148,3 +148,29 @@ def test_fragment_ignores_garbage_attempt(client, user, db):
 
     assert resp.status_code == 200
     assert "hx-get=" in resp.content.decode()
+
+
+def test_fragment_404s_when_activity_is_hidden(client, user, other_user, db):
+    """Otherwise the endpoint is a way around the profile page's own rules."""
+    cache.clear()
+    _connect(other_user)
+    other_user.hide_github_activity = True
+    other_user.save()
+
+    client.force_login(user)
+    assert client.get(_fragment_url(other_user)).status_code == 404
+
+
+def test_fragment_serves_hidden_activity_to_its_owner(client, user, db):
+    cache.clear()
+    _connect(user)
+    user.github_username = "testuser"
+    user.hide_github_activity = True
+    user.save()
+    GithubActivity.upsert_for_user(user, {"total_commits": 5, "commit_repo_count": 1})
+
+    client.force_login(user)
+    resp = client.get(_fragment_url(user))
+
+    assert resp.status_code == 200
+    assert "Created 5 Commits" in resp.content.decode()

--- a/users/tests/test_github_activity_view.py
+++ b/users/tests/test_github_activity_view.py
@@ -1,35 +1,117 @@
 from unittest.mock import patch
+
+import pytest
 from django.core.cache import cache
 from django.urls import reverse
 from model_bakery import baker
+
 from users.models import GithubActivity
 
 
-def _connect(user):
+def _connect(user, login="testuser"):
     return baker.make(
         "socialaccount.SocialAccount",
         user=user,
         provider="github",
-        extra_data={"login": "testuser"},
+        extra_data={"login": login},
     )
 
 
-def test_fragment_requires_login(client, db):
-    resp = client.get(reverse("profile-github-activity"))
-    assert resp.status_code == 302
+def _fragment_url(user, attempt=None):
+    url = reverse(
+        "profile-github-activity", args=[user.profile_routing_key.routing_key]
+    )
+    return f"{url}?attempt={attempt}" if attempt is not None else url
+
+
+@pytest.fixture
+def other_user(db):
+    """A second user, to be looked at rather than logged in as."""
+    return baker.make(
+        "users.User",
+        email="other@example.com",
+        display_name="Other User",
+        image=None,
+    )
+
+
+def test_fragment_is_public(client, user, db):
+    """The profile page is public, so its polling endpoint must be too, or a
+    signed-out visitor's card never updates."""
+    cache.clear()
+    _connect(user)
+
+    with patch("users.tasks.refresh_github_activity.delay"):
+        resp = client.get(_fragment_url(user))
+
+    assert resp.status_code == 200
+
+
+def test_fragment_serves_the_profile_in_the_url_not_the_viewer(
+    client, user, other_user, db
+):
+    """The bug this endpoint shape prevents: signed in as one user, polling
+    another's card must not swap in the viewer's own numbers."""
+    cache.clear()
+    _connect(user, login="viewer")
+    user.github_username = "viewer"
+    user.save()
+    GithubActivity.upsert_for_user(user, {"total_commits": 111, "commit_repo_count": 1})
+
+    _connect(other_user, login="subject")
+    other_user.github_username = "subject"
+    other_user.save()
+    GithubActivity.upsert_for_user(
+        other_user, {"total_commits": 222, "commit_repo_count": 1}
+    )
+
+    client.force_login(user)
+    html = client.get(_fragment_url(other_user)).content.decode()
+
+    assert "Created 222 Commits" in html
+    assert "111" not in html
+
+
+def test_fragment_404s_for_a_deactivated_account(client, other_user, db):
+    """Matches the profile page, so the fragment cannot serve what the page
+    itself refuses to."""
+    cache.clear()
+    _connect(other_user)
+    url = _fragment_url(other_user)
+    other_user.is_active = False
+    other_user.save()
+
+    assert client.get(url).status_code == 404
+
+
+def test_fragment_404s_for_an_unknown_routing_key(client, db):
+    assert client.get("/users/no-such-person/github-activity/").status_code == 404
 
 
 def test_fragment_polls_while_refreshing(client, user, db):
     cache.clear()
     _connect(user)
-    client.force_login(user)
+
     with patch("users.tasks.refresh_github_activity.delay"):
-        resp = client.get(reverse("profile-github-activity"))
+        resp = client.get(_fragment_url(user))
+
     html = resp.content.decode()
     assert resp.status_code == 200
     assert "hx-get=" in html
     assert 'hx-trigger="load delay:5s"' in html
     assert "Fetching GitHub activity" in html
+
+
+def test_fragment_polls_its_own_profile_address(client, user, db):
+    """Each response points the next poll at the same profile, so the chain
+    cannot drift onto the viewer."""
+    cache.clear()
+    _connect(user)
+
+    with patch("users.tasks.refresh_github_activity.delay"):
+        html = client.get(_fragment_url(user)).content.decode()
+
+    assert f'hx-get="{_fragment_url(user)}?attempt=1"' in html
 
 
 def test_fragment_stops_polling_once_fresh(client, user, db):
@@ -38,9 +120,9 @@ def test_fragment_stops_polling_once_fresh(client, user, db):
     user.github_username = "testuser"
     user.save()
     GithubActivity.upsert_for_user(user, {"total_commits": 5, "commit_repo_count": 2})
-    client.force_login(user)
-    resp = client.get(reverse("profile-github-activity"))
-    html = resp.content.decode()
+
+    html = client.get(_fragment_url(user)).content.decode()
+
     assert "hx-get=" not in html
     assert "Created 5 Commits" in html
     assert "Updated" in html
@@ -49,10 +131,10 @@ def test_fragment_stops_polling_once_fresh(client, user, db):
 def test_fragment_gives_up_at_cap(client, user, db):
     cache.clear()
     _connect(user)
-    client.force_login(user)
+
     with patch("users.tasks.refresh_github_activity.delay"):
-        resp = client.get(reverse("profile-github-activity") + "?attempt=12")
-    html = resp.content.decode()
+        html = client.get(_fragment_url(user, attempt=12)).content.decode()
+
     assert "hx-get=" not in html
     assert "reload the page" in html
 
@@ -60,8 +142,9 @@ def test_fragment_gives_up_at_cap(client, user, db):
 def test_fragment_ignores_garbage_attempt(client, user, db):
     cache.clear()
     _connect(user)
-    client.force_login(user)
+
     with patch("users.tasks.refresh_github_activity.delay"):
-        resp = client.get(reverse("profile-github-activity") + "?attempt=abc")
+        resp = client.get(_fragment_url(user, attempt="abc"))
+
     assert resp.status_code == 200
     assert "hx-get=" in resp.content.decode()

--- a/users/tests/test_profile_cards.py
+++ b/users/tests/test_profile_cards.py
@@ -133,14 +133,18 @@ ACTIVITY_DATA = {
 }
 
 
-def test_card_shows_connect_prompt_without_linked_account(user, db):
+def test_card_is_empty_without_a_linked_account(user, db):
+    """Nothing to show and nothing to offer: connecting lives on the account
+    connections card, so this card just reports that it has no data and its
+    callers omit the section."""
     cache.clear()
 
     card = github_activity_card(user)
 
-    assert "Connect your GitHub account" in card["markdown_text"]
-    assert card["button_label"] == "Connect GitHub"
-    assert "process=connect" in card["button_url"]
+    assert card["linked"] is False
+    assert card["markdown_text"] == ""
+    assert card["button_label"] == ""
+    assert card["button_url"] == ""
 
 
 def test_card_shows_empty_state_when_linked_but_unsynced(user, db):
@@ -150,7 +154,9 @@ def test_card_shows_empty_state_when_linked_but_unsynced(user, db):
     with patch("users.tasks.refresh_github_activity.delay"):
         card = github_activity_card(user)
 
-    assert "Fetching your Boost GitHub activity" in card["markdown_text"]
+    assert "Fetching Boost GitHub activity" in card["markdown_text"]
+    # Reads on anyone's profile, not just your own.
+    assert "your" not in card["markdown_text"]
     assert card["refreshing"] is True
     assert card["button_url"] == ""
 

--- a/users/tests/test_v3_profile_public.py
+++ b/users/tests/test_v3_profile_public.py
@@ -335,3 +335,38 @@ def test_public_profile_omits_github_activity_without_a_linked_account(other_use
     )
 
     assert "user-profile__github" not in response.content.decode()
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_hidden_github_activity_is_withheld_from_visitors(other_user, tp):
+    """The switch already saved; until now nothing read it back."""
+    _link_github(other_user)
+    other_user.github_username = "otherdev"
+    other_user.hide_github_activity = True
+    other_user.save()
+    GithubActivity.upsert_for_user(other_user, {"total_commits": 9})
+
+    response = tp.get(
+        "profile-user", routing_key=other_user.profile_routing_key.routing_key
+    )
+
+    content = response.content.decode()
+    assert "user-profile__github" not in content
+    assert "Created 9 Commits" not in content
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_hidden_github_activity_still_shows_to_its_owner(user, tp):
+    """Hiding is about the public profile, not about hiding it from yourself."""
+    _link_github(user, login="me")
+    user.github_username = "me"
+    user.hide_github_activity = True
+    user.save()
+    GithubActivity.upsert_for_user(user, {"total_commits": 9})
+
+    with tp.login(user):
+        response = tp.get("profile-account")
+
+    content = response.content.decode()
+    assert "user-profile__github" in content
+    assert "Created 9 Commits" in content

--- a/users/tests/test_v3_profile_public.py
+++ b/users/tests/test_v3_profile_public.py
@@ -3,7 +3,7 @@ import waffle.testutils
 from django.urls import resolve
 from model_bakery import baker
 
-from users.models import UserProfileRoutingKey
+from users.models import GithubActivity, UserProfileRoutingKey
 
 pytestmark = pytest.mark.django_db
 
@@ -290,3 +290,48 @@ def test_owner_share_button_copies_the_public_url_not_the_edit_url(user, tp):
     assert share["url"] == user.get_absolute_url()
     assert "edit=true" not in share["url"]
     assert share["extra_classes"] == "js-copy-profile-url"
+
+
+def _link_github(user, login="otherdev"):
+    """Give `user` a linked GitHub account, as connecting one would."""
+    return baker.make(
+        "socialaccount.SocialAccount",
+        user=user,
+        provider="github",
+        extra_data={"login": login, "name": user.display_name},
+    )
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_public_profile_shows_the_owners_github_activity(other_user, tp):
+    """The section is the point of #2704: a visitor must see whose profile they
+    are on, not an empty gap."""
+    _link_github(other_user)
+    other_user.github_username = "otherdev"
+    other_user.save()
+    GithubActivity.upsert_for_user(
+        other_user, {"total_commits": 9, "commit_repo_count": 2}
+    )
+
+    response = tp.get(
+        "profile-user", routing_key=other_user.profile_routing_key.routing_key
+    )
+
+    tp.response_200(response)
+    content = response.content.decode()
+    assert "user-profile__github" in content
+    assert "Created 9 Commits" in content
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_public_profile_omits_github_activity_without_a_linked_account(other_user, tp):
+    """github_username alone is not a linked account: libraries.tasks sets it
+    from commit-author matching, with no GitHub connection involved."""
+    other_user.github_username = "otherdev"
+    other_user.save()
+
+    response = tp.get(
+        "profile-user", routing_key=other_user.profile_routing_key.routing_key
+    )
+
+    assert "user-profile__github" not in response.content.decode()

--- a/users/views.py
+++ b/users/views.py
@@ -9,6 +9,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import auth
 from django.contrib.messages.views import SuccessMessageMixin
 from django.http import (
+    Http404,
     HttpResponsePermanentRedirect,
     HttpResponseRedirect,
     JsonResponse,
@@ -180,7 +181,14 @@ class GithubActivityFragmentView(TemplateView):
             attempt = int(self.request.GET.get("attempt", 0))
         except ValueError:
             attempt = 0
-        return github_activity_card_context(key.user, attempt=attempt)
+        context = github_activity_card_context(
+            key.user, attempt=attempt, include_hidden=key.user == self.request.user
+        )
+        # Hidden activity 404s rather than rendering, so this endpoint cannot
+        # be used to read past the profile page's own visibility rules.
+        if context is None:
+            raise Http404("No GitHub activity for this profile.")
+        return context
 
 
 class CurrentUserProfileView(

--- a/users/views.py
+++ b/users/views.py
@@ -153,22 +153,34 @@ class PublicUserProfileView(V3UserProfileContextMixin, V3Mixin, DetailView):
         return context
 
 
-class GithubActivityFragmentView(LoginRequiredMixin, TemplateView):
-    """Re-render just the GitHub activity card.
+class GithubActivityFragmentView(TemplateView):
+    """Re-render just the GitHub activity card for one profile.
 
     Polled by the card itself while a background refresh runs, so the numbers
     appear without the user reloading. Read-only: it renders whatever is stored
     and never waits on GitHub.
+
+    Keyed by routing key rather than the logged-in user: the card now appears
+    on public profiles, so a visitor polling must get the numbers of the
+    profile they are looking at, not their own. No login required, for the
+    same reason.
     """
 
     template_name = "v3/includes/_github_activity_card.html"
 
     def get_context_data(self, **kwargs):
+        # Deactivated accounts 404 here as they do on the profile page, so the
+        # fragment cannot serve a profile the page itself refuses to.
+        key = get_object_or_404(
+            UserProfileRoutingKey.objects.select_related("user"),
+            routing_key=self.kwargs["routing_key"],
+            user__is_active=True,
+        )
         try:
             attempt = int(self.request.GET.get("attempt", 0))
         except ValueError:
             attempt = 0
-        return github_activity_card_context(self.request.user, attempt=attempt)
+        return github_activity_card_context(key.user, attempt=attempt)
 
 
 class CurrentUserProfileView(


### PR DESCRIPTION
# Issue: #2704

## Summary & Context

The GitHub activity section only showed on your own profile, never on anyone else's. QA spotted the gap.

It was deliberate when the feature shipped in **#2616**, which this builds on. Back then there was no public profile page, and the "hide GitHub activity" switch saved but was never read. Both have changed since, so the restriction is now just a gap.

- **Figma link**: [activity card](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=6635-17182)
- **Link to components/page**: `/users/<routing-key>/` and `/users/me/`

## Changes

1. **Show the section on other people's profiles:** removed the check that limited it to your own page. Profiles with no connected GitHub account still show no section at all.

2. **Made the self-updating card follow the right person:** while a refresh runs, the card re-fetches itself every 5 seconds. It used to ask for *the logged-in user's* activity, so on someone else's profile a signed-in visitor would see their own numbers appear a few seconds after load, and a signed-out visitor saw no update at all. It now asks for the person whose profile is open, and works signed out.
 
3. **Enabled the "hide GitHub activity" switch:** it already saved, but nothing read it. Now you always see your own activity and visitors see nothing when it's on. Same behaviour as the hide switch for badges.

4. **Removed wording that assumed you were looking at yourself:** "Fetching *your* Boost GitHub activity" is now "Fetching Boost GitHub activity". Also deleted the "Connect your GitHub account" prompt (see risks).

## ‼️ Risks & Considerations ‼️

**This drops one requirement from #2583:** the connect prompt on the card. The section is skipped entirely when no account is linked, so nobody ever reached it, even on their own page. Connecting now lives on the account connections card, which is where it belongs. Flagging so it isn't read as an oversight. @henryajisegiri

**Anyone opening a profile can now trigger a background refresh** of that person's data if it's more than a day old. There's a 5-minute limit per profile, so one popular page can't cause a storm. Worth watching only if a crawler starts walking every profile, since all fetches share one GitHub token with the library sync.

## How to test

Verify the following:

- Sign in as A and navigate to B's profile. After the card updates itself, the numbers are still B's.
- Sign out and corroborate activity shows and still updates.
- Hide activity when editing your profile and confirm nothing's shown up when accessed externally, and viceversa.
- A connected account with no Boost contributions shows "No Boost contributions in the last 12 months", not a blank card.

Please take a look at the _**Screenshots**_ section for some concrete examples.

## Screenshots
### Access External Accounts with Unhidden Activity
https://github.com/user-attachments/assets/5725e72f-c772-4d7e-9295-b643c7f6e509

### Access External Accounts with Hidden Activity 
https://github.com/user-attachments/assets/9558d1da-9e5c-4c41-b6c0-defbb0eed915

### Hide Activity Functionality
https://github.com/user-attachments/assets/f9db88c5-132c-4cb2-965c-35f068d1814e

### Account with no Github Activity
<img width="1332" height="1080" alt="NoBoostContributions" src="https://github.com/user-attachments/assets/b7fce24c-c36a-4541-a0a9-db34a699b89b" />

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub activity is now available on public profiles with linked GitHub accounts.
  * Profile owners can view their activity even when it is hidden from visitors.
  * Activity loading and polling now work per profile.

* **Bug Fixes**
  * Removed the GitHub connection prompt for profiles without linked accounts.
  * Hidden, unavailable, deactivated, or unknown profiles no longer expose activity incorrectly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->