### PR TITLE
Fix 2691 and 2699: make the v3 header cache-safe and flush to the top on /doc pages

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -73,6 +73,7 @@ from users.views import (
     PublicUserProfileView,
     UserViewSet,
     UserAvatar,
+    V3HeaderAuth,
     DeleteUserView,
     CancelDeletionView,
     DeleteImmediatelyView,
@@ -176,6 +177,11 @@ urlpatterns = (
             name="profile-delete-immediately",
         ),
         path("users/avatar/", UserAvatar.as_view(), name="user-avatar"),
+        path(
+            "users/header-auth/",
+            V3HeaderAuth.as_view(),
+            name="v3-header-auth",
+        ),
         # Must stay last of the single-segment "users/..." routes: `slug`
         # matches "me" and "avatar" too, so every literal segment has to be
         # registered ahead of it.

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -239,6 +239,7 @@ def header_context(request):
         "nav_links": nav_links,
         "releases_url": reverse("releases-most-recent"),
         "edit_profile_url": edit_profile_url(),
+        "auth_state_url": reverse("v3-header-auth"),
         "profile_cancel_delete_url": reverse("profile-cancel-delete"),
     }
 

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -579,3 +579,35 @@ def test_user_guide_top_level_request_is_modernized(request_factory, headers):
 
     mock_modernize.assert_called_once()
     assert mock_render.call_args_list[-1].args[0] == "docsiframe.html"
+
+
+def test_user_guide_defers_the_header_auth_state(request_factory):
+    """Guide pages sit behind a shared cache, so the header must not bake in auth.
+
+    Whichever visitor warmed the cache would otherwise decide what login state
+    every later visitor sees.
+    """
+    from core.views import UserGuideTemplateView
+
+    content = b"<html><body>guide page</body></html>"
+    view = UserGuideTemplateView()
+    view.request = request_factory.get("/doc/user-guide/index.html")
+    view.content_dict = {"content": content, "content_type": "text/html"}
+
+    with patch(
+        "core.views.modernize_legacy_page", return_value="<p>modernized</p>"
+    ), patch("core.views.render_to_string", return_value="wrapped page") as mock_render:
+        view.process_content(content)
+
+    assert mock_render.call_args_list[-1].args[1]["defer_auth_state"] is True
+
+
+@pytest.mark.django_db
+@override_settings(CACHES=TEST_CACHES)
+def test_static_content_context_defers_the_header_auth_state(request_factory):
+    view = StaticContentTemplateView()
+    view.request = request_factory.get("/foo.adoc")
+    view.kwargs = {"content_path": "foo.adoc"}
+    view.content_dict = {"content": b"= Title", "content_type": "text/asciidoc"}
+
+    assert view.get_context_data()["defer_auth_state"] is True

--- a/core/views.py
+++ b/core/views.py
@@ -783,6 +783,10 @@ class BaseStaticContentTemplateView(TemplateView):
                 "content": content,
                 "content_type": content_type,
                 "selected_version": self.get_selected_version(),
