### PR TITLE
Story #2425 :: Webpage Integration: Post Notification

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -378,6 +378,13 @@ CONTRIBUTOR_DATA_CACHE_TIMEOUT = env.int(
     "CONTRIBUTOR_DATA_CACHE_TIMEOUT", default=60 * 60 * 24
 )
 
+# How long a user's "I have seen the newest post" acknowledgement is kept. Only
+# a reclaim window for users who never come back; an expiry shows the nav dot
+# once more, it never hides a genuinely new post.
+POST_NOTIFICATION_SEEN_TIMEOUT = env.int(
+    "POST_NOTIFICATION_SEEN_TIMEOUT", default=60 * 60 * 24 * 180
+)
+
 # Default interval by which to clear the static content cache
 # New method: "never" clear, just overwrite, so that the id
 # field doesn't expand without bounds.

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -7,6 +7,7 @@ from django.urls import NoReverseMatch, reverse
 
 from libraries.constants import LATEST_RELEASE_URL_PATH_STR
 from libraries.utils import get_version_from_cookie
+from pages.notifications import has_unread_posts
 from pages.routing import post_index_url
 from versions.converters import BoostVersionSlugConverter
 from versions.models import Version
@@ -229,8 +230,11 @@ def header_context(request):
         NavLink(label="Learn", url=reverse("learn"), nav_id="learn"),
         NavLink(label="Community", url=reverse("community"), nav_id="community"),
         NavLink(
-            label="Posts", url=post_index_url(request), nav_id="news", is_unread=True
-        ),  # TODO: update is_unread based on actual unread state
+            label="Posts",
+            url=post_index_url(request),
+            nav_id="news",
+            is_unread=has_unread_posts(getattr(request, "user", None)),
+        ),
         NavLink(
             label="Downloads", url=reverse("releases-most-recent"), nav_id="releases"
         ),

--- a/pages/apps.py
+++ b/pages/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class PagesConfig(AppConfig):
     name = "pages"
+
+    def ready(self):
+        from pages import signals  # noqa: F401

--- a/pages/models.py
+++ b/pages/models.py
@@ -30,6 +30,7 @@ from pages.feed import (
     PostFeedFilters,
 )
 from pages.mixins import BasePage
+from pages.notifications import mark_post_seen, mark_posts_seen
 
 from news.tasks import summary_dispatcher
 from news.tasks import set_thumbnail_for_video_page
@@ -109,6 +110,9 @@ class PostIndexPage(BasePage):
 
             return EntryListView.as_view()(request)
 
+        # Reaching the feed acknowledges every post, so the nav dot clears
+        # before this very response is rendered.
+        mark_posts_seen(getattr(request, "user", None))
         return super().serve(request, *args, **kwargs)
 
     def _filtered_queryset(self, filters) -> models.QuerySet["PostPage"]:
@@ -264,6 +268,7 @@ class PostPage(BasePage):
 
             return EntryDetailView.as_view()(request, slug=self.slug)
 
+        mark_post_seen(getattr(request, "user", None), self.pk)
         return super().serve(request, *args, **kwargs)
 
     def get_content(self):

