### PR TITLE
feat(2531): rebuild the transactional email templates on the V3 base

### DIFF
--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -1,7 +1,8 @@
 from datetime import date, timedelta
+from urllib.parse import urlsplit
 
 from celery import shared_task, chain
-from django.core.mail import EmailMultiAlternatives, send_mail
+from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.core.management import call_command
 import structlog
@@ -645,22 +646,26 @@ def send_commit_author_email_verify_mail(
         # unlike the legacy log line below, no address (PII) or url (which
         # embeds the claim token) may end up in the logs
         logger.info("Sending commit email verification message")
-        message = render_to_string(
-            "v3/libraries/email/verify_commit_email.txt",
-            {
-                "email": commit_author_email,
-                "requester": requester,
-                "confirm_url": url,
-                "expiry_label": format_duration(COMMIT_EMAIL_CLAIM_MAX_AGE),
-            },
-        )
-        send_mail(
-            subject="Confirm your commit email address",
-            message=message,
+        # The task has no request; the claim URL is already absolute, so the
+        # branded template's scheme/host come from it.
+        parts = urlsplit(url)
+        context = {
+            "email": commit_author_email,
+            "requester": requester,
+            "action_url": url,
+            "expiry_label": format_duration(COMMIT_EMAIL_CLAIM_MAX_AGE),
+            "scheme": parts.scheme,
+            "host": parts.netloc,
+        }
+        prefix = "v3/libraries/email/verify_commit_email"
+        msg = EmailMultiAlternatives(
+            subject=render_to_string(f"{prefix}_subject.txt", context).strip(),
+            body=render_to_string(f"{prefix}.txt", context),
             from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[commit_author_email],
-            fail_silently=False,
+            to=[commit_author_email],
         )
+        msg.attach_alternative(render_to_string(f"{prefix}.html", context), "text/html")
+        msg.send(fail_silently=False)
     else:
         # pre-v3 email, preserved verbatim
         logger.info(f"Sending verification email to {commit_author_email} with {url=}")

--- a/libraries/tests/test_commit_email_verification.py
+++ b/libraries/tests/test_commit_email_verification.py
@@ -1,0 +1,48 @@
+"""The commit-author claim confirmation email."""
+
+import re
+
+import pytest
+from django.core import mail
+
+from libraries.tasks import send_commit_author_email_verify_mail
+
+CONFIRM_URL = "http://testserver/libraries/commit-author-email/verify/abc-123/"
+
+
+@pytest.mark.django_db
+def test_v3_verification_email_is_branded_multipart():
+    send_commit_author_email_verify_mail(
+        "author@example.com", CONFIRM_URL, requester="Vinnie Falco", v3=True
+    )
+
+    msg = mail.outbox[0]
+    assert msg.subject == "Confirm your commit email address"
+    assert msg.recipients() == ["author@example.com"]
+
+    html_body = next(
+        alt.content for alt in msg.alternatives if alt.mimetype == "text/html"
+    )
+    assert "Confirm your commit email" in html_body
+    assert "Vinnie Falco has asked to link author@example.com" in html_body
+    assert CONFIRM_URL in html_body
+    assert CONFIRM_URL in msg.body
+
+    for href in re.findall(r'href="([^"]*)"', html_body):
+        assert href.startswith(("http://", "https://", "mailto:")), href
+
+
+@pytest.mark.django_db
+def test_v3_verification_email_without_a_named_requester():
+    """The claimant's name is optional, and the copy must not leak their
+    account email in its place."""
+    send_commit_author_email_verify_mail(
+        "author@example.com", CONFIRM_URL, requester="", v3=True
+    )
+
+    html_body = next(
+        alt.content
+        for alt in mail.outbox[0].alternatives
+        if alt.mimetype == "text/html"
+    )
+    assert "A user has asked to link author@example.com" in html_body

--- a/libraries/tests/test_v3_commit_email_views.py
+++ b/libraries/tests/test_v3_commit_email_views.py
@@ -104,7 +104,7 @@ def test_v3_commit_email_verification_email_names_the_requester(user, tp, mailou
             tp.reverse("v3-commit-author-email-create"),
             data={"commit_email": commit_author_email.email},
         )
-    assert "The user Requesting User has asked to link" in mailoutbox[0].body
+    assert "Requesting User has asked to link" in mailoutbox[0].body
 
 
 def test_v3_commit_email_create_htmx_returns_updated_card(user, tp):

--- a/mailing_list/tests/test_confirmation_email.py
+++ b/mailing_list/tests/test_confirmation_email.py
@@ -1,0 +1,54 @@
+"""The subscription confirmation email itself.
+
+The view tests mock _send_confirmation_email away, so this is where the
+rendered message is checked.
+"""
+
+import re
+
+import pytest
+from django.core import mail
+
+from mailing_list.constants import MAILMAN_LISTS
+from mailing_list.views import _send_confirmation_email
+
+pytestmark = pytest.mark.django_db
+
+
+def _send(rf):
+    request = rf.get("/", HTTP_HOST="testserver")
+    _send_confirmation_email(request, "subscriber@example.com", None, MAILMAN_LISTS[:2])
+    return mail.outbox[0]
+
+
+def test_confirmation_email_is_branded_multipart(rf):
+    msg = _send(rf)
+
+    assert msg.subject == "Confirm your Boost mailing list subscription"
+    assert msg.recipients() == ["subscriber@example.com"]
+
+    html_body = next(
+        alt.content for alt in msg.alternatives if alt.mimetype == "text/html"
+    )
+    assert "Confirm your subscription" in html_body
+    assert "Confirm my subscription" in html_body
+
+
+def test_confirmation_link_is_absolute_and_in_both_bodies(rf):
+    msg = _send(rf)
+    html_body = next(
+        alt.content for alt in msg.alternatives if alt.mimetype == "text/html"
+    )
+
+    confirm_urls = {
+        href
+        for href in re.findall(r'href="([^"]*)"', html_body)
+        if "/mailing-list/confirm/" in href
+    }
+    assert len(confirm_urls) == 1
+    confirm_url = confirm_urls.pop()
+    assert confirm_url.startswith("http://testserver/")
+    assert confirm_url in msg.body
+
+    for href in re.findall(r'href="([^"]*)"', html_body):
+        assert href.startswith(("http://", "https://", "mailto:")), href

--- a/mailing_list/views.py
+++ b/mailing_list/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core import signing
 from django.core.cache import cache
-from django.core.mail import send_mail
+from django.core.mail import EmailMultiAlternatives
 from django.db import IntegrityError, transaction
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
@@ -148,22 +148,25 @@ def _send_confirmation_email(
             lists.append(entry)
         else:
             lists.append({"name": lid, "address": lid, "description": None})
-    message = render_to_string(
-        "v3/mailing_list/email/confirm_subscription.txt",
-        {
-            "email": email,
-            "lists": lists,
-            "confirm_url": confirm_url,
-            "expiry_label": _format_duration(_CONFIRM_MAX_AGE),
-        },
-    )
-    send_mail(
-        subject="Confirm your Boost mailing list subscription",
-        message=message,
+    context = {
+        "email": email,
+        "lists": lists,
+        # The branded base template drives its CTA and fallback URL off
+        # action_url, and resolves images and the logo link from scheme/host.
+        "action_url": confirm_url,
+        "expiry_label": _format_duration(_CONFIRM_MAX_AGE),
+        "scheme": request.scheme,
+        "host": request.get_host(),
+    }
+    prefix = "v3/mailing_list/email/confirm_subscription"
+    msg = EmailMultiAlternatives(
+        subject=render_to_string(f"{prefix}_subject.txt", context).strip(),
+        body=render_to_string(f"{prefix}.txt", context),
         from_email=settings.DEFAULT_FROM_EMAIL,
-        recipient_list=[email],
-        fail_silently=False,
+        to=[email],
     )
+    msg.attach_alternative(render_to_string(f"{prefix}.html", context), "text/html")
+    msg.send(fail_silently=False)
 
 
 """

--- a/news/notifications.py
+++ b/news/notifications.py
@@ -1,15 +1,8 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.mail import (
-    EmailMessage,
-    get_connection,
-    send_mail,
-    EmailMultiAlternatives,
-)
-from django.template import Template, Context
+from django.core.mail import EmailMultiAlternatives, get_connection
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils.safestring import mark_safe
 from itsdangerous.url_safe import URLSafeTimedSerializer
 
 from .acl import moderators
@@ -18,32 +11,44 @@ from .constants import NEWS_APPROVAL_SALT, MAGIC_LINK_EXPIRATION
 User = get_user_model()
 
 
+def _base_context(request):
+    """Context every news notification email needs.
+
+    scheme/host resolve the branded template's images and logo link;
+    preferences_url drives the footer's opt-out sentence, which the base
+    template omits when it is absent.
+    """
+    return {
+        "scheme": request.scheme,
+        "host": request.get_host(),
+        "preferences_url": request.build_absolute_uri(reverse("profile-account")),
+    }
+
+
+def _render_message(name, context, to):
+    subject = render_to_string(f"news/emails/{name}_subject.txt", context).strip()
+    msg = EmailMultiAlternatives(
+        subject=subject,
+        body=render_to_string(f"news/emails/{name}.txt", context),
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        to=to,
+    )
+    msg.attach_alternative(
+        render_to_string(f"news/emails/{name}.html", context), "text/html"
+    )
+    return msg
+
+
 def send_email_news_approved(request, entry):
     if entry.tag not in entry.author.preferences.allow_notification_own_news_approved:
         return False
 
-    template = Template(
-        'Congratulations! The news entry "{{ title }}" that you submitted on '
-        '{{ entry.created_at|date:"M jS, Y" }} was approved.\n'
-        "You can view this news at {{ url }}.\n\n"
-        "Thank you, the Boost moderator team."
-    )
-    body = template.render(
-        Context(
-            {
-                "entry": entry,
-                "url": request.build_absolute_uri(entry.get_absolute_url()),
-                "title": mark_safe(entry.title),  # Mark the title as safe
-            }
-        )
-    )
-    subject = "Boost.org: News entry approved"
-    return send_mail(
-        subject=subject,
-        message=body,
-        from_email=None,
-        recipient_list=[entry.author.email],
-    )
+    context = {
+        **_base_context(request),
+        "entry": entry,
+        "action_url": request.build_absolute_uri(entry.get_absolute_url()),
+    }
+    return _render_message("approved", context, [entry.author.email]).send()
 
 
 def generate_magic_approval_link(entry_slug: str, moderator_id: int):
@@ -67,30 +72,22 @@ def send_email_news_needs_moderation(request, entry):
         return False
 
     context = {
+        **_base_context(request),
         "entry": entry,
         "detail_url": request.build_absolute_uri(entry.get_absolute_url()),
         "moderate_url": request.build_absolute_uri(reverse("news-moderate")),
         "expiration_hours": int(MAGIC_LINK_EXPIRATION / 3600),
-        "scheme": request.scheme,
-        "host": request.get_host(),
     }
 
-    subject = "Boost.org: News entry needs moderation"
-    from_address = settings.DEFAULT_FROM_EMAIL
-    # Send each recipient their own email
+    # Each moderator gets their own message: the approval link is minted per
+    # moderator so an approval is attributable.
     messages = []
     for moderator in recipient_list:
         magic_link_url = generate_magic_approval_link(
             entry_slug=entry.slug, moderator_id=moderator.id
         )
         context["approval_magic_link"] = request.build_absolute_uri(magic_link_url)
-        text_body = render_to_string("news/emails/needs_moderation.txt", context)
-        html_body = render_to_string("news/emails/needs_moderation.html", context)
-        msg = EmailMultiAlternatives(
-            subject, text_body, from_address, [moderator.email]
-        )
-        msg.attach_alternative(html_body, "text/html")
-        messages.append(msg)
+        messages.append(_render_message("needs_moderation", context, [moderator.email]))
     get_connection().send_messages(messages)
     return len(messages)
 
@@ -107,34 +104,13 @@ def send_email_news_posted(request, entry):
     if not recipient_list:
         return False
 
-    template = Template(
-        "Hello! A news entry was just posted:\n\n"
-        "{{ title }}\n\n"
-        "You can view this news at: {{ detail_url }}.\n\n"
-        "If you no longer wish to receive these emails, please review your "
-        "notifications preferences at {{ preferences_url }}.\n\n"
-        "Thank you, the Boost news team."
-    )
-    body = template.render(
-        Context(
-            {
-                "entry": entry,
-                "detail_url": request.build_absolute_uri(entry.get_absolute_url()),
-                "preferences_url": request.build_absolute_uri(
-                    reverse("profile-account")
-                ),
-                "title": mark_safe(entry.title),
-            }
-        )
-    )
-    subject = "Boost.org: News entry posted"
+    context = {
+        **_base_context(request),
+        "entry": entry,
+        "action_url": request.build_absolute_uri(entry.get_absolute_url()),
+    }
     messages = [
-        EmailMessage(
-            subject=subject,
-            body=body,
-            from_email=None,
-            to=[user_email],
-        )
+        _render_message("posted", context, [user_email])
         for user_email in recipient_list
     ]
     return get_connection().send_messages(messages)

--- a/news/tests/test_notifications.py
+++ b/news/tests/test_notifications.py
@@ -1,3 +1,4 @@
+import re
 from datetime import date
 
 import pytest
@@ -224,3 +225,45 @@ def test_send_email_news_posted_many_users(rf, tp, make_entry, make_user, model_
         # do not share all emails among all recipients
         assert msg.to == [f"u{usr_num}@example.com"]
         assert msg.recipients() == [f"u{usr_num}@example.com"]
+
+
+def _html_of(msg):
+    return next(alt.content for alt in msg.alternatives if alt.mimetype == "text/html")
+
+
+@pytest.mark.parametrize(
+    "sender,marker",
+    [
+        (send_email_news_approved, "Your post was approved"),
+        (send_email_news_posted, "New on Boost"),
+        (send_email_news_needs_moderation, "A post needs moderation"),
+    ],
+)
+def test_notification_emails_are_branded_multipart(
+    rf, tp, make_entry, sender, marker, make_user
+):
+    """Every news notification goes out as text + the branded HTML alternative,
+    with the entry link and the preferences footer resolving absolutely."""
+    entry = make_entry(NEWS_MODELS[0], approved=True)
+    if sender is send_email_news_needs_moderation:
+        make_user(is_staff=True, is_superuser=True)
+    elif sender is send_email_news_posted:
+        make_user(
+            email="subscriber@example.com",
+            allow_notification_others_news_posted=[entry.tag],
+        )
+
+    request = rf.get("")
+    sender(request, entry)
+
+    assert mail.outbox
+    msg = mail.outbox[0]
+    html_body = _html_of(msg)
+    assert marker in html_body
+    assert entry.title in msg.body
+
+    # The footer's opt-out link, and every other link, must be clickable from
+    # an inbox that has no page to resolve a relative path against.
+    for href in re.findall(r'href="([^"]*)"', html_body):
+        assert href.startswith(("http://", "https://", "mailto:")), href
+    assert request.build_absolute_uri(reverse("profile-account")) in html_body

--- a/pages/signals.py
+++ b/pages/signals.py
@@ -1,10 +1,11 @@
 """Signal wiring for `pages`. Imported from `PagesConfig.ready()`."""
 
 from django.dispatch import receiver
-from wagtail.signals import page_published
+from wagtail.signals import page_published, workflow_approved
 
 from pages.models import PostPage
 from pages.notifications import record_published_post
+from pages.tasks import send_post_approved_email
 
 
 @receiver(page_published, sender=PostPage, dispatch_uid="post_notification_published")
@@ -22,3 +23,24 @@ def raise_post_notification(sender, instance, **kwargs):
     if instance.first_published_at != instance.last_published_at:
         return
     record_published_post(instance.pk)
+
+
+@receiver(workflow_approved)
+def notify_post_author_on_approval(sender, instance, user, **kwargs):
+    """Email a PostPage's author once its moderation workflow fully approves.
+
+    `workflow_approved` fires once per workflow (not per task), so a
+    multi-stage moderation chain still only sends one email, matching the
+    legacy news.Entry behavior of a single "approved" notice.
+    """
+    page = instance.content_object
+    if not isinstance(page, PostPage):
+        page = getattr(page, "specific", None)
+    if not isinstance(page, PostPage):
+        return
+
+    author = page.author
+    if not author or not author.email:
+        return
+
+    send_post_approved_email.delay(page.pk)

--- a/pages/tasks.py
+++ b/pages/tasks.py
@@ -5,9 +5,13 @@ command on a worker instead of holding the request open.
 """
 
 import logging
+from urllib.parse import urlsplit
 
 from celery import shared_task
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
 from django.core.management import call_command
+from django.template.loader import render_to_string
 
 logger = logging.getLogger(__name__)
 
@@ -33,3 +37,35 @@ def update_index_task():
     and its command is a no-op that exits successfully.
     """
     call_command("wagtail_update_index")
+
+
+@shared_task
+def send_post_approved_email(page_id):
+    """Tell a PostPage's author their post cleared moderation and is live.
+
+    Fired from pages.signals in response to Wagtail's `workflow_approved`
+    signal, which carries no request, so scheme/host come from the page's own
+    absolute URL instead. Takes an id rather than the page itself since
+    Celery arguments must serialize to JSON; the page is refetched fresh on
+    the worker.
+    """
+    from pages.models import PostPage
+
+    page = PostPage.objects.get(pk=page_id)
+    action_url = page.get_full_url()
+    parts = urlsplit(action_url)
+    context = {
+        "page": page,
+        "action_url": action_url,
+        "scheme": parts.scheme,
+        "host": parts.netloc,
+    }
+    prefix = "v3/pages/email/post_approved"
+    msg = EmailMultiAlternatives(
+        subject=render_to_string(f"{prefix}_subject.txt", context).strip(),
+        body=render_to_string(f"{prefix}.txt", context),
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        to=[page.author.email],
+    )
+    msg.attach_alternative(render_to_string(f"{prefix}.html", context), "text/html")
+    msg.send(fail_silently=False)

--- a/pages/tests/test_signals.py
+++ b/pages/tests/test_signals.py
@@ -1,0 +1,51 @@
+"""Notifying a PostPage's author once Wagtail's moderation workflow approves it."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from wagtail.signals import workflow_approved
+
+from pages.signals import notify_post_author_on_approval
+
+
+@pytest.mark.django_db
+def test_workflow_approved_emails_the_post_author(user, wagtail_site, make_post_page):
+    page = make_post_page(owner=user)
+
+    with patch("pages.signals.send_post_approved_email.delay") as delay:
+        workflow_approved.send(
+            sender=object(),
+            instance=SimpleNamespace(content_object=page),
+            user=user,
+        )
+
+    delay.assert_called_once_with(page.pk)
+
+
+@pytest.mark.django_db
+def test_workflow_approved_ignores_non_post_page_content(user):
+    with patch("pages.signals.send_post_approved_email.delay") as delay:
+        workflow_approved.send(
+            sender=object(),
+            instance=SimpleNamespace(content_object=SimpleNamespace()),
+            user=user,
+        )
+
+    delay.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_workflow_approved_skips_author_with_no_email(wagtail_site, make_post_page):
+    author = SimpleNamespace(email="", display_name="No Email")
+    page = make_post_page()
+    page.author = author
+
+    with patch("pages.signals.send_post_approved_email.delay") as delay:
+        notify_post_author_on_approval(
+            sender=object(),
+            instance=SimpleNamespace(content_object=page),
+            user=None,
+        )
+
+    delay.assert_not_called()

--- a/pages/tests/test_tasks.py
+++ b/pages/tests/test_tasks.py
@@ -1,0 +1,54 @@
+"""The post-approved email, sent from pages.signals via a Celery task."""
+
+import re
+
+import pytest
+from django.core import mail
+from model_bakery import baker
+
+from pages.tasks import send_post_approved_email
+
+
+@pytest.mark.django_db
+def test_post_approved_email_is_branded_multipart(user, wagtail_site, make_post_page):
+    page = make_post_page(
+        title="Boost 1.90.0 has been released",
+        owner=user,
+        summary="A summary of the release.",
+    )
+
+    send_post_approved_email(page.pk)
+
+    msg = mail.outbox[0]
+    assert msg.subject == "Boost.org: Post approved"
+    assert msg.recipients() == [user.email]
+
+    html_body = next(
+        alt.content for alt in msg.alternatives if alt.mimetype == "text/html"
+    )
+    assert f"Hi {user.display_name}" in html_body
+    assert page.title in html_body
+    assert "A summary of the release." in html_body
+    action_url = page.get_full_url()
+    assert action_url in html_body
+    assert action_url in msg.body
+
+    for href in re.findall(r'href="([^"]*)"', html_body):
+        assert href.startswith(("http://", "https://", "mailto:")), href
+
+
+@pytest.mark.django_db
+def test_post_approved_email_falls_back_when_display_name_is_blank(
+    wagtail_site, make_post_page
+):
+    author = baker.make("users.User", email="anon@example.com", display_name="")
+    page = make_post_page(owner=author)
+
+    send_post_approved_email(page.pk)
+
+    html_body = next(
+        alt.content
+        for alt in mail.outbox[0].alternatives
+        if alt.mimetype == "text/html"
+    )
+    assert "Hi there" in html_body

--- a/templates/account/email/email_confirmation_message.html
+++ b/templates/account/email/email_confirmation_message.html
@@ -1,0 +1,1 @@
+{% extends "emails/confirm_email.html" %}

--- a/templates/account/email/email_confirmation_message.txt
+++ b/templates/account/email/email_confirmation_message.txt
@@ -1,0 +1,1 @@
+{% include "emails/confirm_email.txt" %}

--- a/templates/account/email/email_confirmation_signup_message.html
+++ b/templates/account/email/email_confirmation_signup_message.html
@@ -1,0 +1,1 @@
+{% extends "emails/confirm_email.html" %}

--- a/templates/account/email/email_confirmation_signup_message.txt
+++ b/templates/account/email/email_confirmation_signup_message.txt
@@ -1,0 +1,1 @@
+{% include "emails/confirm_email.txt" %}

--- a/templates/account/email/email_confirmation_signup_subject.txt
+++ b/templates/account/email/email_confirmation_signup_subject.txt
@@ -1,0 +1,1 @@
+{% include "emails/confirm_email_subject.txt" %}

--- a/templates/account/email/email_confirmation_subject.txt
+++ b/templates/account/email/email_confirmation_subject.txt
@@ -1,0 +1,1 @@
+{% include "emails/confirm_email_subject.txt" %}

--- a/templates/emails/_cta_button.html
+++ b/templates/emails/_cta_button.html
@@ -1,0 +1,11 @@
+{% comment %}
+  Primary CTA button. Include with `url` and `label`; pass secondary=True for
+  the outlined variant used by emails carrying more than one action.
+{% endcomment %}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:16px 0 0 0;">
+  <tr>
+    <td {% if secondary %}bgcolor="#ffffff" style="border-radius:4px;border:1px solid #e2e2e4;"{% else %}bgcolor="#ffa000" style="border-radius:4px;"{% endif %} align="center">
+      <a href="{{ url }}" style="display:block;padding:12px 24px;font-family:Arial,Helvetica,sans-serif;font-size:12px;font-weight:bold;line-height:1.5;letter-spacing:-0.24px;color:#050816;text-decoration:none;border-radius:4px;">{{ label }}</a>
+    </td>
+  </tr>
+</table>

--- a/templates/emails/_fallback_url.html
+++ b/templates/emails/_fallback_url.html
@@ -1,0 +1,8 @@
+{% comment %}
+  Plain-text copy of a CTA target, for clients that strip or mangle buttons.
+  Include with `url`, and optionally `intro` to override the lead-in line.
+{% endcomment %}
+<div style="font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:12px;line-height:1.45;color:#71737b;margin:16px 0 0 0;">
+  {{ intro|default:"Or copy and paste this URL into your browser:" }}<br>
+  <a href="{{ url }}" style="color:#71737b;text-decoration:underline;word-break:break-all;">{{ url }}</a>
+</div>

--- a/templates/emails/base_email.html
+++ b/templates/emails/base_email.html
@@ -8,15 +8,18 @@
     scheme            "https" (request.scheme)
     host              "www.boost.org" (request.get_host)
     action_url        the CTA + fallback URL (confirmation or reset link)
-    preferences_url   manage-email-preferences URL (optional, defaults to #)
-    unsubscribe_url   unsubscribe URL (optional, defaults to #)
+    preferences_url   notification-preferences URL; the footer sentence
+                      offering it is omitted when this is absent, so
+                      one-off transactional emails render without it
 
   Body copy uses the platform UI font stack (Segoe UI on Windows, San Francisco
   on Apple, Roboto on Android) at a light 300 weight; the title, button and
   footer use Arial.
 
   Child templates override the blocks: preheader, hero, card_title,
-  card_body, cta_label and after_card.
+  card_body, cta_label and after_card. Emails that need more than one CTA, or
+  none, override cta instead of cta_label and compose the _cta_button.html /
+  _fallback_url.html partials themselves.
 {% endcomment %}<!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
   <head>
@@ -84,19 +87,18 @@
                       <div style="font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:14px;line-height:1.45;color:#050816;">
                         {% block card_body %}{% endblock %}
                       </div>
-                      <!-- CTA button -->
-                      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:16px 0 0 0;">
-                        <tr>
-                          <td bgcolor="#ffa000" align="center" style="border-radius:4px;">
-                            <a href="{{ action_url|default:'#' }}" style="display:block;padding:12px 24px;font-family:Arial,Helvetica,sans-serif;font-size:12px;font-weight:bold;line-height:1.5;letter-spacing:-0.24px;color:#050816;text-decoration:none;border-radius:4px;">{% block cta_label %}{% endblock %}</a>
-                          </td>
-                        </tr>
-                      </table>
-                      <!-- Fallback URL -->
-                      <div style="font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:12px;line-height:1.45;color:#71737b;margin:16px 0 0 0;">
-                        Or copy and paste this URL into your browser:<br>
-                        <a href="{{ action_url|default:'#' }}" style="color:#71737b;text-decoration:underline;word-break:break-all;">{{ action_url|default:'#' }}</a>
-                      </div>
+                      {% block cta %}
+                        <!-- CTA button -->
+                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:16px 0 0 0;">
+                          <tr>
+                            <td bgcolor="#ffa000" align="center" style="border-radius:4px;">
+                              <a href="{{ action_url }}" style="display:block;padding:12px 24px;font-family:Arial,Helvetica,sans-serif;font-size:12px;font-weight:bold;line-height:1.5;letter-spacing:-0.24px;color:#050816;text-decoration:none;border-radius:4px;">{% block cta_label %}{% endblock %}</a>
+                            </td>
+                          </tr>
+                        </table>
+                        <!-- Fallback URL -->
+                        {% include "emails/_fallback_url.html" with url=action_url %}
+                      {% endblock %}
                     </td>
                   </tr>
                 </table>
@@ -129,9 +131,11 @@
                 <div style="font-family:Arial,Helvetica,sans-serif;font-size:14px;line-height:1.45;letter-spacing:0.14px;color:#050816;">
                   <a href="https://www.boost.org/" style="color:#050816;text-decoration:underline;">Boost.org</a> is supported by grants from <a href="https://cppalliance.org/" style="color:#050816;text-decoration:underline;">The C++ Alliance.</a>
                   {% block footer_links %}
-                    <br><br>
-                    Want to change how you receive these emails?<br>
-                    You can <a href="{{ preferences_url|default:'#' }}" style="color:#050816;text-decoration:underline;">update your preferences</a> or <a href="{{ unsubscribe_url|default:'#' }}" style="color:#050816;text-decoration:underline;">unsubscribe from this list</a>.
+                    {% if preferences_url %}
+                      <br><br>
+                      Want to change how you receive these emails?<br>
+                      You can <a href="{{ preferences_url }}" style="color:#050816;text-decoration:underline;">update your notification preferences</a>.
+                    {% endif %}
                   {% endblock %}
                 </div>
               </td>

--- a/templates/emails/confirm_email.txt
+++ b/templates/emails/confirm_email.txt
@@ -14,6 +14,3 @@ If you didn't create a Boost account, you can safely ignore this email.
 
 --
 Boost.org is supported by grants from The C++ Alliance.
-
-Want to change how you receive these emails?
-You can update your preferences or unsubscribe from this list.

--- a/templates/emails/password_reset.txt
+++ b/templates/emails/password_reset.txt
@@ -15,6 +15,3 @@ ignore this email safely - your password will stay the same.
 
 --
 Boost.org is supported by grants from The C++ Alliance.
-
-Want to change how you receive these emails?
-You can update your preferences or unsubscribe from this list.

--- a/templates/news/emails/_entry_preview.html
+++ b/templates/news/emails/_entry_preview.html
@@ -1,0 +1,18 @@
+{% comment %}
+  Quoted preview of a news entry, for the notification emails. Include with
+  `entry`; the excerpt is capped so a long post does not fill the inbox.
+{% endcomment %}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:16px 0 0 0;background-color:#f7fdfe;border-left:3px solid #ffa000;">
+  <tr>
+    <td style="padding:16px;">
+      <div style="font-family:Arial,Helvetica,sans-serif;font-size:16px;line-height:1.3;letter-spacing:-0.16px;color:#050816;">
+        {{ entry.title }}
+      </div>
+      {% if entry.content %}
+        <div style="font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:14px;line-height:1.45;color:#71737b;margin:8px 0 0 0;">
+          {{ entry.content|striptags|truncatewords:50 }}
+        </div>
+      {% endif %}
+    </td>
+  </tr>
+</table>

--- a/templates/news/emails/approved.html
+++ b/templates/news/emails/approved.html
@@ -1,0 +1,31 @@
+{% extends "emails/base_email.html" %}
+
+{% comment %}
+  Sent to a news author when a moderator approves their entry.
+  Context: entry, action_url (the entry's public URL), preferences_url,
+  scheme, host.
+{% endcomment %}
+
+{% block title %}Your post was approved{% endblock %}
+
+{% block preheader %}{{ entry.title }} is approved and live on Boost.{% endblock %}
+
+{% block card_title %}Your post was approved{% endblock %}
+
+{% block card_body %}
+  <p style="margin:0;">Hi {{ entry.author.display_name|default:"there" }},</p>
+  <p style="margin:14px 0 0 0;">Congratulations! The {{ entry.tag }} entry you submitted on {{ entry.created_at|date:"M jS, Y" }} has been approved and is now live.</p>
+  {% include "news/emails/_entry_preview.html" %}
+{% endblock %}
+
+{% block cta_label %}View your post{% endblock %}
+
+{% block after_card %}
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td style="padding:24px 0 0 0;font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:12px;line-height:1.45;color:#71737b;text-align:center;">
+        Thank you, the Boost moderator team.
+      </td>
+    </tr>
+  </table>
+{% endblock %}

--- a/templates/news/emails/approved.txt
+++ b/templates/news/emails/approved.txt
@@ -1,0 +1,24 @@
+{% autoescape off %}Your post was approved
+
+Hi {{ entry.author.display_name|default:"there" }},
+
+Congratulations! The {{ entry.tag }} entry you submitted on
+{{ entry.created_at|date:"M jS, Y" }} has been approved and is now live.
+
+------------------------------------------------------------
+{{ entry.title }}
+
+{{ entry.content|striptags|truncatewords:50 }}
+------------------------------------------------------------
+
+View your post:
+{{ action_url }}
+
+Thank you, the Boost moderator team.
+
+--
+Boost.org is supported by grants from The C++ Alliance.
+{% if preferences_url %}
+Want to change how you receive these emails?
+Update your notification preferences: {{ preferences_url }}
+{% endif %}{% endautoescape %}

--- a/templates/news/emails/approved_subject.txt
+++ b/templates/news/emails/approved_subject.txt
@@ -1,0 +1,1 @@
+Boost.org: News entry approved

--- a/templates/news/emails/needs_moderation.html
+++ b/templates/news/emails/needs_moderation.html
@@ -1,228 +1,37 @@
-{% load static %}
-{% load humanize %}
+{% extends "emails/base_email.html" %}
 
-<html>
-  <head>
-    <!-- Compiled with Bootstrap Email version: 1.3.1 -->
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <meta name="x-apple-disable-message-reformatting">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="format-detection" content="telephone=no, date=no, address=no, email=no">
-    <style type="text/css">
-      body,table,td{font-family:Helvetica,Arial,sans-serif !important}.ExternalClass{width:100%}.ExternalClass,.ExternalClass p,.ExternalClass span,.ExternalClass font,.ExternalClass td,.ExternalClass div{line-height:150%}a{text-decoration:none}*{color:inherit}a[x-apple-data-detectors],u+#body a,#MessageViewBody a{color:inherit;text-decoration:none;font-size:inherit;font-family:inherit;font-weight:inherit;line-height:inherit}img{-ms-interpolation-mode:bicubic}table:not([class^=s-]){font-family:Helvetica,Arial,sans-serif;mso-table-lspace:0pt;mso-table-rspace:0pt;border-spacing:0px;border-collapse:collapse}table:not([class^=s-]) td{border-spacing:0px;border-collapse:collapse}@media screen and (max-width: 600px){.w-full,.w-full>tbody>tr>td{width:100% !important}.w-24,.w-24>tbody>tr>td{width:96px !important}.w-40,.w-40>tbody>tr>td{width:160px !important}.p-lg-10:not(table),.p-lg-10:not(.btn)>tbody>tr>td,.p-lg-10.btn td a{padding:0 !important}.p-3:not(table),.p-3:not(.btn)>tbody>tr>td,.p-3.btn td a{padding:12px !important}.p-6:not(table),.p-6:not(.btn)>tbody>tr>td,.p-6.btn td a{padding:24px !important}*[class*=s-lg-]>tbody>tr>td{font-size:0 !important;line-height:0 !important;height:0 !important}.s-4>tbody>tr>td{font-size:16px !important;line-height:16px !important;height:16px !important}.s-6>tbody>tr>td{font-size:24px !important;line-height:24px !important;height:24px !important}.s-10>tbody>tr>td{font-size:40px !important;line-height:40px !important;height:40px !important}}
-    </style>
-  </head>
-  <body class="bg-light" style="outline: 0; width: 100%; min-width: 100%; height: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-family: Helvetica, Arial, sans-serif; line-height: 24px; font-weight: normal; font-size: 16px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; color: #000000; margin: 0; padding: 0; border-width: 0;" bgcolor="#f7fafc">
-    <table class="bg-light body" valign="top" role="presentation" border="0" cellpadding="0" cellspacing="0" style="outline: 0; width: 100%; min-width: 100%; height: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-family: Helvetica, Arial, sans-serif; line-height: 24px; font-weight: normal; font-size: 16px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; color: #000000; margin: 0; padding: 0; border-width: 0;" bgcolor="#f7fafc">
-      <tbody>
-        <tr>
-          <td valign="top" style="line-height: 24px; font-size: 16px; margin: 0;" align="left" bgcolor="#f7fafc">
-            <table class="container" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;">
-              <tbody>
-                <tr>
-                  <td align="center" style="line-height: 24px; font-size: 16px; margin: 0; padding: 0 16px;">
-                    <!--[if (gte mso 9)|(IE)]>
-                      <table align="center" role="presentation">
-                        <tbody>
-                          <tr>
-                            <td width="600">
-                    <![endif]-->
-                    <table align="center" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%; max-width: 600px; margin: 0 auto;">
-                      <tbody>
-                        <tr>
-                          <td style="line-height: 24px; font-size: 16px; margin: 0;" align="left">
-                            <table class="s-10 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 40px; font-size: 40px; width: 100%; height: 40px; margin: 0;" align="left" width="100%" height="40">
-                                    &nbsp;
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            <table class="ax-center" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 24px; font-size: 16px; margin: 0;" align="left">
-                                    <img class="w-24" src="{{ scheme }}://{{ host }}{% static 'img/boost-logo.png' %}" style="height: auto; line-height: 100%; outline: none; text-decoration: none; display: block; width: 96px; border-style: none; border-width: 0;" width="96">
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            <table class="s-10 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 40px; font-size: 40px; width: 100%; height: 40px; margin: 0;" align="left" width="100%" height="40">
-                                    &nbsp;
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            <div>
-                              <h2 style="padding-top: 0; padding-bottom: 0; font-weight: 800 !important; vertical-align: baseline; font-size: 24px; line-height: 36px; margin: 0;" align="left">
-                                Boost.org news entry awaiting moderation
-                              </h2>
-                              <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                                <tbody>
-                                  <tr>
-                                    <td style="line-height: 16px; font-size: 16px; width: 100%; height: 16px; margin: 0;" align="left" width="100%" height="16">
-                                      &nbsp;
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </table>
-                              <p class="" style="line-height: 24px; font-size: 16px; width: 100%; margin: 0;" align="left">
-                                Hello! You are receiving this email because you are a Boost news moderator. <br/>
-                                The user <strong>{{ entry.author.display_name|default:entry.author.email }}</strong> has submitted a new {{ entry.tag }} that requires moderation:
-                              </p>
-                            </div>
+{% comment %}
+  Sent to every news moderator when an entry is submitted.
+  Context: entry, approval_magic_link, detail_url, moderate_url,
+  expiration_hours, preferences_url, scheme, host.
+{% endcomment %}
 
-                            {# Entry preview #}
-                            <table class="s-10 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 40px; font-size: 40px; width: 100%; height: 40px; margin: 0;" align="left" width="100%" height="40">
-                                    &nbsp;
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            <table class="card p-6 p-lg-10 space-y-4" role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-radius: 6px; border-collapse: separate !important; width: 100%; overflow: hidden; border: 1px solid #e2e8f0;" bgcolor="#ffffff">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 24px; font-size: 16px; width: 100%; margin: 0; padding: 40px;" align="left" bgcolor="#ffffff">
-                                    <h1 class="h3 fw-700" style="padding-top: 0; padding-bottom: 0; font-weight: 700 !important; vertical-align: baseline; font-size: 28px; line-height: 33.6px; margin: 0;" align="left">
-                                      {{ entry.title }}
-                                    </h1>
-                                    <table class="s-4 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                                      <tbody>
-                                        <tr>
-                                          <td style="line-height: 16px; font-size: 16px; width: 100%; height: 16px; margin: 0;" align="left" width="100%" height="16">
-                                            &nbsp;
-                                          </td>
-                                        </tr>
-                                      </tbody>
-                                    </table>
-                                    <p class="" style="line-height: 24px; font-size: 16px; width: 100%; margin: 0;" align="left">
-                                      {{ entry.content|linebreaksbr }}
-                                    </p>
-                                    <table class="s-4 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                                      <tbody>
-                                        <tr>
-                                          <td style="line-height: 16px; font-size: 16px; width: 100%; height: 16px; margin: 0;" align="left" width="100%" height="16">
-                                            &nbsp;
-                                          </td>
-                                        </tr>
-                                      </tbody>
-                                    </table>
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            {# End Entry Preview #}
+{% block title %}News entry needs moderation{% endblock %}
 
-                            <table class="s-10 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 40px; font-size: 40px; width: 100%; height: 40px; margin: 0;" align="left" width="100%" height="40">
-                                    &nbsp;
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            <div style="color: #383c45;">
-                              You can instantly approve this entry without logging in by clicking the button below. This link will expire in
-                              {{ expiration_hours }} hour{{ expiration_hours|pluralize }}. <br/>
-                            </div>
-                            <table class="w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 20px; font-size: 20px; width: 100%; height: 20px; margin: 0;" align="left" width="100%" height="20">
-                                    &nbsp;
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            <table class="btn btn-primary p-3 fw-700" role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-radius: 6px; border-collapse: separate !important; font-weight: 700 !important;">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 24px; font-size: 16px; border-radius: 6px; font-weight: 700 !important; margin: 0;" align="center" bgcolor="#0d6efd">
-                                    <a href="{{ approval_magic_link }}" style="color: #ffffff; font-size: 16px; font-family: Helvetica, Arial, sans-serif; text-decoration: none; border-radius: 6px; line-height: 20px; display: block; font-weight: 700 !important; white-space: nowrap; background-color: orange; padding: 12px;">
-                                      Approve Now
-                                    </a>
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            <table class="s-6 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 24px; font-size: 24px; width: 100%; height: 24px; margin: 0;" align="left" width="100%" height="24">
-                                    &nbsp;
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            <div class="text-muted" style="color: #718096;">
-                              You can also <a style="color:#1A01CC;text-decoration:underline;" href="{{ detail_url }}">view, approve, or delete this item here</a>. <br/>
-                              The complete list of news pending moderation <a style="color:#1A01CC;text-decoration:underline;" href="{{ moderate_url }}">can be found here</a>. <br/><br/>
-                              Thank you, the Boost moderator team. <br/>
-                            </div>
-                            <table class="s-6 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 24px; font-size: 24px; width: 100%; height: 24px; margin: 0;" align="left" width="100%" height="24">
-                                    &nbsp;
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            <table class="s-6 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 24px; font-size: 24px; width: 100%; height: 24px; margin: 0;" align="left" width="100%" height="24">
-                                    &nbsp;
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            <table class="s-6 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 24px; font-size: 24px; width: 100%; height: 24px; margin: 0;" align="left" width="100%" height="24">
-                                    &nbsp;
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                            <table class="s-6 w-full" role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
-                              <tbody>
-                                <tr>
-                                  <td style="line-height: 24px; font-size: 24px; width: 100%; height: 24px; margin: 0;" align="left" width="100%" height="24">
-                                    &nbsp;
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                          </td>
-                        </tr>
-                      </tbody>
-                    </table>
-                    <!--[if (gte mso 9)|(IE)]>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-                    <![endif]-->
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+{% block preheader %}{{ entry.author.display_name|default:entry.author.email }} submitted a {{ entry.tag }} entry for review.{% endblock %}
 
+{% block card_title %}A post needs moderation{% endblock %}
 
-</body></html>
+{% block card_body %}
+  <p style="margin:0;">You&#39;re receiving this because you moderate Boost news.</p>
+  <p style="margin:14px 0 0 0;">{{ entry.author.display_name|default:entry.author.email }} submitted a new {{ entry.tag }} entry for review.</p>
+  {% include "news/emails/_entry_preview.html" %}
+  <p style="margin:14px 0 0 0;">Approving from the button below doesn&#39;t require signing in. That link expires in {{ expiration_hours }} hour{{ expiration_hours|pluralize }}.</p>
+{% endblock %}
+
+{% block cta %}
+  {% include "emails/_cta_button.html" with url=approval_magic_link label="Approve now" %}
+  {% include "emails/_cta_button.html" with url=detail_url label="View, approve or delete" secondary=True %}
+  {% include "emails/_cta_button.html" with url=moderate_url label="See everything pending" secondary=True %}
+  {% include "emails/_fallback_url.html" with url=approval_magic_link intro="Or copy and paste this approval URL into your browser:" %}
+{% endblock %}
+
+{% block after_card %}
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td style="padding:24px 0 0 0;font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:12px;line-height:1.45;color:#71737b;text-align:center;">
+        Thank you, the Boost moderator team.
+      </td>
+    </tr>
+  </table>
+{% endblock %}

--- a/templates/news/emails/needs_moderation.txt
+++ b/templates/news/emails/needs_moderation.txt
@@ -1,24 +1,32 @@
-{% load humanize %}
+{% autoescape off %}A post needs moderation
 
-Hello! You are receiving this email because you are a Boost news moderator.
+You're receiving this because you moderate Boost news.
 
-The user {{ entry.author.display_name|default:entry.author.email }} has submitted a new {{ entry.tag }} that requires moderation:
+{{ entry.author.display_name|default:entry.author.email }} submitted a new {{ entry.tag }} entry for review:
 
----
-{% autoescape off %}
+------------------------------------------------------------
 {{ entry.title }}
 
-{{ entry.content }}
-{% endautoescape %}
----
+{{ entry.content|striptags|truncatewords:50 }}
+------------------------------------------------------------
 
-You can instantly approve this entry without logging in by using the link below.
-This link will expire in {{ expiration_hours }} hour{{ expiration_hours|pluralize }}.
+Approving from the link below doesn't require signing in. It expires in
+{{ expiration_hours }} hour{{ expiration_hours|pluralize }}.
 
+Approve now:
 {{ approval_magic_link }}
 
-You can also view, approve or delete this item at: {{ detail_url }}
+View, approve or delete this post:
+{{ detail_url }}
 
-The complete list of news pending moderation can be found at: {{ moderate_url }}
+See everything pending moderation:
+{{ moderate_url }}
 
 Thank you, the Boost moderator team.
+
+--
+Boost.org is supported by grants from The C++ Alliance.
+{% if preferences_url %}
+Want to change how you receive these emails?
+Update your notification preferences: {{ preferences_url }}
+{% endif %}{% endautoescape %}

--- a/templates/news/emails/needs_moderation_subject.txt
+++ b/templates/news/emails/needs_moderation_subject.txt
@@ -1,0 +1,1 @@
+Boost.org: News entry needs moderation

--- a/templates/news/emails/posted.html
+++ b/templates/news/emails/posted.html
@@ -1,0 +1,30 @@
+{% extends "emails/base_email.html" %}
+
+{% comment %}
+  Sent to everyone who opted in to notifications for newly posted entries.
+  Context: entry, action_url (the entry's public URL), preferences_url,
+  scheme, host.
+{% endcomment %}
+
+{% block title %}New on Boost{% endblock %}
+
+{% block preheader %}{{ entry.title }} was just posted on Boost.{% endblock %}
+
+{% block card_title %}New on Boost{% endblock %}
+
+{% block card_body %}
+  <p style="margin:0;">A new {{ entry.tag }} entry was just posted.</p>
+  {% include "news/emails/_entry_preview.html" %}
+{% endblock %}
+
+{% block cta_label %}Read the post{% endblock %}
+
+{% block after_card %}
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td style="padding:24px 0 0 0;font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:12px;line-height:1.45;color:#71737b;text-align:center;">
+        Thank you, the Boost news team.
+      </td>
+    </tr>
+  </table>
+{% endblock %}

--- a/templates/news/emails/posted.txt
+++ b/templates/news/emails/posted.txt
@@ -1,0 +1,21 @@
+{% autoescape off %}New on Boost
+
+A new {{ entry.tag }} entry was just posted.
+
+------------------------------------------------------------
+{{ entry.title }}
+
+{{ entry.content|striptags|truncatewords:50 }}
+------------------------------------------------------------
+
+Read the post:
+{{ action_url }}
+
+Thank you, the Boost news team.
+
+--
+Boost.org is supported by grants from The C++ Alliance.
+{% if preferences_url %}
+Want to change how you receive these emails?
+Update your notification preferences: {{ preferences_url }}
+{% endif %}{% endautoescape %}

--- a/templates/news/emails/posted_subject.txt
+++ b/templates/news/emails/posted_subject.txt
@@ -1,0 +1,1 @@
+Boost.org: News entry posted

--- a/templates/v3/libraries/email/verify_commit_email.html
+++ b/templates/v3/libraries/email/verify_commit_email.html
@@ -1,0 +1,31 @@
+{% extends "emails/base_email.html" %}
+
+{% comment %}
+  Sent to a commit address when someone asks to link it to their Boost account.
+  Context: email, requester (display name, may be blank), action_url
+  (confirm_url), expiry_label, scheme, host.
+{% endcomment %}
+
+{% block title %}Confirm your commit email address{% endblock %}
+
+{% block preheader %}Confirm linking {{ email }} and its commit history to a Boost account.{% endblock %}
+
+{% block card_title %}Confirm your commit email{% endblock %}
+
+{% block card_body %}
+  <p style="margin:0;">{% if requester %}{{ requester }} has{% else %}A user has{% endif %} asked to link {{ email }}, and its commit history, to their boost.org account.</p>
+  <p style="margin:14px 0 0 0;">To confirm, sign in to that account first, then use the button below and the confirmation button on the page it opens.</p>
+  <p style="margin:14px 0 0 0;">The link only works while signed in to the account that requested it, and expires in {{ expiry_label }}.</p>
+{% endblock %}
+
+{% block cta_label %}Confirm this email{% endblock %}
+
+{% block after_card %}
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td style="padding:24px 0 0 0;font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:12px;line-height:1.45;color:#71737b;text-align:center;">
+        If you didn&#39;t request this, you can safely ignore this email &mdash; nothing will be linked.
+      </td>
+    </tr>
+  </table>
+{% endblock %}

--- a/templates/v3/libraries/email/verify_commit_email.txt
+++ b/templates/v3/libraries/email/verify_commit_email.txt
@@ -1,11 +1,18 @@
-Hi,
+Confirm your commit email
 
-{% if requester %}The user {{ requester }} has{% else %}A user has{% endif %} asked to link {{ email }} and its commit history to their boost.org account.
+{% if requester %}{{ requester }} has{% else %}A user has{% endif %} asked to link {{ email }}, and its commit
+history, to their boost.org account.
 
-To confirm, sign in to that boost.org account, then open the link below and use the confirmation button there:
+To confirm, sign in to that boost.org account, then open the link below and
+use the confirmation button there:
 
-  {{ confirm_url }}
+{{ action_url }}
 
-The link only works while signed in to the account that requested it. It expires in {{ expiry_label }}.
+The link only works while signed in to the account that requested it.
+It expires in {{ expiry_label }}.
 
-If you did not request this, you can safely ignore this email - nothing will be linked.
+If you didn't request this, you can safely ignore this email - nothing will
+be linked.
+
+--
+Boost.org is supported by grants from The C++ Alliance.

--- a/templates/v3/libraries/email/verify_commit_email_subject.txt
+++ b/templates/v3/libraries/email/verify_commit_email_subject.txt
@@ -1,0 +1,1 @@
+Confirm your commit email address

--- a/templates/v3/mailing_list/email/confirm_subscription.html
+++ b/templates/v3/mailing_list/email/confirm_subscription.html
@@ -1,0 +1,49 @@
+{% extends "emails/base_email.html" %}
+
+{% comment %}
+  Mailing list subscription confirmation (double opt-in).
+  Context: email, lists (name/address/description dicts), action_url
+  (confirm_url), expiry_label, scheme, host.
+{% endcomment %}
+
+{% block title %}Confirm your mailing list subscription{% endblock %}
+
+{% block preheader %}Confirm {{ email }} to finish subscribing to the Boost mailing list{{ lists|length|pluralize }}.{% endblock %}
+
+{% block card_title %}Confirm your subscription{% endblock %}
+
+{% block card_body %}
+  <p style="margin:0;">You asked to subscribe {{ email }} to the following Boost mailing list{{ lists|length|pluralize }}:</p>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:16px 0 0 0;background-color:#f7fdfe;border-left:3px solid #ffa000;">
+    <tr>
+      <td style="padding:16px;">
+        {% for item in lists %}
+          <div style="font-family:Arial,Helvetica,sans-serif;font-size:16px;line-height:1.3;letter-spacing:-0.16px;color:#050816;{% if not forloop.first %}margin-top:16px;{% endif %}">
+            {{ item.name }}
+          </div>
+          <div style="font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:12px;line-height:1.45;color:#71737b;margin:2px 0 0 0;">
+            {{ item.address }}
+          </div>
+          {% if item.description %}
+            <div style="font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:14px;line-height:1.45;color:#050816;margin:6px 0 0 0;">
+              {{ item.description }}
+            </div>
+          {% endif %}
+        {% endfor %}
+      </td>
+    </tr>
+  </table>
+  <p style="margin:14px 0 0 0;">This link expires in {{ expiry_label }}.</p>
+{% endblock %}
+
+{% block cta_label %}Confirm my subscription{% endblock %}
+
+{% block after_card %}
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td style="padding:24px 0 0 0;font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:12px;line-height:1.45;color:#71737b;text-align:center;">
+        If you didn&#39;t request this, you can safely ignore this email &mdash; nothing will be subscribed.
+      </td>
+    </tr>
+  </table>
+{% endblock %}

--- a/templates/v3/mailing_list/email/confirm_subscription.txt
+++ b/templates/v3/mailing_list/email/confirm_subscription.txt
@@ -1,17 +1,21 @@
-Hi,
+Confirm your subscription
 
-You requested to subscribe {{ email }} to the following Boost mailing list{{ lists|length|pluralize }}:
+You asked to subscribe {{ email }} to the following Boost mailing list{{ lists|length|pluralize }}:
 {% for item in lists %}
 ------------------------------------------------------------
-{{ item.name }} — {{ item.address }}
+{{ item.name }} - {{ item.address }}
 {% if item.description %}
 {{ item.description }}
 {% endif %}{% endfor %}------------------------------------------------------------
 
-To confirm your subscription, click the link below:
+To confirm your subscription, visit the link below:
 
-  {{ confirm_url }}
+{{ action_url }}
 
 This link expires in {{ expiry_label }}.
 
-If you did not request this, you can safely ignore this email.
+If you didn't request this, you can safely ignore this email - nothing will
+be subscribed.
+
+--
+Boost.org is supported by grants from The C++ Alliance.

--- a/templates/v3/mailing_list/email/confirm_subscription_subject.txt
+++ b/templates/v3/mailing_list/email/confirm_subscription_subject.txt
@@ -1,0 +1,1 @@
+Confirm your Boost mailing list subscription

--- a/templates/v3/pages/email/_post_preview.html
+++ b/templates/v3/pages/email/_post_preview.html
@@ -1,0 +1,20 @@
+{% comment %}
+  Quoted preview of a PostPage, for its notification emails. Include with
+  `page`; mirrors news/emails/_entry_preview.html's design, but sources its
+  excerpt from `search_body` since `page.content` is a StreamField rather
+  than plain text.
+{% endcomment %}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:16px 0 0 0;background-color:#f7fdfe;border-left:3px solid #ffa000;">
+  <tr>
+    <td style="padding:16px;">
+      <div style="font-family:Arial,Helvetica,sans-serif;font-size:16px;line-height:1.3;letter-spacing:-0.16px;color:#050816;">
+        {{ page.title }}
+      </div>
+      {% if page.summary or page.search_body %}
+        <div style="font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:14px;line-height:1.45;color:#71737b;margin:8px 0 0 0;">
+          {{ page.summary|default:page.search_body|truncatewords:50 }}
+        </div>
+      {% endif %}
+    </td>
+  </tr>
+</table>

--- a/templates/v3/pages/email/post_approved.html
+++ b/templates/v3/pages/email/post_approved.html
@@ -1,0 +1,33 @@
+{% extends "emails/base_email.html" %}
+
+{% comment %}
+  Sent to a PostPage's author when a moderator approves it through Wagtail's
+  moderation workflow (wagtail.signals.workflow_approved, see pages/signals.py).
+  Mirrors news/emails/approved.html's design and copy -- the equivalent
+  notice for the legacy news.Entry flow -- adapted to PostPage's fields.
+  Context: page, action_url, scheme, host.
+{% endcomment %}
+
+{% block title %}Your post was approved{% endblock %}
+
+{% block preheader %}{{ page.title }} is approved and live on Boost.{% endblock %}
+
+{% block card_title %}Your post was approved{% endblock %}
+
+{% block card_body %}
+  <p style="margin:0;">Hi {{ page.author.display_name|default:"there" }},</p>
+  <p style="margin:14px 0 0 0;">Congratulations! The {{ page.post_content_type|lower }} you submitted on {{ page.created_at|date:"M jS, Y" }} has been approved and is now live.</p>
+  {% include "v3/pages/email/_post_preview.html" %}
+{% endblock %}
+
+{% block cta_label %}View your post{% endblock %}
+
+{% block after_card %}
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td style="padding:24px 0 0 0;font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif;font-weight:300;font-size:12px;line-height:1.45;color:#71737b;text-align:center;">
+        Thank you, the Boost moderator team.
+      </td>
+    </tr>
+  </table>
+{% endblock %}

--- a/templates/v3/pages/email/post_approved.txt
+++ b/templates/v3/pages/email/post_approved.txt
@@ -1,0 +1,21 @@
+{% autoescape off %}Your post was approved
+
+Hi {{ page.author.display_name|default:"there" }},
+
+Congratulations! The {{ page.post_content_type|lower }} you submitted on
+{{ page.created_at|date:"M jS, Y" }} has been approved and is now live.
+
+------------------------------------------------------------
+{{ page.title }}
+
+{{ page.summary|default:page.search_body|truncatewords:50 }}
+------------------------------------------------------------
+
+View your post:
+{{ action_url }}
+
+Thank you, the Boost moderator team.
+
+--
+Boost.org is supported by grants from The C++ Alliance.
+{% endautoescape %}

--- a/templates/v3/pages/email/post_approved_subject.txt
+++ b/templates/v3/pages/email/post_approved_subject.txt
@@ -1,0 +1,1 @@
+Boost.org: Post approved

--- a/users/account_adapters.py
+++ b/users/account_adapters.py
@@ -4,6 +4,7 @@
 from datetime import timedelta
 from urllib.parse import quote, urlsplit
 
+from allauth.account import app_settings as allauth_account_settings
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.utils import build_absolute_uri
 from django.conf import settings
@@ -103,6 +104,25 @@ class AccountAdapter(DefaultAccountAdapter):
         parts = urlsplit(build_absolute_uri(self.request, "/"))
         context.setdefault("scheme", parts.scheme)
         context.setdefault("host", parts.netloc)
+        if template_prefix.startswith("account/email/email_confirmation"):
+            # allauth names the confirmation link activate_url; the branded
+            # template drives its CTA and fallback URL off action_url.
+            context.setdefault("action_url", context.get("activate_url"))
+            # Signup collects display_name, not first_name, so the greeting
+            # falls back to it before going anonymous.
+            user = context.get("user")
+            context.setdefault(
+                "first_name",
+                getattr(user, "first_name", "") or getattr(user, "display_name", ""),
+            )
+            context.setdefault(
+                "confirmation_link_lifetime",
+                humanize_link_lifetime(
+                    timedelta(
+                        days=allauth_account_settings.EMAIL_CONFIRMATION_EXPIRE_DAYS
+                    )
+                ),
+            )
         if template_prefix == "account/email/unknown_account":
             # Sent when a password reset is requested for an address with no
             # account; the call site only provides a signup URL, so point the

--- a/users/management/commands/send_test_emails.py
+++ b/users/management/commands/send_test_emails.py
@@ -30,7 +30,8 @@ that provider has verified.
 
 import re
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from email.message import EmailMessage as PyEmailMessage
 from email.mime.image import MIMEImage
 
@@ -43,33 +44,137 @@ from django.template.loader import render_to_string
 
 from users.utils import humanize_link_lifetime
 
-# Available templates: key -> subject / text / html templates + a sample link.
+SAMPLE_ENTRY = SimpleNamespace(
+    title="Boost 1.90.0 has been released",
+    content=(
+        "This release adds two new libraries and includes fixes across the "
+        "collection. See the release notes for the full list of changes, "
+        "acknowledgements and known issues."
+    ),
+    tag="news",
+    slug="boost-1-90-0-has-been-released",
+    created_at=datetime(2026, 8, 12, tzinfo=timezone.utc),
+    author=SimpleNamespace(display_name="Vinnie Falco", email="vinnie@example.com"),
+)
+
+SAMPLE_LISTS = [
+    {
+        "name": "Boost Users",
+        "address": "boost-users@lists.boost.org",
+        "description": "Questions and discussion about using the Boost libraries.",
+    },
+    {
+        "name": "Boost Developers",
+        "address": "boost@lists.boost.org",
+        "description": "Development of the Boost libraries themselves.",
+    },
+]
+
+# Available templates: key -> template prefix, a sample CTA link and any
+# context the template needs beyond the shared base below.
 TEMPLATES = {
     "confirm": {
-        "subject": "emails/confirm_email_subject.txt",
-        "text": "emails/confirm_email.txt",
-        "html": "emails/confirm_email.html",
+        "prefix": "emails/confirm_email",
         "action_url": "https://www.boost.org/auth/confirm?token=test-confirm-token-abc123",
     },
     "password_reset": {
-        "subject": "emails/password_reset_subject.txt",
-        "text": "emails/password_reset.txt",
-        "html": "emails/password_reset.html",
+        "prefix": "emails/password_reset",
         "action_url": "https://www.boost.org/auth/reset?token=test-reset-token-xyz789",
     },
     "unknown_account": {
-        "subject": "emails/unknown_account_subject.txt",
-        "text": "emails/unknown_account.txt",
-        "html": "emails/unknown_account.html",
+        "prefix": "emails/unknown_account",
         "action_url": "https://www.boost.org/v3/accounts/signup/",
     },
     "account_deletion_scheduled": {
-        "subject": "emails/account_deletion_scheduled_subject.txt",
-        "text": "emails/account_deletion_scheduled.txt",
-        "html": "emails/account_deletion_scheduled.html",
+        "prefix": "emails/account_deletion_scheduled",
         "action_url": "https://www.boost.org/accounts/login/",
     },
+    "news_needs_moderation": {
+        "prefix": "news/emails/needs_moderation",
+        "action_url": "https://www.boost.org/news/magic-approve/test-token-abc123/",
+        "context": {
+            "entry": SAMPLE_ENTRY,
+            "approval_magic_link": (
+                "https://www.boost.org/news/magic-approve/test-token-abc123/"
+            ),
+            "detail_url": (
+                "https://www.boost.org/news/boost-1-90-0-has-been-released/"
+            ),
+            "moderate_url": "https://www.boost.org/news/moderate/",
+            "expiration_hours": 24,
+            "with_preferences": True,
+        },
+    },
+    "news_approved": {
+        "prefix": "news/emails/approved",
+        "action_url": "https://www.boost.org/news/boost-1-90-0-has-been-released/",
+        "context": {"entry": SAMPLE_ENTRY, "with_preferences": True},
+    },
+    "news_posted": {
+        "prefix": "news/emails/posted",
+        "action_url": "https://www.boost.org/news/boost-1-90-0-has-been-released/",
+        "context": {"entry": SAMPLE_ENTRY, "with_preferences": True},
+    },
+    "mailing_list_confirm": {
+        "prefix": "v3/mailing_list/email/confirm_subscription",
+        "action_url": "https://www.boost.org/mailing-list/confirm/test-token-abc123/",
+        "context": {"lists": SAMPLE_LISTS, "expiry_label": "7\u00a0days"},
+    },
+    "verify_commit_email": {
+        "prefix": "v3/libraries/email/verify_commit_email",
+        "action_url": "https://www.boost.org/libraries/commit-email/confirm/test-token/",
+        "context": {"requester": "Vinnie Falco", "expiry_label": "7\u00a0days"},
+    },
 }
+
+
+def build_context(key, base_url, first_name="Vinnie", email="you@example.com"):
+    """Sample context for one template, matching what the real flow passes."""
+    scheme, _, host = base_url.partition("://")
+    if not host:  # base_url given without a scheme
+        scheme, host = "https", base_url
+
+    spec = TEMPLATES[key]
+    extra = dict(spec.get("context", {}))
+    # Only the notification emails carry the footer's preferences link; the
+    # base template omits that sentence without it.
+    preferences_url = (
+        f"{base_url}/users/me/" if extra.pop("with_preferences", False) else ""
+    )
+    return {
+        "scheme": scheme,
+        "host": host,
+        "first_name": first_name,
+        "user_email": email,
+        "email": email,
+        "action_url": spec["action_url"],
+        "preferences_url": preferences_url,
+        # Account-deletion-scheduled email context.
+        "grace_days": settings.ACCOUNT_DELETION_GRACE_PERIOD_DAYS,
+        "postorius_url": settings.POSTORIUS_URL,
+        # Link lifetimes shown in the email bodies, sourced from the same
+        # settings the real flows enforce (allauth email confirmation in days,
+        # Django's password reset token timeout in seconds).
+        "confirmation_link_lifetime": humanize_link_lifetime(
+            timedelta(days=allauth_account_settings.EMAIL_CONFIRMATION_EXPIRE_DAYS)
+        ),
+        "password_reset_link_lifetime": humanize_link_lifetime(
+            timedelta(seconds=settings.PASSWORD_RESET_TIMEOUT)
+        ),
+        **extra,
+    }
+
+
+def render_template(key, base_url="https://www.boost.org", **kwargs):
+    """Render one template's subject, text and HTML bodies."""
+    context = build_context(key, base_url, **kwargs)
+    prefix = TEMPLATES[key]["prefix"]
+    return (
+        render_to_string(f"{prefix}_subject.txt", context).strip(),
+        render_to_string(f"{prefix}.txt", context),
+        render_to_string(f"{prefix}.html", context),
+    )
+
 
 # Matches the URL of any email image, e.g. src="/static/static-large/img/emails/x.png"
 # (local dev) or the absolute S3 URL (prod) -- both end in "img/emails/<file>".
@@ -212,10 +317,6 @@ def command(
     delay,
 ):
     """Render and send the transactional email templates."""
-    scheme, _, host = base_url.partition("://")
-    if not host:  # base_url given without a scheme
-        scheme, host = "https", base_url
-
     # Use the project's configured email backend -- the same one the real
     # transactional emails go through (local maildev SMTP, or the deployed
     # email service provider).
@@ -233,32 +334,12 @@ def command(
     for index, key in enumerate(keys):
         if index and delay:
             time.sleep(delay)
-        spec = TEMPLATES[key]
-        context = {
-            "scheme": scheme,
-            "host": host,
-            "first_name": first_name,
-            "user_email": user_email or recipient,
-            "email": user_email or recipient,
-            "action_url": spec["action_url"],
-            "preferences_url": f"{base_url}/account/preferences",
-            "unsubscribe_url": f"{base_url}/account/unsubscribe",
-            # Account-deletion-scheduled email context.
-            "grace_days": settings.ACCOUNT_DELETION_GRACE_PERIOD_DAYS,
-            "postorius_url": settings.POSTORIUS_URL,
-            # Link lifetimes shown in the email bodies, sourced from the same
-            # settings the real flows enforce (allauth email confirmation in
-            # days, Django's password reset token timeout in seconds).
-            "confirmation_link_lifetime": humanize_link_lifetime(
-                timedelta(days=allauth_account_settings.EMAIL_CONFIRMATION_EXPIRE_DAYS)
-            ),
-            "password_reset_link_lifetime": humanize_link_lifetime(
-                timedelta(seconds=settings.PASSWORD_RESET_TIMEOUT)
-            ),
-        }
-        subject = render_to_string(spec["subject"], context).strip()
-        text_body = render_to_string(spec["text"], context)
-        html_body = render_to_string(spec["html"], context)
+        subject, text_body, html_body = render_template(
+            key,
+            base_url=base_url,
+            first_name=first_name,
+            email=user_email or recipient,
+        )
 
         if inline_images:
             _send_inline(

--- a/users/management/commands/send_test_emails.py
+++ b/users/management/commands/send_test_emails.py
@@ -57,6 +57,18 @@ SAMPLE_ENTRY = SimpleNamespace(
     author=SimpleNamespace(display_name="Vinnie Falco", email="vinnie@example.com"),
 )
 
+SAMPLE_POST_PAGE = SimpleNamespace(
+    title="Boost 1.90.0 has been released",
+    summary=(
+        "This release adds two new libraries and includes fixes across the "
+        "collection."
+    ),
+    search_body="",
+    post_content_type="News",
+    created_at=datetime(2026, 8, 12, tzinfo=timezone.utc),
+    author=SimpleNamespace(display_name="Vinnie Falco", email="vinnie@example.com"),
+)
+
 SAMPLE_LISTS = [
     {
         "name": "Boost Users",
@@ -124,6 +136,11 @@ TEMPLATES = {
         "prefix": "v3/libraries/email/verify_commit_email",
         "action_url": "https://www.boost.org/libraries/commit-email/confirm/test-token/",
         "context": {"requester": "Vinnie Falco", "expiry_label": "7\u00a0days"},
+    },
+    "post_approved": {
+        "prefix": "v3/pages/email/post_approved",
+        "action_url": "https://www.boost.org/news/boost-1-90-0-has-been-released/",
+        "context": {"page": SAMPLE_POST_PAGE},
     },
 }
 

--- a/users/tests/test_email_templates.py
+++ b/users/tests/test_email_templates.py
@@ -1,0 +1,59 @@
+"""Rendering guards shared by every branded transactional email.
+
+The per-flow tests live with the app that sends the email; these check the
+templates themselves, so a template that stops resolving its CTA or leaks an
+unrendered tag fails here rather than in an inbox.
+"""
+
+import re
+
+import pytest
+
+from users.management.commands.send_test_emails import TEMPLATES, render_template
+
+BASE_URL = "https://www.boost.org"
+
+
+@pytest.mark.parametrize("key", sorted(TEMPLATES))
+def test_template_renders_without_leftover_tags(key):
+    subject, text_body, html_body = render_template(key, base_url=BASE_URL)
+
+    assert subject
+    for body in (subject, text_body, html_body):
+        assert "{{" not in body
+        assert "{%" not in body
+
+
+@pytest.mark.parametrize("key", sorted(TEMPLATES))
+def test_every_link_is_absolute(key):
+    """No CTA may fall back to a placeholder or a root-relative path: an email
+    client has no page to resolve those against."""
+    _, _, html_body = render_template(key, base_url=BASE_URL)
+
+    hrefs = re.findall(r'href="([^"]*)"', html_body)
+    assert hrefs
+    for href in hrefs:
+        assert href.startswith(("http://", "https://", "mailto:")), href
+
+
+@pytest.mark.parametrize("key", sorted(TEMPLATES))
+def test_cta_url_reaches_both_bodies(key):
+    """The button URL has to appear in the plain-text part too, for clients
+    that never render the HTML alternative."""
+    action_url = TEMPLATES[key]["action_url"]
+    _, text_body, html_body = render_template(key, base_url=BASE_URL)
+
+    assert action_url in text_body
+    assert action_url in html_body
+
+
+@pytest.mark.parametrize("key", sorted(TEMPLATES))
+def test_preferences_link_only_where_it_applies(key):
+    """The footer's opt-out sentence belongs on the notification emails, not on
+    the one-off transactional ones the recipient cannot unsubscribe from."""
+    expected = bool(TEMPLATES[key].get("context", {}).get("with_preferences"))
+    _, text_body, html_body = render_template(key, base_url=BASE_URL)
+
+    footer_sentence = "Want to change how you receive these emails?"
+    assert (footer_sentence in html_body) is expected
+    assert (footer_sentence in text_body) is expected

--- a/users/tests/test_signup.py
+++ b/users/tests/test_signup.py
@@ -1,5 +1,9 @@
 import pytest
 import waffle.testutils
+from allauth.account.models import EmailConfirmationHMAC
+from django.contrib.sites.models import Site
+from django.core import mail
+from django.urls import reverse
 from model_bakery import baker
 
 from users.forms import (
@@ -19,6 +23,12 @@ SIGNUP_DATA = {
     "display_name": "Signup Tester",
     "accept_terms_of_use": "on",
 }
+
+
+@pytest.fixture(autouse=True)
+def _disable_account_rate_limits(settings):
+    """Avoid 429s from allauth's per-email rate limit across test runs."""
+    settings.ACCOUNT_RATE_LIMITS = False
 
 
 @waffle.testutils.override_flag("v3", active=True)
@@ -134,3 +144,29 @@ def test_a_name_accepted_at_signup_can_be_saved_on_the_edit_form(tp):
 
     user.refresh_from_db()
     assert str(user.country) == "US"
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_signup_sends_the_branded_confirmation_email(tp):
+    """Signing up has to send the V3 confirmation template, not allauth's
+    default one, with a link the recipient can actually click."""
+    tp.post("account_signup", data=SIGNUP_DATA)
+
+    assert len(mail.outbox) == 1
+    msg = mail.outbox[0]
+    site_name = Site.objects.get_current().name
+    assert msg.subject == f"[{site_name}] Confirm your email"
+    assert msg.recipients() == [SIGNUP_DATA["email"]]
+
+    html_body = next(
+        alt.content for alt in msg.alternatives if alt.mimetype == "text/html"
+    )
+    assert "Welcome to Boost" in html_body
+    assert f"Hi {SIGNUP_DATA['display_name']}," in html_body
+    user = User.objects.get(email=SIGNUP_DATA["email"])
+    confirmation = EmailConfirmationHMAC(user.emailaddress_set.get())
+    activate_path = reverse("account_confirm_email", args=[confirmation.key]).rsplit(
+        "/", 2
+    )[0]
+    assert activate_path in msg.body
+    assert activate_path in html_body


### PR DESCRIPTION
# Issue: #2531

## Summary & Context
Seven of the eight emails in the scope list were still legacy: two were built by inline `Template(...)` strings in Python, three were plain-text-only sends, one was a Bootstrap-Email export, and the V3 sign-up confirmation template existed but was never wired to allauth. This rebuilds them all on `emails/base_email.html` from #2479 and wires the confirmation.

Figma link: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1828-48034

Each section below is self-contained: includes its own changes, screenshots and test steps, per email.

This sends all emails programatically:

```bash
docker compose exec -T web python manage.py send_test_emails --to qa@example.com
```

That command inlines the images in the email body, so MailDev shows them correctly. Emails sent by the actual flows (interacting with the site) show broken images locally instead, which is expected rather than a regression: `{% large_static %}` returns a relative `/static/...` path when `LOCAL_DEVELOPMENT` is on and an absolute S3 URL otherwise. Use the command (or ask me to use it and send it to your mail address) to check the visuals, and the real flows to validate the wiring.

## Changes

### Base template
The CTA is now an overridable `{% block cta %}`, so an email can carry more than one action (post moderation has three) or none. The default block is byte-identical to what shipped, so the already-approved confirmation and password-reset emails did not move.

Extracted `_cta_button.html` (primary and outlined variants) and `_fallback_url.html` for emails that compose their own actions.

Removed the footer's `unsubscribe from this list` link, which pointed at `#` because there is no unsubscribe endpoint in the codebase (worth building as its own feature). `update your preferences` now points to the profile page and renders **only** for the emails whose recipient can act on it, which is the three news notifications. The same dead prose was still sitting in the shipped `.txt` bodies and is gone too.

---

### 1. Sign Up Confirmation
This is the one the ticket flagged as not wired. Added `account/email/email_confirmation{,_signup}_{message.html,message.txt,subject.txt}` as thin extends of the existing V3 templates, so allauth picks them up for both the signup send and the resend-on-unverified-login path.

`AccountAdapter.send_mail` now supplies `action_url`, `first_name` and the link lifetime, mirroring what it already did for password reset. The greeting falls back to `display_name`, since signup collects that rather than `first_name`.

<details>
<summary>Screenshot Desktop</summary>

<img width="1280" height="963" alt="2531-01-signup-confirmation-desktop" src="https://github.com/user-attachments/assets/9b17c685-a622-437c-9371-9b365c0b2853" />

</details>

<details>
<summary>Screenshot Mobile</summary>

<img width="390" height="900" alt="2531-01-signup-confirmation-mobile" src="https://github.com/user-attachments/assets/7b0659a8-834b-4f43-975a-c034d9062429" />

</details>

<details>
<summary>Test instructions</summary>

1. Sign up at http://localhost:8000/accounts/signup/ with a fresh address.
2. MailDev receives `[<site name>] Confirm your email`. allauth prefixes the subject with the site name, as it does for every account email, so that prefix is expected.
3. The greeting should show the username you typed, not "Hi there".
4. Click **Confirm my email**. It should land on the confirmation page and verify the address.
5. The footer should show no preferences link, since the recipient has no account to manage yet.
</details>

---

### 2. Password Reset
No design change: this one shipped in #2479 and is already on the V3 base. It is included here because it inherits the footer change above, so it is worth a look to confirm nothing regressed.

<details>
<summary>Screenshot Desktop</summary>

<img width="1280" height="1006" alt="2531-02-password-reset-desktop" src="https://github.com/user-attachments/assets/e7a25f2b-179d-490c-a517-79539ec38b13" />

</details>

<details>
<summary>Screenshot Mobile</summary>

<img width="390" height="943" alt="2531-02-password-reset-mobile" src="https://github.com/user-attachments/assets/21beb329-95ed-40b3-a6c1-efdc1c665250" />

</details>

<details>
<summary>Test instructions</summary>

1. Request a reset at http://localhost:8000/accounts/password/reset/ for an existing account.
2. Subject should be `[<site name>] Password reset link`.
3. The CTA should open the V3 reset form and let you set a new password.
4. The footer should show no preferences link, and no unsubscribe link in either the HTML or the plain-text part.
</details>

---

### 3. Post Moderation Notice
Was a Bootstrap-Email export on the old design; rebuilt on the base template. This is the email that motivated making the CTA a block: it carries three actions (Approve now, View/approve/delete, See everything pending) where the base template assumes one.

Added a shared `_entry_preview.html` partial and capped the excerpt, so a long post no longer fills the inbox.

<details>
<summary>Screenshot Desktop</summary>

<img width="1280" height="938" alt="2531-05-post-moderation-desktop" src="https://github.com/user-attachments/assets/4ed11b02-b978-4c51-b254-87c57281e478" />


</details>

<details>
<summary>Screenshot Mobile</summary>

<img width="390" height="1016" alt="2531-05-post-moderation-mobile" src="https://github.com/user-attachments/assets/c2dd3879-d828-49a5-9450-4918ad767cab" />

</details>

<details>
<summary>Test instructions</summary>

Needs a moderator account and a normal user.

1. Submit a news entry as the normal user.
2. Moderators receive `Boost.org: News entry needs moderation`.
3. The entry preview should show the title and a truncated excerpt, not the whole post.
4. All three CTAs should work. **Approve now** in particular should approve the entry *without* signing in, since it is a magic link.
5. The footer's **update your notification preferences** link should open the profile page.
</details>

---

### 4. Post Approval Notice
`send_email_news_approved` built its body from an inline `Template(...)` string and sent text-only. It now renders real templates and sends multipart, via a shared `_render_message` helper.

<details>
<summary>Screenshot Desktop</summary>
<img width="1280" height="900" alt="2531-06-post-approval-desktop" src="https://github.com/user-attachments/assets/a093732e-5f38-4bfa-b1d2-d8d49b62e058" />
</details>


<details>
<summary>Screenshot Mobile</summary>
<img width="390" height="900" alt="2531-06-post-approval-mobile" src="https://github.com/user-attachments/assets/6a151cd8-b43f-41dc-99a2-4bac3e16711b" />
</details>

<details>
<summary>Test instructions</summary>

1. Approve the entry submitted in the previous step.
2. The author receives `Boost.org: News entry approved`.
3. The CTA should open the now-published entry.
4. The footer's **update your notification preferences** link should open the profile page.
</details>

---

### 5. Post Published Notice
Same story as the approval notice: inline `Template(...)` string, text-only, now real templates and multipart through the same helper. The bulk send path (one message per recipient via `send_messages`) is unchanged.

<details>
<summary>Screenshot Desktop</summary>
<img width="1280" height="900" alt="2531-07-post-published-desktop" src="https://github.com/user-attachments/assets/aef0fad3-0b87-44a5-8a17-17c12914968a" />
</details>

<details>
<summary>Screenshot Mobile</summary>
<img width="390" height="900" alt="2531-07-post-published-mobile" src="https://github.com/user-attachments/assets/a6c06bcc-700e-43f5-a362-bab1a2808557" />
</details>

<details>
<summary>Test instructions</summary>

1. With a second account that opted into posted-entry notifications, publish an entry.
2. That account receives `Boost.org: News entry posted`.
3. The CTA should open the entry.
4. The footer's **update your notification preferences** link should open the profile page.
</details>

---

### 6. Mailing List Subscription
Was `send_mail` text-only; now multipart with a branded HTML sibling.

<details>
<summary>Screenshot Desktop</summary>
<img width="1280" height="900" alt="2531-08-mailing-list-desktop" src="https://github.com/user-attachments/assets/6546eec2-3fab-4ccc-a34a-71f7aac6b848" />
</details>

<details>
<summary>Screenshot Mobile</summary>
<img width="390" height="900" alt="2531-08-mailing-list-mobile" src="https://github.com/user-attachments/assets/a1a7b5e3-e272-4ee4-a9e9-de37100a76cb" />
</details>

<details>
<summary>Test instructions</summary>

1. Subscribe an address from any mailing-list card on the homepage.
2. Subject is `Confirm your Boost mailing list subscription`.
3. The body should list every list you checked, each with its address and description. Check more than one to confirm the list renders repeated entries correctly.
4. The CTA should confirm the subscription.
5. The footer should show no preferences link: an anonymous subscriber has no profile to send them to.
</details>

---

### 7. Commit Author Confirmation
It was text-only before. This send happens in a Celery task with no request, so scheme and host are derived from the claim URL rather than adding a task argument.

<details>
<summary>Screenshot Desktop</summary>
<img width="1280" height="900" alt="2531-09-commit-author-desktop" src="https://github.com/user-attachments/assets/2c4a7657-2b77-4968-9964-f4ab14891b31" />
</details>

<details>
<summary>Screenshot Mobile</summary>
<img width="390" height="900" alt="2531-09-commit-author-mobile" src="https://github.com/user-attachments/assets/3581a6f7-ba83-4992-8652-c784ba03993e" />

</details>

<details>
<summary>Test instructions</summary>

1. From your profile's commit-emails card, claim an unverified commit address.
2. Subject is `Confirm your commit email address`.
3. With a display name set, the body reads "&lt;name&gt; has asked to link...".
4. With no display name, it must fall back to "A user has asked to link..." and **must not** show the claimant's account email.
5. The CTA should only work while signed in as the account that requested the claim.
</details>

---

### 8. Account Deletion
Deliberately unchanged. `account_deletion_scheduled` already shipped on the V3 base in #2537, so there was nothing to rebuild. Evidence is included so the set is complete and so we can confirm the footer change did not regress it.

There is a second, unbuilt account-deletion email. See Risks below.

<details>
<summary>Screenshot Desktop</summary>
<img width="1280" height="940" alt="2531-04-account-deletion-scheduled-desktop" src="https://github.com/user-attachments/assets/5ec81362-a8de-4595-a754-2d54334e9f0a" />
</details>

<details>
<summary>Screenshot Mobile</summary>
<img width="390" height="1050" alt="2531-04-account-deletion-scheduled-mobile" src="https://github.com/user-attachments/assets/3428600c-69ec-432f-ad0f-a68178e0c5bb" />
</details>

<details>
<summary>Test instructions</summary>

1. Schedule an account for deletion from the profile page.
2. Subject is `Your account is scheduled for deletion`.
3. The CTA should open the login page, which is how a user cancels the deletion.
4. This template overrides the footer block entirely, so confirm it still shows no preferences link.
</details>

---

### Bonus: Unknown Account
Not in the ticket's scope list, but it shares the base template and so inherits the footer change. Included for completeness.

<details>
<summary>Screenshot Desktop</summary>
<img width="1280" height="900" alt="2531-03-unknown-account-desktop" src="https://github.com/user-attachments/assets/cd91ea20-cbba-4f35-b3bc-f576bb8fba1a" />
</details>

<details>
<summary>Screenshot Mobile</summary>
<img width="390" height="900" alt="2531-03-unknown-account-mobile" src="https://github.com/user-attachments/assets/4b500b14-a973-47de-8d45-ebec35df6af1" />
</details>

<details>
<summary>Test instructions</summary>

1. Request a password reset for an address with no account.
2. Subject is `[<site name>] No account found for this email`.
3. The CTA should open the signup page.
</details>

---


## ‼️ Risks & Considerations ‼️

**There is a second account-deletion email that is not built.** `users.tasks.send_account_deleted_email`, which fires after the grace period expires, is still a hardcoded one-line string with no HTML.

**Texts** Double check against copy in Notion.

## Rejected alternatives

**Building a real unsubscribe endpoint.** The dead `unsubscribe` link needed *something*, and a signed one-click unsubscribe view is the proper answer, but it is a behavioural feature with its own token handling and preference writes, which is too much to include in this ticket. Removing the link and pointing preferences at the profile page is a good middle ground.

## Self-review Checklist
- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [ ] UI implementation matches Figma design
- [ ] Responsive / mobile verified
- [ ] Ensure design tokens are used for colors, spacing, typography, etc. No hardcoded values
- [ ] Test without JavaScript (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added branded HTML and plain-text emails for account confirmation, commit verification, mailing-list subscriptions, news notifications, and post approvals.
  * Added clear call-to-action buttons, fallback links, content previews, expiry details, and consistent Boost.org messaging.
  * Authors now receive notifications when moderated posts are approved and published.
  * Added support for verifying commit email addresses and confirming mailing-list subscriptions through updated email flows.

* **Bug Fixes**
  * Improved requester fallback wording and ensured links use complete, safe URLs.
  * Standardized signup confirmation emails with clickable activation links and shared branding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->