+                # These pages are served through a shared HTTP cache, so their
+                # HTML must not bake in one visitor's login state. The header
+                # leaves the auth slot empty and fetches it per request.
+                "defer_auth_state": True,
             }
         )
         logger.info(
@@ -1162,7 +1166,7 @@ class UserGuideTemplateView(BaseStaticContentTemplateView):
             # was not generate from Antora builders.
             return content
 
-        context = {"disable_theme_switcher": False}
+        context = {"disable_theme_switcher": False, "defer_auth_state": True}
         # TODO: investigate if this base_html + template can be removed completely,
         #  seems unused
         base_html = render_to_string(

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -133,8 +133,14 @@ html:has(#docsiframe) .header-menu-bar.topnavbar {
   z-index: 1000;
 }
 
-html:has(#docsiframe) .bg-white:has(.version_alert),
-html:has(#docsiframe) .version_alert {
+/* The legacy docs chrome pins the 41px topnavbar and the alert under it, then
+   pays for both with padding on <body>. V3 has no fixed bar: the header is
+   absolutely positioned inside .docs-iframe-page and the space is reserved by
+   .docs-iframe-page > .w-full (static/css/v3/header.css). Applying both leaves
+   a 41px gap above the v3 header and overflows the viewport, so these stay
+   legacy-only. */
+html:not(.v3):has(#docsiframe) .bg-white:has(.version_alert),
+html:not(.v3):has(#docsiframe) .version_alert {
   position: fixed;
   top: var(--header-height, 41px);
   left: 0;
@@ -143,11 +149,11 @@ html:has(#docsiframe) .version_alert {
   width: 100%;
 }
 
-html:has(#docsiframe):has(.version_alert) {
+html:not(.v3):has(#docsiframe):has(.version_alert) {
   --version-alert-height: 32px;
 }
 
-html:has(#docsiframe) body {
+html:not(.v3):has(#docsiframe) body {
   padding-top: calc(var(--header-height, 41px) + var(--version-alert-height, 0px));
 }
 

--- a/static/css/v3/components.css
+++ b/static/css/v3/components.css
@@ -10,6 +10,7 @@
 @import "./count-badge.css";
 @import "./v3-examples-section.css";
 @import "./header.css";
+@import "./header-auth.css";
 @import "./heros.css";
 @import "./footer.css";
 @import "./forms.css";

--- a/static/css/v3/header-auth.css
+++ b/static/css/v3/header-auth.css
@@ -1,0 +1,7 @@
+.header__auth-placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--header-height);
+  min-width: var(--header-height);
+}

--- a/static/css/v3/header.css
+++ b/static/css/v3/header.css
@@ -47,6 +47,13 @@ body.v3 .docs-iframe-page {
   margin-right: auto;
 }
 
+body.v3 #docsiframe {
+  margin-top: 0;
+  height: calc(100vh - var(--v3-header-footprint) - var(--version-alert-height, 0px));
+  height: calc(100svh - var(--v3-header-footprint) - var(--version-alert-height, 0px));
+  max-height: calc(100svh - var(--v3-header-footprint) - var(--version-alert-height, 0px));
+}
+
 /* ── Shared control surface ────────────────────── */
 
 .header__nav--desktop,

--- a/templates/v3/includes/header/_header_auth.html
+++ b/templates/v3/includes/header/_header_auth.html
@@ -1,0 +1,16 @@
+{% comment %}
+  Header Auth — the avatar menu for a signed-in visitor, the log in link otherwise.
+
+  Rendered inline by _header_utilities.html, and served on its own by the
+  v3-header-auth view when the surrounding page defers its auth state.
+
+  Context Variables:
+    request    (HttpRequest, required) — Django request object (for auth state)
+    avatar_id  (string, required)      — unique ID prefix for avatar component, e.g. "desktop-user-menu"
+{% endcomment %}
+{% if request.user.is_authenticated %}
+  <span class="header__user">{% include "v3/includes/header/_header_avatar.html" with avatar_id=avatar_id %}</span>
+{% else %}
+  <a href="{% url 'account_login' %}"
+     class="header__nav-btn">Log In</a>
+{% endif %}

--- a/templates/v3/includes/header/_header_utilities.html
+++ b/templates/v3/includes/header/_header_utilities.html
@@ -29,11 +29,25 @@
     </button>
   {% endif %}
 
-  {% comment %} Auth (Login or Avatar) {% endcomment %}
-  {% if request.user.is_authenticated %}
-    <span class="header__user">{% include "v3/includes/header/_header_avatar.html" with avatar_id=avatar_id %}</span>
+  {% comment %}
+    Auth (Login or Avatar).
+
+    Pages whose HTML is served from a shared HTTP cache cannot carry a per-user
+    auth state, so they set defer_auth_state and the slot is filled from the
+    always-uncached v3-header-auth endpoint instead. The placeholder is swapped
+    whole (outerHTML), so the resulting DOM matches the inline branch exactly.
+  {% endcomment %}
+  {% if defer_auth_state %}
+    <span class="header__auth-placeholder"
+          aria-busy="true"
+          hx-get="{{ auth_state_url }}?avatar_id={{ avatar_id }}"
+          hx-trigger="load"
+          hx-swap="outerHTML">
+      <noscript>
+        {% include "v3/includes/header/_header_auth.html" with avatar_id=avatar_id %}
+      </noscript>
+    </span>
   {% else %}
-    <a href="{% url 'account_login' %}"
-       class="header__nav-btn">Log In</a>
+    {% include "v3/includes/header/_header_auth.html" with avatar_id=avatar_id %}
   {% endif %}
 </div>

--- a/users/tests/test_v3_header_auth.py
+++ b/users/tests/test_v3_header_auth.py
@@ -1,0 +1,77 @@
+from django.contrib.auth.models import AnonymousUser
+from django.template.loader import render_to_string
+from django.urls import reverse
+
+
+def test_anonymous_gets_the_log_in_link(client, db):
+    response = client.get(reverse("v3-header-auth"))
+    html = response.content.decode()
+
+    assert response.status_code == 200
+    assert "Log In" in html
+    assert "header__user-menu" not in html
+
+
+def test_authenticated_gets_the_avatar_menu(client, user, db):
+    client.force_login(user)
+    response = client.get(reverse("v3-header-auth"))
+    html = response.content.decode()
+
+    assert response.status_code == 200
+    assert "header__user-menu" in html
+    assert "Log In" not in html
+
+
+def test_response_is_never_cached(client, user, db):
+    """The whole point of the endpoint: a shared cache must not store it."""
+    client.force_login(user)
+    response = client.get(reverse("v3-header-auth"))
+
+    assert "no-store" in response["Cache-Control"]
+    assert "private" in response["Cache-Control"]
+    assert "Cookie" in response["Vary"]
+
+
+def test_avatar_id_is_used_when_known(client, user, db):
+    client.force_login(user)
+    response = client.get(reverse("v3-header-auth"), {"avatar_id": "mobile-user-menu"})
+
+    assert 'id="mobile-user-menu-toggle"' in response.content.decode()
+
+
+def test_unknown_avatar_id_falls_back_to_the_default(client, user, db):
+    """An arbitrary id would otherwise be reflected into the markup."""
+    client.force_login(user)
+    response = client.get(
+        reverse("v3-header-auth"), {"avatar_id": 'x" onload="alert(1)'}
+    )
+    html = response.content.decode()
+
+    assert 'id="desktop-user-menu-toggle"' in html
+    assert "onload" not in html
+
+
+def _render_utilities(rf, db, **context):
+    request = rf.get("/doc/user-guide/index.html")
+    request.user = AnonymousUser()
+    return render_to_string(
+        "v3/includes/header/_header_utilities.html",
+        {"avatar_id": "desktop-user-menu", **context},
+        request=request,
+    )
+
+
+def test_header_defers_the_auth_slot_when_flagged(rf, db):
+    html = _render_utilities(rf, db, defer_auth_state=True)
+
+    assert "header__auth-placeholder" in html
+    assert f'hx-get="{reverse("v3-header-auth")}?avatar_id=desktop-user-menu"' in html
+    assert "<noscript>" in html
+
+
+def test_header_renders_the_auth_slot_inline_by_default(rf, db):
+    html = _render_utilities(rf, db)
+
+    assert "header__auth-placeholder" not in html
+    assert "hx-get" not in html
+    assert "Log In" in html

--- a/users/views.py
+++ b/users/views.py
@@ -14,8 +14,10 @@ from django.http import (
     JsonResponse,
 )
 from django.shortcuts import get_object_or_404
+from django.utils.decorators import method_decorator
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.urls import reverse, reverse_lazy
+from django.views.decorators.cache import never_cache
 from django.views.generic import DetailView, FormView, View
 from django.views.generic.base import TemplateView
 from django.utils import timezone
@@ -884,6 +886,30 @@ class UserAvatar(TemplateView):
                 response.delete_cookie("csrftoken", path="/")
 
         return response
+
+
+@method_decorator(never_cache, name="dispatch")
+class V3HeaderAuth(TemplateView):
+    """Serve the V3 header's auth slot on its own, for HTMX to fill in.
+
+    Static content pages under ``/doc/`` are served through a shared HTTP cache,
+    so their HTML cannot carry a per-user login state: whichever visitor warmed
+    the cache decides what everyone else sees. Those pages leave the slot empty
+    and fetch it from here, which is marked uncacheable, so the header reflects
+    the visitor's own session rather than the cached one.
+    """
+
+    template_name = "v3/includes/header/_header_auth.html"
+    default_avatar_id = "desktop-user-menu"
+    allowed_avatar_ids = frozenset({"desktop-user-menu", "mobile-user-menu"})
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        avatar_id = self.request.GET.get("avatar_id", "")
+        if avatar_id not in self.allowed_avatar_ids:
+            avatar_id = self.default_avatar_id
+        context["avatar_id"] = avatar_id
+        return context
 
 
 # Confirmation-phrase error shown inline in the delete modal.


### PR DESCRIPTION
# Issues: #2691, #2699

⚠️ The `/doc` page showing the legacy header is a really difficult one to test or reproduce. I hope this PR fixes the issue, but if it doesn't we can keep digging. 

## Summary & Context

Both tickets are the same surface, the `/doc/**` pages, so they ship together. This PR
stops the v3 header baking per-user auth state into HTML that a shared cache hands to
everybody (#2691), and removes the legacy 41px top offset that pushed the v3 header down
the page and overflowed the viewport there (#2699).

**Read this before reviewing, it changes what both tickets claim.** `/doc/**` is served
from a single shared copy at the edge: the same URL requested with four different session
cookies returns one identical cached object, while `/` and `/libraries/` return a fresh
per-visitor copy. That shared copy is rendered for a logged-out stranger, and since `v3` is
enabled per user in production, a stranger's copy is a **flag-off, old-design** page. That
is why QA sees the new design everywhere except docs. The app is picking the right header;
the answer is cached and handed to the wrong people. Django already sends `Vary: Cookie` on
those responses and the edge ignores it for that path, so the actual fix is a cache
configuration change outside this repo, or the `v3` rollout going global.

- **Figma link**: n/a (bug fixes, no design change)
- **Link to components/page:**
  - [http://localhost:8000/doc/user-guide/getting-started.html](http://localhost:8000/doc/user-guide/getting-started.html)
  - [http://localhost:8000/doc/user-guide/reporting-issues.html](http://localhost:8000/doc/user-guide/reporting-issues.html)

## Changes

- **`templates/v3/includes/header/_header_auth.html`** - new partial holding the avatar-or-login slot, renderable inline or alone.
- **`templates/v3/includes/header/_header_utilities.html`** - renders a placeholder with `hx-get`/`hx-swap="outerHTML"` when `defer_auth_state` is set, inline otherwise.
- **`users/views.py`**, **`config/urls.py`**, **`core/context_processors.py`** - `V3HeaderAuth`, a `never_cache` view serving that partial, its route, and `auth_state_url`; `avatar_id` is allowlisted rather than reflected.
- **`core/views.py`** - the S3 static-content views set `defer_auth_state`; every other page keeps rendering auth server-side.
- **`static/css/v3/header-auth.css`** - reserves the slot's height and a square min-width so the swap does not shift the row.
- **`frontend/styles.css`**, **`static/css/v3/header.css`** - the legacy `html:has(#docsiframe)` body padding and fixed alert placement are scoped to `html:not(.v3)`, and `#docsiframe` takes its height from `--v3-header-footprint` instead of the legacy 41px.

## ‼️ Risks & Considerations ‼️

- **Neither change makes QA's screenshots go away on their own.** Users with the flag are served the shared flag-off copy, which contains the legacy header, so none of the v3 header code here renders for them yet. This is the prerequisite: without it, the day `v3` goes global every logged-in user gets "Log In" on doc pages, because the shared copy would then be a v3 page with someone else's auth state baked in. `/doc/libs/**` pages falling through to `original_docs.html` remain on the green legacy heading, a separate and larger surface.
- Deferral is scoped to the S3 static-content views, so no-JS users keep a correct server-rendered header everywhere else; on those pages a `<noscript>` copy is served, correct on a cache miss and stale on a hit. Marking the pages private instead would drop the doc caching this whole mechanism exists to preserve.
- **`frontend/styles.css` is a Tailwind source and its build output is gitignored**, so the CSS half of this diff is invisible in a browser until `yarn build` runs. Reverting the commit without rebuilding looks like a no-op.

## Screenshots
Before
<img width="1728" height="962" alt="image" src="https://github.com/user-attachments/assets/ca0da82b-51c3-4954-8b38-148627078d66" />

After
<img width="1727" height="770" alt="image" src="https://github.com/user-attachments/assets/faf912b7-f4bc-4a97-81ed-0fd40b78942a" />

## Peer-review testing steps

1. `yarn build` first, or the CSS changes will not be in the page at all.
2. Enable the `v3` waffle flag, log in, and open the getting started user guide page.
3. The header sits flush with the top like the homepage, with no gap and no page scrollbar; the iframe scrolls itself.
4. The header shows your avatar rather than a Login button, and never flashes "Log In" first.
5. Log out and reload: the header shows "Log In". `curl -I /users/header-auth/` must carry `Cache-Control: no-store, private`.
6. Turn the flag off and reload: legacy top bar fixed at 0, body padded 41px, unchanged. Repeat steps 3 and 4 in light and dark mode at 1440, 900 and 390 px.