--- a/pages/notifications.py
+++ b/pages/notifications.py
@@ -1,0 +1,85 @@
+"""Cache-backed state for the "new posts" dot on the Posts nav item.
+
+No database models are involved. Publishing a post writes that post's id under
+one well-known key; every user carries one key holding the id they last
+acknowledged. The dot is on whenever those two disagree, so a publish clears
+everybody's acknowledgement implicitly and no bulk key deletion is ever needed.
+
+Everything goes through Django's cache API (the ``default`` alias, backed by
+Redis) rather than a raw Redis handle, so the state survives a backend swap and
+is trivially fakeable in tests.
+"""
+
+from django.conf import settings
+from django.core.cache import cache
+
+LATEST_POST_KEY = "posts:notification:latest_post_id"
+SEEN_KEY_PREFIX = "posts:notification:seen"
+
+
+def _seen_key(user_id) -> str:
+    return f"{SEEN_KEY_PREFIX}:{user_id}"
+
+
+def _acknowledgeable_user(user):
+    """The user we can store an acknowledgement for, or None.
+
+    Anonymous visitors have no stable identity to dismiss the dot against, and
+    giving them one would mean writing a session on every anonymous page view.
+    They never see the dot.
+    """
+    if user is None or not getattr(user, "is_authenticated", False):
+        return None
+    return user
+
+
+def latest_notified_post_id():
+    """Id of the post the dot currently advertises, or None when there is none."""
+    return cache.get(LATEST_POST_KEY)
+
+
+def record_published_post(post_id) -> None:
+    """Turn the dot on for everyone, pointing it at `post_id`."""
+    cache.set(LATEST_POST_KEY, int(post_id), timeout=None)
+
+
+def has_unread_posts(user) -> bool:
+    """Whether `user` should see the dot on the Posts nav item."""
+    if _acknowledgeable_user(user) is None:
+        return False
+    latest = latest_notified_post_id()
+    if latest is None:
+        return False
+    return cache.get(_seen_key(user.pk)) != latest
+
+
+def _store_acknowledgement(user, latest) -> None:
+    cache.set(
+        _seen_key(user.pk),
+        latest,
+        timeout=settings.POST_NOTIFICATION_SEEN_TIMEOUT,
+    )
+
+
+def mark_posts_seen(user) -> None:
+    """Dismiss the dot for `user`, whatever post it is advertising."""
+    if _acknowledgeable_user(user) is None:
+        return
+    latest = latest_notified_post_id()
+    if latest is None:
+        return
+    _store_acknowledgement(user, latest)
+
+
+def mark_post_seen(user, post_id) -> None:
+    """Dismiss the dot for `user`, but only on the post it advertises.
+
+    Reading an older post says nothing about having seen the newest one, so it
+    leaves the dot alone.
+    """
+    if _acknowledgeable_user(user) is None:
+        return
+    latest = latest_notified_post_id()
+    if latest is None or latest != int(post_id):
+        return
+    _store_acknowledgement(user, latest)

--- a/pages/signals.py
+++ b/pages/signals.py
@@ -1,0 +1,24 @@
+"""Signal wiring for `pages`. Imported from `PagesConfig.ready()`."""
+
+from django.dispatch import receiver
+from wagtail.signals import page_published
+
+from pages.models import PostPage
+from pages.notifications import record_published_post
+
+
+@receiver(page_published, sender=PostPage, dispatch_uid="post_notification_published")
+def raise_post_notification(sender, instance, **kwargs):
+    """Light up the Posts nav dot when a net new post goes live.
+
+    Wagtail fires `page_published` for every publish, including edits to a post
+    that is already live, and also for a scheduled publish that has not reached
+    its go-live time. Only the first publication of a live page counts: Wagtail
+    stamps `first_published_at` and `last_published_at` with the same timestamp
+    on that publish and only moves the latter afterwards.
+    """
+    if not instance.live:
+        return
+    if instance.first_published_at != instance.last_published_at:
+        return
+    record_published_post(instance.pk)

