### PR TITLE
Story #2694 :: Task: Remove the "mailing list subscription" checkbox from the sign up form

### DIFF
--- a/templates/v3/accounts/signup.html
+++ b/templates/v3/accounts/signup.html
@@ -2,8 +2,8 @@
 {% comment %}
   Sign Up (Create Account) Page — extends the auth page layout.
   Renders the account creation form with email, password fields,
-  mailing list checkbox, and social login options. Inherits from
-  allauth's SignupView for full registration handling.
+  and social login options. Inherits from allauth's SignupView for
+  full registration handling.
 
   This form triggers client-side validation on all fields, then submits natively if no errors.
 
@@ -52,7 +52,6 @@
     {% if form.non_field_errors %}
       {% for error in form.non_field_errors %}<p class="field__error" role="alert">{{ error }}</p>{% endfor %}
     {% endif %}
-    {% include "v3/includes/_field_checkbox.html" with name="mailing_list" label="Also join the Boost Developers Mailing List" %}
     <label class="checkbox  auth-page_tou-checkbox" for="checkbox-accept_terms_of_use">
         <input
           class="checkbox__input"


### PR DESCRIPTION
# Issue: #2694


## Summary & Context

Removes the "Also join the Boost Developers Mailing List" checkbox from the V3 sign up form. 
- **Link to components/page:** [http://localhost:8000/accounts/signup/](http://localhost:8000/accounts/signup/)

## Changes

- **`templates/v3/accounts/signup.html`** - drop the `_field_checkbox.html` include for `mailing_list`; update the template comment block that described it.

## ‼️ Risks & Considerations ‼️

- Mailing list opt-in for new accounts still happens through the post-auth modal on the homepage, which is gated on the `show_ml_post_auth_modal` session flag and is independent of this checkbox.


## Screenshots

<img width="1715" height="1284" alt="image" src="https://github.com/user-attachments/assets/b9ecd782-3d59-43db-a11e-25c23beea9e7" />

## Peer-review testing steps

1. Enable the `v3` waffle flag and log out.
2. Open `/accounts/signup/`.
3. Confirm the only checkbox above Create Account is the Terms of Use one, and the button stays disabled until it is ticked.
4. Complete a signup and confirm the account is created and the verification email is sent.
5. Disable the `v3` flag and open `/accounts/signup/` again to confirm the legacy form is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the mailing list signup checkbox from the account registration form.
  * Updated the signup page messaging to reflect the streamlined form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->