### PR TITLE
Add the post edit-window timer

### DIFF
--- a/pages/models.py
+++ b/pages/models.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from structlog import get_logger
 from wagtail.admin.panels import FieldPanel
 from wagtail.models import PageManager
@@ -457,18 +459,37 @@ class PostPage(BasePage):
         else:
             return None
 
-    def _in_edit_window(self):
+    # How long after first submitting a post its author may still edit or
+    # delete it. Surfaced to the reader by `edit_window_remaining_display`.
+    EDIT_WINDOW = timedelta(hours=6)
+
+    @property
+    def edit_window_remaining(self):
+        """Time left in the edit window, or None once it has closed.
+
+        Not cached: the value moves with the clock, so a `cached_property`
+        would freeze it for the life of the request's page object.
+        """
         first_revision = self.revisions.order_by("created_at").first()
         if not first_revision:
-            return False
+            return None
 
-        right_now = localtime(now())
-        td = abs(right_now - first_revision.created_at)
-        if td.days > 0 or abs(right_now - first_revision.created_at).seconds > (
-            6 * 60 * 60
-        ):
-            return False
-        return True
+        remaining = (first_revision.created_at + self.EDIT_WINDOW) - localtime(now())
+        return remaining if remaining > timedelta(0) else None
+
+    @property
+    def edit_window_remaining_display(self):
+        """The remaining window as "5h 9m", or "9m" inside the last hour."""
+        remaining = self.edit_window_remaining
+        if remaining is None:
+            return ""
+
+        minutes = int(remaining.total_seconds() // 60)
+        hours, minutes = divmod(minutes, 60)
+        return f"{hours}h {minutes}m" if hours else f"{minutes}m"
+
+    def _in_edit_window(self):
+        return self.edit_window_remaining is not None
 
     def user_can_edit(self, user):
         return self.owner == user and self._in_edit_window()

--- a/pages/models.py
+++ b/pages/models.py
@@ -459,8 +459,7 @@ class PostPage(BasePage):
         else:
             return None
 
-    # How long after first submitting a post its author may still edit or
-    # delete it. Surfaced to the reader by `edit_window_remaining_display`.
+    # Measured from the first revision, so a later edit does not restart it.
     EDIT_WINDOW = timedelta(hours=6)
 
     @property
@@ -484,7 +483,8 @@ class PostPage(BasePage):
         if remaining is None:
             return ""
 
-        minutes = int(remaining.total_seconds() // 60)
+        # Clamped: the final 59 seconds would floor to "0m" while still editable.
+        minutes = max(1, int(remaining.total_seconds() // 60))
         hours, minutes = divmod(minutes, 60)
         return f"{hours}h {minutes}m" if hours else f"{minutes}m"
 

--- a/pages/tests/test_edit_window.py
+++ b/pages/tests/test_edit_window.py
@@ -1,0 +1,112 @@
+"""The six-hour window in which a post's author may still edit or delete it.
+
+Measured from the *first* revision, so the clock starts when the author first
+submits and is not restarted by later edits or by a moderator approving.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.utils.timezone import now
+
+from pages.models import PostPage
+
+
+@pytest.fixture
+def post_with_first_revision(make_post_page, user):
+    """A live post owned by `user`, with a back-datable first revision."""
+
+    def _make_it(age=timedelta(0)):
+        page = make_post_page(owner=user)
+        revision = page.save_revision()
+        # created_at is auto_now_add, so it has to be written after the fact.
+        revision.created_at = now() - age
+        revision.save(update_fields=["created_at"])
+        return page
+
+    return _make_it
+
+
+class TestEditWindowRemaining:
+    def test_a_fresh_post_has_nearly_the_whole_window(self, post_with_first_revision):
+        page = post_with_first_revision()
+        remaining = page.edit_window_remaining
+        assert remaining is not None
+        # Allow for the seconds the test itself takes.
+        assert timedelta(hours=5, minutes=59) < remaining <= PostPage.EDIT_WINDOW
+
+    def test_it_closes_once_the_window_has_passed(self, post_with_first_revision):
+        page = post_with_first_revision(age=timedelta(hours=6, seconds=1))
+        assert page.edit_window_remaining is None
+
+    def test_it_is_measured_from_the_first_revision_not_the_latest(
+        self, post_with_first_revision
+    ):
+        """A later edit must not hand the author a fresh six hours."""
+        page = post_with_first_revision(age=timedelta(hours=5, minutes=30))
+        page.save_revision()
+        remaining = page.edit_window_remaining
+        assert remaining is not None
+        assert remaining < timedelta(minutes=31)
+
+    def test_a_page_with_no_revisions_is_closed(self, make_post_page, user):
+        page = make_post_page(owner=user)
+        assert page.revisions.count() == 0
+        assert page.edit_window_remaining is None
+
+    def test_it_is_not_cached_across_reads(self, post_with_first_revision):
+        """A cached_property here would freeze the value for the request."""
+        page = post_with_first_revision()
+        first = page.edit_window_remaining
+        second = page.edit_window_remaining
+        assert second <= first
+
+
+class TestEditWindowRemainingDisplay:
+    # Ages sit mid-minute on purpose. The display floors, so an age exactly on a
+    # minute boundary drops a minute for the fraction of a second the test spends
+    # between writing `created_at` and reading the value back.
+    @pytest.mark.parametrize(
+        "age,expected",
+        [
+            (timedelta(seconds=30), "5h 59m"),
+            (timedelta(hours=4, minutes=59, seconds=30), "1h 0m"),
+            (timedelta(hours=5, seconds=30), "59m"),
+            (timedelta(hours=5, minutes=58, seconds=30), "1m"),
+            # Would floor to "0m" unclamped, while still editable.
+            (timedelta(hours=5, minutes=59, seconds=30), "1m"),
+            (timedelta(hours=6, seconds=1), ""),
+        ],
+    )
+    def test_it_formats_the_window(self, post_with_first_revision, age, expected):
+        page = post_with_first_revision(age=age)
+        assert page.edit_window_remaining_display == expected
+
+    def test_it_never_renders_zero_minutes_while_the_window_is_open(
+        self, post_with_first_revision
+    ):
+        page = post_with_first_revision(age=PostPage.EDIT_WINDOW - timedelta(seconds=5))
+        assert page.edit_window_remaining is not None
+        assert page.edit_window_remaining_display == "1m"
+
+
+class TestPermissionsFollowTheWindow:
+    def test_the_owner_may_edit_and_delete_inside_the_window(
+        self, post_with_first_revision
+    ):
+        page = post_with_first_revision()
+        assert page.user_can_edit(page.owner)
+        assert page.user_can_delete(page.owner)
+
+    def test_the_owner_may_not_once_it_has_closed(self, post_with_first_revision):
+        page = post_with_first_revision(age=timedelta(hours=6, seconds=1))
+        assert not page.user_can_edit(page.owner)
+        assert not page.user_can_delete(page.owner)
+
+    def test_a_different_user_may_not_even_inside_the_window(
+        self, post_with_first_revision, staff_user
+    ):
+        page = post_with_first_revision()
+        assert page.owner != staff_user
+        assert not page.user_can_edit(staff_user)
+        assert not page.user_can_delete(staff_user)

--- a/static/css/v3/post-detail.css
+++ b/static/css/v3/post-detail.css
@@ -32,41 +32,36 @@
   line-height: var(--line-height-tight);
 }
 
-/* Right-aligned against the page gutter, not the 696px article column, so it
-   sits outside `.post-detail-page`. Matches the design, where the row is a
-   page-level sibling of the centred content rather than article content. */
+/* Page-level, outside `.post-detail-page`: the design aligns Delete's right
+   edge with the header avatar's, which sits on the page gutter, not the article
+   column. The wrapper already supplies that gutter, hence no inline padding. */
 .post-detail__admin-actions {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-default);
   align-items: center;
   justify-content: flex-end;
-  padding: var(--space-large) var(--space-large) 0;
+  padding-block-start: var(--space-large);
 }
 
 .post-detail__approve-form {
   margin: 0;
 }
 
-/* The Delete button's form only wraps the confirmation modal, which is either
-   `display: none` or `position: fixed` and so never in flow. Without this the
-   empty form still takes a flex slot, leaving a stray gap between the last
-   button and the gutter. */
+/* The form only wraps the confirmation modal, which is never in flow. Without
+   this it still takes a flex slot and pushes the last button off the gutter. */
 .post-detail__admin-actions > form:has(.dialog-modal) {
   display: contents;
 }
 
 /* ── Edit-window timer ──────────────────────────────────── */
-/* Sits left of the Edit button while the author's edit window is open.
-   Rendered server-side, so the value is a snapshot taken at page load
-   rather than a live countdown. */
+/* Server-rendered, so the value is a page-load snapshot, not a live countdown. */
 .post-detail__edit-timer {
   display: flex;
   align-items: center;
   gap: var(--space-s);
-  /* The design holds this at 24px on mobile too, and no token is 24px below
-     768px (--space-xlarge drops to 16px), so this one stays literal. Same
-     approach as the fixed chrome heights in badge.css and branch-buttons.css. */
+  /* Literal: the design holds 24px at every width, and no token is 24px below
+     768px, where --space-xlarge drops to 16px. */
   height: 24px;
   padding-inline: var(--space-default);
   border-radius: var(--border-radius-m);
@@ -352,9 +347,8 @@ html.dark .post-detail__related .card-group {
     margin-top: calc(64px - var(--space-large));
   }
 
-  /* The action row stays on one line, with a tighter 8px gutter and the two
-     buttons splitting whatever the timer leaves. Their shared 128px min-width
-     would otherwise overrun a 390px viewport and wrap. */
+  /* One line at 390px: the buttons' shared 128px min-width would overrun and
+     wrap, so they split whatever the timer leaves. */
   .post-detail__admin-actions {
     padding-inline: var(--space-medium);
   }
@@ -364,10 +358,8 @@ html.dark .post-detail__related .card-group {
     min-width: 0;
   }
 
-  /* The design holds the timer at 12px and 8px padding on mobile, but both
-     scales step down below 768px: `--font-size-xs` lands on 10px and
-     `--space-default` on 6px. `--font-size-small` and `--space-medium` are the
-     steps that are 12px and 8px here. */
+  /* Both scales step down below 768px, so the tokens that hold the design's
+     12px and 8px here are the next ones up. */
   .post-detail__edit-timer {
     padding-inline: var(--space-medium);
     font-size: var(--font-size-small);

--- a/static/css/v3/post-detail.css
+++ b/static/css/v3/post-detail.css
@@ -32,16 +32,55 @@
   line-height: var(--line-height-tight);
 }
 
+/* Right-aligned against the page gutter, not the 696px article column, so it
+   sits outside `.post-detail-page`. Matches the design, where the row is a
+   page-level sibling of the centred content rather than article content. */
 .post-detail__admin-actions {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-default);
   align-items: center;
-  justify-content: flex-start;
+  justify-content: flex-end;
+  padding: var(--space-large) var(--space-large) 0;
 }
 
 .post-detail__approve-form {
   margin: 0;
+}
+
+/* The Delete button's form only wraps the confirmation modal, which is either
+   `display: none` or `position: fixed` and so never in flow. Without this the
+   empty form still takes a flex slot, leaving a stray gap between the last
+   button and the gutter. */
+.post-detail__admin-actions > form:has(.dialog-modal) {
+  display: contents;
+}
+
+/* ── Edit-window timer ──────────────────────────────────── */
+/* Sits left of the Edit button while the author's edit window is open.
+   Rendered server-side, so the value is a snapshot taken at page load
+   rather than a live countdown. */
+.post-detail__edit-timer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-s);
+  /* The design holds this at 24px on mobile too, and no token is 24px below
+     768px (--space-xlarge drops to 16px), so this one stays literal. Same
+     approach as the fixed chrome heights in badge.css and branch-buttons.css. */
+  height: 24px;
+  padding-inline: var(--space-default);
+  border-radius: var(--border-radius-m);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-default);
+  letter-spacing: var(--letter-spacing-tight);
+  color: var(--color-text-primary);
+  white-space: nowrap;
+}
+
+.post-detail__edit-timer-icon {
+  flex: none;
 }
 
 .post-detail__pending-badge {
@@ -311,5 +350,26 @@ html.dark .post-detail__related .card-group {
      gap + margin-top = 64. */
   .post-detail-page > .post-detail + section {
     margin-top: calc(64px - var(--space-large));
+  }
+
+  /* The action row stays on one line, with a tighter 8px gutter and the two
+     buttons splitting whatever the timer leaves. Their shared 128px min-width
+     would otherwise overrun a 390px viewport and wrap. */
+  .post-detail__admin-actions {
+    padding-inline: var(--space-medium);
+  }
+
+  .post-detail__admin-actions > .btn {
+    flex: 1;
+    min-width: 0;
+  }
+
+  /* The design holds the timer at 12px and 8px padding on mobile, but both
+     scales step down below 768px: `--font-size-xs` lands on 10px and
+     `--space-default` on 6px. `--font-size-small` and `--space-medium` are the
+     steps that are 12px and 8px here. */
+  .post-detail__edit-timer {
+    padding-inline: var(--space-medium);
+    font-size: var(--font-size-small);
   }
 }

--- a/templates/includes/icon.html
+++ b/templates/includes/icon.html
@@ -95,6 +95,8 @@
     <path d="M3 3h2v18H3V3zm16 0H5v2h14v14H5v2h16V3h-2zm-8 6h2V7h-2v2zm2 8h-2v-6h2v6z" />
   {% elif icon_name == "check" %}
     <path d="M18 6H20V8H18V6ZM16 10V8H18V10H16ZM14 12V10H16V12H14ZM12 14H14V12H12V14ZM10 16H12V14H10V16ZM8 16V18H10V16H8ZM6 14H8V16H6V14ZM6 14H4V12H6V14Z" />
+  {% elif icon_name == "clock" %}
+    <path d="M19 3H5v2H3v14h2v2h14v-2h2V5h-2V3zm0 2v14H5V5h14zm-8 2h2v6h4v2h-6V7z" />
   {% elif icon_name == "close" %}
     <path d="M5 5h2v2H5V5zm4 4H7V7h2v2zm2 2H9V9h2v2zm2 0h-2v2H9v2H7v2H5v2h2v-2h2v-2h2v-2h2v2h2v2h2v2h2v-2h-2v-2h-2v-2h-2v-2zm2-2v2h-2V9h2zm2-2v2h-2V7h2zm0 0V5h2v2h-2z" />
   {% elif icon_name == "reload" %}

--- a/templates/news/v3/detail.html
+++ b/templates/news/v3/detail.html
@@ -12,8 +12,7 @@
 {% endblock %}
 
 {% block content %}
-  {% comment %} Page-level, not article content: the design puts this row at the
-  full page width with a gutter, right-aligned, above the centred column. {% endcomment %}
+  {% comment %} Outside the article on purpose: the design aligns this row with the page gutter. {% endcomment %}
   {% if not is_preview %}
     {% if user_can_approve or user_can_edit or user_can_delete %}
       <div class="post-detail__admin-actions">

--- a/templates/news/v3/detail.html
+++ b/templates/news/v3/detail.html
@@ -12,38 +12,46 @@
 {% endblock %}
 
 {% block content %}
+  {% comment %} Page-level, not article content: the design puts this row at the
+  full page width with a gutter, right-aligned, above the centred column. {% endcomment %}
+  {% if not is_preview %}
+    {% if user_can_approve or user_can_edit or user_can_delete %}
+      <div class="post-detail__admin-actions">
+        {% if object.needs_approval %}
+          {% if user_can_approve %}
+            <form method="POST" action="{% url 'news-approve' object.slug %}" class="post-detail__approve-form">
+              {% csrf_token %}
+              {% include "v3/includes/_button.html" with label="Approve" type="submit" style="green" %}
+            </form>
+          {% else %}
+            <span class="post-detail__pending-badge">Pending Moderation</span>
+          {% endif %}
+        {% endif %}
+        {% if user_can_edit and not object.deleted_at %}
+          {% if object.edit_window_remaining_display %}
+            <span class="post-detail__edit-timer">
+              {% include "includes/icon.html" with icon_name="clock" icon_class="post-detail__edit-timer-icon" icon_size=14 %}
+              Editable for {{ object.edit_window_remaining_display }}
+            </span>
+          {% endif %}
+          {% include "v3/includes/_button.html" with url=object.edit_url label="Edit" style="primary" %}
+        {% endif %}
+        {% if user_can_delete and not object.deleted_at %}
+          {% include "v3/includes/_button.html" with url='#delete-modal' label="Delete" style="secondary" %}
+          <form action="{{object.delete_url}}" method="POST">
+            {% csrf_token %}
+            {% include 'v3/includes/_dialog.html' with dialog_id="delete-modal" title="Delete Post" primary_label="Delete" submit=True secondary_label="Cancel" primary_style="error" description="Are you sure you want to delete this post? This can't be undone." only %}
+          </form>
+        {% endif %}
+      </div>
+    {% endif %}
+  {% endif %}
   <div class="post-detail-page">
     <article class="post-detail">
       {% if object.deleted_at %}
         <div class="post-detail__deleted-notice" role="status">
           Entry deleted on {{ object.deleted_at|date:"m/d/Y" }}{% if object.deleted_by %} by {{ object.deleted_by.display_name }}{% endif %}.
         </div>
-      {% endif %}
-      {% if not is_preview %}
-        {% if user_can_approve or user_can_edit or user_can_delete %}
-          <div class="post-detail__admin-actions">
-            {% if object.needs_approval %}
-              {% if user_can_approve %}
-                <form method="POST" action="{% url 'news-approve' object.slug %}" class="post-detail__approve-form">
-                  {% csrf_token %}
-                  {% include "v3/includes/_button.html" with label="Approve" type="submit" style="green" %}
-                </form>
-              {% else %}
-                <span class="post-detail__pending-badge">Pending Moderation</span>
-              {% endif %}
-            {% endif %}
-            {% if user_can_edit and not object.deleted_at %}
-              {% include "v3/includes/_button.html" with url=object.edit_url label="Edit" style="secondary" %}
-            {% endif %}
-            {% if user_can_delete and not object.deleted_at %}
-              {% include "v3/includes/_button.html" with url='#delete-modal' label="Delete" style="error" %}
-              <form action="{{object.delete_url}}" method="POST">
-                {% csrf_token %}
-                {% include 'v3/includes/_dialog.html' with dialog_id="delete-modal" title="Delete Post" primary_label="Delete" submit=True secondary_label="Cancel" primary_style="error" description="Are you sure you want to delete this post? This can't be undone." only %}
-              </form>
-            {% endif %}
-          </div>
-        {% endif %}
       {% endif %}
       {% include "v3/includes/_post_header.html" with title=object.title publish_date=object.publish_at tag=post_tag author=post_author %}
 


### PR DESCRIPTION
# Issue: #2655

## Summary & Context

Adds the "Editable for 5h 9m" timer beside the Edit button on a post detail page. Worth flagging up front: #2655 asks to update the timer's font, font size and icon, but the timer did not exist. Nothing rendered remaining edit time. The six-hour window lived in `PostPage._in_edit_window()` purely as a boolean gating the Edit and Delete buttons, so this is the first implementation rather than a restyle.

- **Figma link**: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=11873-19910
- **Link to components/page:** `/posts/<slug>/` on a post you own, inside its six-hour window. See the first risk below: this URL currently 404s.

## Changes

- `pages/models.py`: the window was a hardcoded `6 * 60 * 60` inside a boolean check. It is now `EDIT_WINDOW = timedelta(hours=6)`, with `edit_window_remaining` returning a timedelta or `None` and `edit_window_remaining_display` formatting it as "5h 9m", or "9m" inside the last hour. `_in_edit_window()` reads off the same value, so there is one source of truth. Both are plain properties, not `cached_property`, because the value moves with the clock.
- `templates/includes/icon.html`: adds a `clock` icon. The Figma glyph is pixelarticons `clock`, confirmed by normalising the exported SVG's 9-unit grid against the official 24-grid path rather than assumed from the name, so the official path drops into the existing 24-viewBox chain.
- `templates/news/v3/detail.html`: renders the chip, and moves the whole admin action row out of `<article class="post-detail">`. The design places it at full page width against a 16px gutter, not inside the 696px article column.
- `static/css/v3/post-detail.css`: the chip, the right-aligned row, and a mobile block. Also takes the Delete button's `<form>` out of the flex flow with `display: contents`; it only wraps the confirmation modal, which is `display: none` closed and `position: fixed` open, but it was still consuming a flex slot and leaving the last button 8px short of the gutter.
- Two buttons in the same row were off the design and are corrected here. Edit was `secondary` where Figma has it on `buttons/primary`, and Delete was `error` red where the design draws it neutral with a `stroke/strong` border.

## ‼️ Risks & Considerations ‼️

**This page cannot be loaded to review or QA it.** The static-content catch-all at `config/urls.py:491` matches `^(?!__debug__|outreach/|testimonials/|news/)(?P<content_path>.+)/?`. That lookahead does not exclude `posts/`, so every post detail URL is swallowed before Wagtail sees it and 404s, and `/news/entry/` redirects into the same dead end. This is a pre-existing bug, not caused by this branch, and is deliberately not fixed here because it changes routing for the whole `/posts/` tree. Adding `posts/` to that lookahead makes the page reachable locally.

**No test coverage.** There are no tests for `edit_window_remaining` or `edit_window_remaining_display`, and there were none for `_in_edit_window` before this either. A method that gates edit and delete permissions was refactored without a safety net. Happy to add them if preferred.

**Subtle behaviour change in `_in_edit_window`.** The old code compared `abs(now - first_revision.created_at)`, measuring distance in either direction. The new one is directional. A first revision dated in the future would previously count as in-window only within six hours; it now always counts as in-window and would render a large figure. `Revision.created_at` is set automatically so this should not arise, but it is a real difference.

**Taking Delete off red removes its destructive cue.** That matches the design, but is worth a second opinion if the red was deliberate for a button that unpublishes a post.

**The timer is a page-load snapshot, not a live countdown.** It does not tick down; a refresh moves it. The design shows a static value and the v3 posture is CSS-first, so no JS was added.

## Screenshots

Width | Light | Dark
-- | -- | --
**1440** | <img alt="desktop-1440-light" src="https://github.com/user-attachments/assets/28ef4f34-2560-4c99-b657-96ae87f838fe" /> | <img alt="desktop-1440-dark" src="https://github.com/user-attachments/assets/290a8429-744f-4776-aa19-36b93c7d8d01" />
**1024 (Figma frame)** | <img alt="desktop-1024-light" src="https://github.com/user-attachments/assets/bb80bea9-8d03-415c-850d-9bed9932ba3a" /> | <img alt="desktop-1024-dark" src="https://github.com/user-attachments/assets/a4a61f5f-68f2-4446-a193-9460113e39ff" />
**768** | <img alt="tablet-768-light" src="https://github.com/user-attachments/assets/92de62dc-e40c-4bc1-8ec6-bd048d8c5fc9" /> | <img alt="tablet-768-dark" src="https://github.com/user-attachments/assets/0729507f-4c0f-4922-8b3a-d610de03b47e" />
**390** | <img alt="mobile-390-light" src="https://github.com/user-attachments/assets/a0c94e61-1191-48ec-9772-7e2bc6d16b6c" /> | <img alt="mobile-390-dark" src="https://github.com/user-attachments/assets/ee8dab05-ca18-4096-b7d3-db87e5862e1f" />

Measured against the Figma spec, values are exact: Mona Sans VF 12px/400, line-height 14.4px, tracking -0.12px, `text/primary`, gap 4px, height 24px, padding 8px, radius 6px, 14px icon. Edit resolves to `rgb(239, 239, 241)` (`#efeff1`) and Delete's border to `rgba(5, 8, 22, 0.25)`. The 16px gutter holds from 768 up. At 390px the row stays on one line with the buttons at 108px against the design's 108/109, and the right edge lands on 374 exactly. No horizontal overflow at any width.

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified (1440, 1024, 768, 390, 360; no horizontal overflow at any width)
- [ ] Accessibility checked (keyboard navigation, etc.) — not done. The chip is a non-interactive `<span>` so it adds no focus targets, but no full pass was made.
- [x] Ensure design tokens are used for colors, spacing, typography, etc. — with one deliberate exception. The chip's `height: 24px` is literal: `--space-xlarge` is 24px on desktop but 16px below 768px, and no token is 24px there, while the design holds 24px at every width. Commented in place, matching how `badge.css` and `branch-buttons.css` handle fixed chrome heights.
- [ ] Test without JavaScript (if applicable) — not verified. The chip is server-rendered and carries no JS, so it should be unaffected.
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a countdown timer showing the remaining six-hour window for editing and deleting eligible posts.
  - Added a clock icon to support the edit timer.

- **Improvements**
  - Reorganized post actions for clearer, right-aligned access.
  - Updated Edit and Delete button styling for improved visual distinction.
  - Improved action-row and timer layout on mobile screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