--- a/pages/tests/test_post_notifications.py
+++ b/pages/tests/test_post_notifications.py
@@ -1,0 +1,181 @@
+"""The "new posts" dot on the Posts nav item.
+
+State lives entirely in the cache: one key naming the most recently published
+post, one key per user naming the post they last acknowledged. The dot is on
+while those disagree.
+"""
+
+import pytest
+from django.core.cache import cache
+from waffle.testutils import override_flag
+
+from core.context_processors import header_context
+from pages import notifications
+from pages.models import PostPage
+from pages.notifications import (
+    LATEST_POST_KEY,
+    has_unread_posts,
+    latest_notified_post_id,
+    mark_post_seen,
+    mark_posts_seen,
+    record_published_post,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_notification_cache(user):
+    """The suite runs against the shared Redis, so clear both keys either side."""
+
+    def _clear():
+        cache.delete(LATEST_POST_KEY)
+        cache.delete(notifications._seen_key(user.pk))
+
+    _clear()
+    yield
+    _clear()
+
+
+def posts_nav_link(request):
+    links = header_context(request)["nav_links"]
+    return next(link for link in links if link.nav_id == "news")
+
+
+class TestNotificationState:
+    def test_no_dot_before_anything_is_published(self, user):
+        assert latest_notified_post_id() is None
+        assert has_unread_posts(user) is False
+
+    def test_publishing_raises_the_dot(self, user):
+        record_published_post(7)
+        assert has_unread_posts(user) is True
+
+    def test_visiting_the_feed_dismisses_it(self, user):
+        record_published_post(7)
+        mark_posts_seen(user)
+        assert has_unread_posts(user) is False
+
+    def test_the_next_publish_raises_it_again(self, user):
+        record_published_post(7)
+        mark_posts_seen(user)
+        record_published_post(8)
+        assert has_unread_posts(user) is True
+
+    def test_dismissal_is_per_user(self, user, staff_user):
+        record_published_post(7)
+        mark_posts_seen(user)
+        assert has_unread_posts(staff_user) is True
+        cache.delete(notifications._seen_key(staff_user.pk))
+
+    def test_a_publish_out_of_id_order_still_raises_it(self, user):
+        """An older draft approved after a newer one is still a new post."""
+        record_published_post(8)
+        mark_posts_seen(user)
+        record_published_post(7)
+        assert has_unread_posts(user) is True
+
+    def test_anonymous_visitors_never_see_it(self):
+        from django.contrib.auth.models import AnonymousUser
+
+        record_published_post(7)
+        assert has_unread_posts(AnonymousUser()) is False
+        assert has_unread_posts(None) is False
+
+    def test_reading_the_newest_post_dismisses_it(self, user):
+        record_published_post(7)
+        mark_post_seen(user, 7)
+        assert has_unread_posts(user) is False
+
+    def test_reading_an_older_post_leaves_it_alone(self, user):
+        record_published_post(7)
+        mark_post_seen(user, 6)
+        assert has_unread_posts(user) is True
+
+
+@pytest.mark.django_db
+class TestPublishSignal:
+    def _publish(self, page):
+        """Publish the way Wagtail's moderation workflow does, minus the perms."""
+        page.save_revision().publish()
+        page.refresh_from_db()
+
+    def test_a_first_publish_raises_the_dot(self, post_index_page, user):
+        page = PostPage(
+            title="Fresh",
+            content=[("news", "Body")],
+            owner=user,
+            summary="A summary",
+        )
+        post_index_page.add_child(instance=page)
+        page.live = False
+        page.first_published_at = None
+        page.last_published_at = None
+        page.save()
+
+        self._publish(page)
+
+        assert latest_notified_post_id() == page.pk
+
+    def test_editing_a_live_post_does_not(self, make_post_page, user):
+        page = make_post_page(title="Already Live", owner=user)
+        cache.delete(LATEST_POST_KEY)
+
+        page.title = "Already Live, Edited"
+        self._publish(page)
+
+        assert latest_notified_post_id() is None
+
+
+@pytest.mark.django_db
+class TestNavLink:
+    @override_flag("v3", active=True)
+    def test_the_nav_link_carries_the_dot(self, rf, post_index_page, user):
+        record_published_post(7)
+        request = rf.get("/")
+        request.user = user
+        assert posts_nav_link(request).is_unread is True
+
+    @override_flag("v3", active=True)
+    def test_the_nav_link_is_plain_for_anonymous_visitors(self, rf, post_index_page):
+        record_published_post(7)
+        assert posts_nav_link(rf.get("/")).is_unread is False
+
+
+@pytest.mark.django_db
+class TestFeedDismissal:
+    @override_flag("v3", active=True)
+    def test_loading_the_feed_clears_the_dot(
+        self, client, wagtail_site, post_index_page, user
+    ):
+        record_published_post(7)
+        client.force_login(user)
+
+        response = client.get("/news/")
+
+        assert response.status_code == 200
+        assert has_unread_posts(user) is False
+
+    @override_flag("v3", active=True)
+    def test_loading_the_newest_post_clears_the_dot(
+        self, client, wagtail_site, make_post_page, user
+    ):
+        page = make_post_page(title="Newest", owner=user)
+        record_published_post(page.pk)
+        client.force_login(user)
+
+        response = client.get(page.url)
+
+        assert response.status_code == 200
+        assert has_unread_posts(user) is False
+
+    @override_flag("v3", active=True)
+    def test_loading_an_older_post_leaves_the_dot(
+        self, client, wagtail_site, make_post_page, user
+    ):
+        older = make_post_page(title="Older", owner=user)
+        record_published_post(older.pk + 1)
+        client.force_login(user)
+
+        response = client.get(older.url)
+
+        assert response.status_code == 200
+        assert has_unread_posts(user) is True


### PR DESCRIPTION
# Issue: #2425

**Branch:** `teo/2425-post-notification` · **Base:** `origin/develop`

## Summary & Context

Wires the Posts nav item's unread dot, which until now was hardcoded `is_unread=True`, to real
cache-backed state. 

- **Figma link**: n/a - the `header__nav-link--unread` state already exists in the V3 header component
- **Link to components/page:**
  - [http://localhost:8000/](http://localhost:8000/)
  - [http://localhost:8000/news/](http://localhost:8000/news/)

## Changes

- **`pages/notifications.py`** - new; the whole feature's state, over `django.core.cache` (no raw Redis handle)
- **`pages/signals.py`**, **`pages/apps.py`** - `page_published` receiver, only for a `PostPage`'s first publication
- **`core/context_processors.py`** - the Posts `NavLink` now asks `has_unread_posts(request.user)` instead of always claiming unread
- **`pages/models.py`** - `PostIndexPage.serve` dismisses the dot; `PostPage.serve` dismisses it only for the post the dot advertises
- **`config/settings.py`** - `POST_NOTIFICATION_SEEN_TIMEOUT` (180 days) so abandoned per-user keys are reclaimed
- **`pages/tests/test_post_notifications.py`** - 16 tests covering state, the publish signal, the nav link and dismissal

## ‼️ Risks & Considerations ‼️

- Deviation from the dev note: no `users_seen_latest_post` hash and no `DEL` reset. Django's cache client has no hash-map API, and the per-user-key plus inequality-compare form needs neither, while also handling an older draft approved after a newer one (the id comparison in the note would miss it).
- Anonymous visitors never see the dot: there is no identity to dismiss it against, and minting a session on every anonymous page view to get one is not worth it.
- Only Wagtail `PostPage` publishes raise the dot. Approving a legacy `news.Entry` with the `v3` flag off does not, which is correct today since the dot is only rendered by the V3 header and flag-on posts are always `PostPage`s.

## Peer-review testing steps

1. The `v3` flag is on; if `/news/` 404s, create a `PostIndexPage` under Home and run `manage.py convert_news_entries`.
2. Log in, then in a shell run `from pages.notifications import record_published_post` and `record_published_post(<newest live PostPage pk>)`.
3. Load any page: the Posts nav item carries the dot, in the desktop nav and the mobile drawer.
4. Open an older post's detail page: the dot stays. Open the newest post's detail page: it clears.
5. Re-run step 2, then load `/news/`: the dot is gone from that very response.
6. Log out and reload: no dot for anonymous visitors, and none for a second user who has not acknowledged.

