### PR TITLE
Story 2702: fix achievements and badges sections for public and private profiles

### DIFF
--- a/badges/display.py
+++ b/badges/display.py
@@ -278,34 +278,67 @@ def held_badges(user, include_hidden=False):
 
 
 def featured_badge(user, include_hidden=False):
-    """The badge the member picked, or ``None``. Never a badge they did not pick.
+    """The badge the member picked, else the highest one they hold, else ``None``.
 
-    There is no default: a member holding badges but choosing none features none.
-    Featuring one for them would publish a choice they never made, and the picker
-    already opens on a suggestion, so the only way here is a deliberate save.
+    A pick always wins, a lower rung included: which badge leads is the point of
+    the picker. Any pick that does not resolve - unset, revoked, or folded away
+    by ``held_badges`` - falls back to the top rank held.
 
-    ``None`` likewise covers a pick that has stopped being displayable - revoked,
-    hidden from the public, or a rank held twice where grandfathering left the row
-    ``held_badges`` folded away.
+    The fallback reverses the earlier rule, which featured nothing without a
+    deliberate save (issue #2702). Almost nobody makes that save, so a member
+    with a full card of badges showed none beside their name. ``hide_badges``
+    still wins, the fallback reaching only what ``held_badges`` allows.
 
     ``display_badge_id`` is read rather than ``display_badge`` because a page
     rendering many users would otherwise cost a query each: the picked row, when
     the member still holds it, is already among ``held_badges``.
     """
+    held = held_badges(user, include_hidden=include_hidden)
     picked = user.display_badge_id
-    if picked is None:
-        return None
-    for row in held_badges(user, include_hidden=include_hidden):
-        if row.pk == picked:
-            return badge_card(row)
-    return None
+    if picked is not None:
+        for row in held:
+            if row.pk == picked:
+                return badge_card(row)
+    return badge_card(held[0]) if held else None
 
 
 def badge_cards(user, include_hidden=False):
-    """Every active badge as a card dict, highest rank first."""
-    return [
-        badge_card(badge) for badge in held_badges(user, include_hidden=include_hidden)
-    ]
+    """Each badge category as one card, its highest rank, highest rank first.
+
+    Climbing keeps the rungs below, so bronze-to-gold in one category listed the
+    same badge three times - eleven rows for six badges in issue #2702. Only the
+    rung reached is a badge to show.
+
+    Deduped here rather than in ``held_badges``, which is what ``featured_badge``
+    validates a pick against: a member may feature a lower rung, and folding it
+    away there would silently override them.
+    """
+    unique = {}
+    for badge in held_badges(user, include_hidden=include_hidden):
+        unique.setdefault(badge.badge_id, badge)
+    return [badge_card(badge) for badge in unique.values()]
+
+
+def achievement_cards(user):
+    """The member's earned achievements, as the dicts the achievement card reads.
+
+    Only achievements with a valid grant: the card records what the member did,
+    so a zero is not a row. Deduped by achievement, ``user_badge_summary``
+    emitting a row per achievement/badge pair while an achievement feeding two
+    badges is still one tally.
+
+    Highest tally first, name breaking ties - the registry orders by name alone,
+    which buries the tallies the card is built around.
+    """
+    cards = {}
+    for row in user_badge_summary(user):
+        if row.valid_grants:
+            cards[row.achievement.pk] = {
+                "title": row.achievement.name,
+                "points": row.valid_grants,
+                "description": row.achievement.description,
+            }
+    return sorted(cards.values(), key=lambda card: (-card["points"], card["title"]))
 
 
 def badge_card(user_badge):

--- a/badges/display.py
+++ b/badges/display.py
@@ -312,11 +312,29 @@ def badge_cards(user, include_hidden=False):
     Deduped here rather than in ``held_badges``, which is what ``featured_badge``
     validates a pick against: a member may feature a lower rung, and folding it
     away there would silently override them.
+
+    The badge the member picked leads, whatever its rank, the rest keeping rank
+    order behind it. Picking is how a member says which badge represents them, so
+    burying it mid-list - which is where rank alone put it, since a pick is
+    usually *not* the top rank - reads as the pick having been ignored.
+
+    Matched on the badge rather than the awarded row, so a pick that is a lower
+    rung of a ladder still leads. The card shows one row per badge, the highest
+    rung reached, and that row is the picked badge's row even when the pick names
+    a rung below it.
     """
+    rows = held_badges(user, include_hidden=include_hidden)
     unique = {}
-    for badge in held_badges(user, include_hidden=include_hidden):
+    for badge in rows:
         unique.setdefault(badge.badge_id, badge)
-    return [badge_card(badge) for badge in unique.values()]
+    cards = list(unique.values())
+    picked = next(
+        (row.badge_id for row in rows if row.pk == user.display_badge_id), None
+    )
+    if picked is not None:
+        # Stable, so everything else keeps the rank order it arrived in.
+        cards.sort(key=lambda row: row.badge_id != picked)
+    return [badge_card(badge) for badge in cards]
 
 
 def achievement_cards(user, rows=None, include_hidden=False):

--- a/badges/display.py
+++ b/badges/display.py
@@ -319,7 +319,7 @@ def badge_cards(user, include_hidden=False):
     return [badge_card(badge) for badge in unique.values()]
 
 
-def achievement_cards(user, rows=None):
+def achievement_cards(user, rows=None, include_hidden=False):
     """The member's earned achievements, as the dicts the achievement card reads.
 
     Only achievements with a valid grant: the card records what the member did,
@@ -330,10 +330,17 @@ def achievement_cards(user, rows=None):
     Highest tally first, name breaking ties - the registry orders by name alone,
     which buries the tallies the card is built around.
 
+    ``hide_badges`` covers achievements as well as badges: it is one control over
+    the recognition column, not two. Same shape as ``held_badges`` - nothing for a
+    member who hid them, unless ``include_hidden`` is set, which only the owner's
+    own views should do.
+
     ``rows`` takes summary rows already read for this member. The owner's own
     profile needs both these cards and the dialog's counts, and the read behind
     them is the same one; passing it in is what keeps it to one.
     """
+    if user.hide_badges and not include_hidden:
+        return []
     if rows is None:
         rows = user_badge_summary(user)
     cards = {}

--- a/badges/display.py
+++ b/badges/display.py
@@ -319,7 +319,7 @@ def badge_cards(user, include_hidden=False):
     return [badge_card(badge) for badge in unique.values()]
 
 
-def achievement_cards(user):
+def achievement_cards(user, rows=None):
     """The member's earned achievements, as the dicts the achievement card reads.
 
     Only achievements with a valid grant: the card records what the member did,
@@ -329,9 +329,15 @@ def achievement_cards(user):
 
     Highest tally first, name breaking ties - the registry orders by name alone,
     which buries the tallies the card is built around.
+
+    ``rows`` takes summary rows already read for this member. The owner's own
+    profile needs both these cards and the dialog's counts, and the read behind
+    them is the same one; passing it in is what keeps it to one.
     """
+    if rows is None:
+        rows = user_badge_summary(user)
     cards = {}
-    for row in user_badge_summary(user):
+    for row in rows:
         if row.valid_grants:
             cards[row.achievement.pk] = {
                 "title": row.achievement.name,
@@ -414,7 +420,7 @@ BADGES_DIALOG_DESCRIPTION = (
 PLACEHOLDER_ACHIEVEMENT_COUNT = 1
 
 
-def achievement_dialog_rows(user=None):
+def achievement_dialog_rows(user=None, rows=None):
     """Every achievement type as a dialog row, Boost Day last.
 
     Each row carries a counter, which is what the design asks for: the tally is
@@ -429,8 +435,11 @@ def achievement_dialog_rows(user=None):
 
     Ordered by name, ``Achievement`` being an admin-editable registry with no
     catalogue ordering of its own.
+
+    ``rows`` takes summary rows already read for this member; see
+    ``achievement_cards``. Ignored without a member, there being nothing to count.
     """
-    counts = {} if user is None else _valid_grant_counts(user)
+    counts = {} if user is None else _valid_grant_counts(user, rows=rows)
     rows = [
         {
             "token": BadgeToken.ACHIEVEMENT_COUNT,
@@ -443,13 +452,15 @@ def achievement_dialog_rows(user=None):
     return rows + [BOOST_DAY_ROW]
 
 
-def _valid_grant_counts(user):
+def _valid_grant_counts(user, rows=None):
     """How many valid grants the member holds of each achievement, by pk.
 
     Read through ``user_badge_summary`` so "a valid grant" keeps one definition
     across the app. It counts ``is_valid`` rows and leaves invalidated ones out.
     """
-    return {row.achievement.pk: row.valid_grants for row in user_badge_summary(user)}
+    if rows is None:
+        rows = user_badge_summary(user)
+    return {row.achievement.pk: row.valid_grants for row in rows}
 
 
 def badge_dialog_rows():

--- a/badges/display.py
+++ b/badges/display.py
@@ -420,19 +420,21 @@ def achievement_dialog_rows(user=None):
     Each row carries a counter, which is what the design asks for: the tally is
     the point, the artwork being the same for every achievement type.
 
-    Given a member, the counters are that member's own valid grants, zero
-    included. Without one they carry a placeholder. Only the owner's own profile
-    passes a user, another member's tallies not being this dialog's to show.
+    Given a member, the counters are that member's own valid grants.
+
+    Nothing earned shows the placeholder rather than a zero, whether or not
+    there is a member to count: the dialog explains how achievements work, and
+    the counter is artwork carrying an example figure. A wall of ``00`` reads as
+    a broken counter instead.
 
     Ordered by name, ``Achievement`` being an admin-editable registry with no
     catalogue ordering of its own.
     """
     counts = {} if user is None else _valid_grant_counts(user)
-    default = PLACEHOLDER_ACHIEVEMENT_COUNT if user is None else 0
     rows = [
         {
             "token": BadgeToken.ACHIEVEMENT_COUNT,
-            "count": counts.get(achievement.pk, default),
+            "count": counts.get(achievement.pk) or PLACEHOLDER_ACHIEVEMENT_COUNT,
             "name": achievement.name,
             "description": achievement.description,
         }

--- a/badges/tests/test_profile.py
+++ b/badges/tests/test_profile.py
@@ -240,6 +240,53 @@ def test_a_revoked_choice_falls_back_to_the_highest_held(plain_user):
     assert display.featured_badge(plain_user)["icon"] == BadgeToken.TIER_3
 
 
+def test_the_picked_badge_leads_the_card(plain_user):
+    """A pick is how a member says which badge represents them.
+
+    Rank alone buried it: a pick is usually not the member's top rank, so the
+    badge they chose to feature turned up mid-list and looked ignored.
+    """
+    _grant(plain_user, "library-review", count=5)  # reviewer, up to diamond
+    _grant(plain_user, "library-authoring", count=1)  # library author, bronze
+    _pick(plain_user, TierRank.BRONZE, slug="library-authoring")
+    plain_user = _reload(plain_user)
+
+    names = [card["name"] for card in display.badge_cards(plain_user)]
+
+    assert names == ["Library Author", "Reviewer"]
+
+
+def test_the_badges_behind_the_pick_keep_rank_order(plain_user):
+    """Only the picked badge moves; the rest are still ranked."""
+    _grant(plain_user, "library-review", count=5)  # diamond
+    _grant(plain_user, "code-commits", count=12)  # silver
+    _grant(plain_user, "library-authoring", count=1)  # bronze
+    _pick(plain_user, TierRank.BRONZE, slug="library-authoring")
+    plain_user = _reload(plain_user)
+
+    names = [card["name"] for card in display.badge_cards(plain_user)]
+
+    assert names == ["Library Author", "Reviewer", "Commits Master"]
+
+
+def test_a_pick_below_the_top_rung_still_leads(plain_user):
+    """The card shows one row per badge, and that row leads on a pick.
+
+    The picker only offers the rung a member has reached, but a stored pick can
+    fall behind when they climb. It is still the badge they chose.
+    """
+    _grant(plain_user, "library-review", count=5)
+    _grant(plain_user, "code-commits", count=12)
+    _pick(plain_user, TierRank.BRONZE)  # reviewer bronze, three rungs down
+    plain_user = _reload(plain_user)
+
+    cards = display.badge_cards(plain_user)
+
+    assert cards[0]["name"] == "Reviewer"
+    # The row is the rung reached, not the rung picked.
+    assert cards[0]["icon"] == BadgeToken.TIER_5
+
+
 def test_only_the_highest_rung_of_a_badge_gets_a_card(plain_user):
     """Climbing keeps the rungs below, and the card listed every one of them.
 

--- a/badges/tests/test_profile.py
+++ b/badges/tests/test_profile.py
@@ -208,32 +208,52 @@ def test_featured_badge_honours_the_members_choice(plain_user):
     assert display.featured_badge(plain_user)["icon"] == BadgeToken.TIER_1
 
 
-def test_badges_held_but_none_picked_features_nothing(plain_user):
-    """No pick, no featured badge - even holding several.
+def test_badges_held_but_none_picked_features_the_highest(plain_user):
+    """No pick features the top rank held, per issue #2702.
 
-    Featuring the top rank for a member who never chose would publish a choice
-    they did not make. The cards list is unaffected; only the headline is a pick.
+    This reverses the earlier rule, which featured nothing without a deliberate
+    save. Almost nobody makes that save, so a member with a full card of badges
+    showed none beside their name and it read as a bug.
     """
-    _grant(plain_user, "library-review", count=3)
+    _grant(plain_user, "library-review", count=3)  # bronze, silver and gold
     plain_user = _reload(plain_user)
 
     assert plain_user.display_badge_id is None
-    assert display.held_badges(plain_user) != []
-    assert display.featured_badge(plain_user) is None
-    assert plain_user.featured_badge is None
-    assert plain_user.to_v3_profile_dict()["badge"] is None
-    assert len(display.badge_cards(plain_user)) == 3
+    assert display.featured_badge(plain_user)["icon"] == BadgeToken.TIER_3
+    assert plain_user.featured_badge["icon"] == BadgeToken.TIER_3
+    assert plain_user.to_v3_profile_dict()["badge"] == BadgeToken.TIER_3
+    # One badge climbed three rungs is one card, not three.
+    assert len(display.badge_cards(plain_user)) == 1
 
 
-def test_featured_badge_shows_nothing_when_the_choice_is_revoked(plain_user):
-    """A revoked pick features nothing rather than silently moving to another."""
+def test_a_revoked_choice_falls_back_to_the_highest_held(plain_user):
+    """A revoked pick is no pick, so the default applies rather than nothing.
+
+    A revocation that left the name bare while the badges card stayed full is
+    the same reported bug by another route.
+    """
     _grant(plain_user, "library-review", count=3)
     picked = _pick(plain_user, TierRank.BRONZE)
     UserBadge.objects.filter(pk=picked.pk).update(revoked_at="2026-01-01T00:00:00Z")
     plain_user = _reload(plain_user)
 
-    assert display.held_badges(plain_user) != []
-    assert display.featured_badge(plain_user) is None
+    assert display.featured_badge(plain_user)["icon"] == BadgeToken.TIER_3
+
+
+def test_only_the_highest_rung_of_a_badge_gets_a_card(plain_user):
+    """Climbing keeps the rungs below, and the card listed every one of them.
+
+    Eleven rows for six badges on the profile in issue #2702. The rungs below
+    stay in ``held_badges``, which is history and what a pick is checked against.
+    """
+    _grant(plain_user, "library-review", count=3)
+    _grant(plain_user, "code-commits", count=12)
+    plain_user = _reload(plain_user)
+
+    cards = display.badge_cards(plain_user)
+
+    assert len(display.held_badges(plain_user)) > len(cards)
+    assert [card["name"] for card in cards] == ["Reviewer", "Commits Master"]
 
 
 def test_a_chosen_badge_is_still_hidden_by_hide_badges(plain_user):

--- a/badges/tests/test_profile_achievements.py
+++ b/badges/tests/test_profile_achievements.py
@@ -182,6 +182,59 @@ def test_a_visitor_gets_no_dialog_rows_of_the_members_own(plain_user, tp):
     assert "achievement_dialog_items" not in response.context
 
 
+def test_hide_badges_hides_achievements_too(plain_user):
+    """One control over the recognition column, not one per card.
+
+    The checkbox reads "Hide badges and achievements on your profile", so a
+    member who ticks it publishes neither.
+    """
+    _grant(plain_user, "library-review", count=3)
+    plain_user.hide_badges = True
+    plain_user.save(update_fields=["hide_badges"])
+
+    assert display.achievement_cards(plain_user) == []
+
+
+def test_the_owner_still_sees_achievements_they_hid(plain_user):
+    """Same bypass as the badges card: hidden from visitors, not from you."""
+    achievement = _grant(plain_user, "library-review", count=3)
+    plain_user.hide_badges = True
+    plain_user.save(update_fields=["hide_badges"])
+
+    (card,) = display.achievement_cards(plain_user, include_hidden=True)
+
+    assert card["title"] == achievement.name
+
+
+def test_hiding_costs_a_visitor_no_summary_read(plain_user, django_assert_num_queries):
+    """Nothing to read once the answer is "show none of it"."""
+    _grant(plain_user, "library-review", count=3)
+    plain_user.hide_badges = True
+    plain_user.save(update_fields=["hide_badges"])
+
+    with django_assert_num_queries(0):
+        assert display.achievement_cards(plain_user) == []
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_a_visitor_sees_no_hidden_achievements_card(plain_user, tp):
+    """End to end: the card is gone from the page, not merely emptied.
+
+    Only the card. The dialog behind it still names every achievement type,
+    because that is the catalogue explaining how they work - the same list on
+    every profile, carrying nobody's tallies.
+    """
+    _grant(plain_user, "library-review", count=3)
+    plain_user.hide_badges = True
+    plain_user.save(update_fields=["hide_badges"])
+
+    response = tp.get(plain_user.get_absolute_url())
+
+    tp.response_200(response)
+    assert "user-profile__achievements" not in response.content.decode()
+    assert "achievement_dialog_items" not in response.context
+
+
 @waffle.testutils.override_flag("v3", active=True)
 def test_public_profile_renders_the_earned_achievements(plain_user, tp):
     """The reported bug: a member's real achievements never reached the page.

--- a/badges/tests/test_profile_achievements.py
+++ b/badges/tests/test_profile_achievements.py
@@ -1,0 +1,123 @@
+"""What the profile's Achievements card is built from.
+
+Separate from ``test_profile``, which covers the badges half of the same card
+column: badges hang off a tier ladder, achievements are a flat tally, and the
+two answer different questions.
+"""
+
+import pytest
+import waffle.testutils
+
+from badges import display
+from badges.enums import BadgeLabel
+from badges.models import Achievement, Badge, UserAchievement
+
+
+@pytest.fixture(autouse=True)
+def _catalogue(catalogue):
+    """Seed the real achievement catalogue for every test in this module."""
+
+
+def _grant(user, slug, count=1):
+    """Grant `count` manual achievements of `slug` (recalcs via the signal)."""
+    achievement = Achievement.objects.get(slug=slug)
+    for _ in range(count):
+        UserAchievement.objects.create(
+            user=user, achievement=achievement, source_type="manual"
+        )
+    return achievement
+
+
+def test_no_achievements_yields_no_cards(plain_user):
+    """A member who has earned nothing gets no rows, not a zeroed catalogue."""
+    assert display.achievement_cards(plain_user) == []
+
+
+def test_an_earned_achievement_becomes_a_card(plain_user):
+    """The card carries the achievement's own name, description and tally."""
+    achievement = _grant(plain_user, "library-review", count=3)
+
+    (card,) = display.achievement_cards(plain_user)
+
+    assert card["title"] == achievement.name
+    assert card["description"] == achievement.description
+    assert card["points"] == 3
+
+
+def test_untouched_achievements_are_left_out(plain_user):
+    """Only what the member did. The catalogue is not a checklist to display."""
+    _grant(plain_user, "library-review")
+
+    titles = [card["title"] for card in display.achievement_cards(plain_user)]
+
+    assert len(titles) == 1
+    assert Achievement.objects.count() > 1
+
+
+def test_invalidated_grants_do_not_count(plain_user):
+    """Invalidation is soft, so the rows survive; the tally must not."""
+    _grant(plain_user, "library-review", count=3)
+    UserAchievement.objects.filter(user=plain_user).update(is_valid=False)
+
+    assert display.achievement_cards(plain_user) == []
+
+
+def test_cards_lead_with_the_biggest_tally(plain_user):
+    """The tally is the point of the card, and the registry orders by name."""
+    _grant(plain_user, "library-review", count=2)
+    _grant(plain_user, "code-commits", count=9)
+
+    cards = display.achievement_cards(plain_user)
+
+    assert [card["points"] for card in cards] == [9, 2]
+
+
+def test_an_achievement_feeding_two_badges_is_one_card(plain_user):
+    """``user_badge_summary`` rows are per achievement/badge pair, cards are not.
+
+    One achievement can feed several badges, each with its own ladder. The
+    member still did one thing that many times, so it is one row on the card.
+    """
+    achievement = _grant(plain_user, "library-review", count=3)
+    # Repointed rather than created: the catalogue already holds every label,
+    # and ``Badge.label`` is unique.
+    second = Badge.objects.get(label=BadgeLabel.PUBLISHER)
+    second.achievement = achievement
+    second.save(update_fields=["achievement"])
+
+    assert achievement.badges.count() == 2
+
+    (card,) = display.achievement_cards(plain_user)
+
+    assert card["points"] == 3
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_public_profile_renders_the_earned_achievements(plain_user, tp):
+    """The reported bug: a member's real achievements never reached the page.
+
+    A visitor, not the owner, because the card used to render for the owner
+    alone - and then only as an example.
+    """
+    achievement = _grant(plain_user, "library-review", count=3)
+
+    response = tp.get(plain_user.get_absolute_url())
+
+    tp.response_200(response)
+    body = response.content.decode()
+    assert "user-profile__achievements" in body
+    assert achievement.name in body
+    assert "achievement-card__achivement-example" not in body
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_own_profile_hides_the_achievements_card_when_empty(plain_user, tp):
+    """No example achievements dressed up as the owner's own."""
+    tp.client.force_login(plain_user)
+
+    response = tp.get(tp.reverse("profile-account"))
+
+    tp.response_200(response)
+    body = response.content.decode()
+    assert "user-profile__achievements" not in body
+    assert "Patch Wizard" not in body

--- a/badges/tests/test_profile_achievements.py
+++ b/badges/tests/test_profile_achievements.py
@@ -107,17 +107,29 @@ def test_public_profile_renders_the_earned_achievements(plain_user, tp):
     body = response.content.decode()
     assert "user-profile__achievements" in body
     assert achievement.name in body
-    assert "achievement-card__achivement-example" not in body
+    assert "Showcase your contributions" not in body
 
 
 @waffle.testutils.override_flag("v3", active=True)
-def test_own_profile_hides_the_achievements_card_when_empty(plain_user, tp):
-    """No example achievements dressed up as the owner's own."""
+def test_own_profile_keeps_the_empty_achievements_card(plain_user, tp):
+    """The owner's empty card carries the only way into the achievements dialog.
+
+    The same rule as the badges card beside it, so the two behave alike.
+    """
     tp.client.force_login(plain_user)
 
     response = tp.get(tp.reverse("profile-account"))
 
     tp.response_200(response)
     body = response.content.decode()
-    assert "user-profile__achievements" not in body
-    assert "Patch Wizard" not in body
+    assert "user-profile__achievements" in body
+    assert "Learn how achievements work" in body
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_a_visitor_sees_no_empty_achievements_card(plain_user, tp):
+    """The empty state is the owner's prompt to earn some, not a visitor's."""
+    response = tp.get(plain_user.get_absolute_url())
+
+    tp.response_200(response)
+    assert "user-profile__achievements" not in response.content.decode()

--- a/badges/tests/test_profile_achievements.py
+++ b/badges/tests/test_profile_achievements.py
@@ -7,10 +7,13 @@ two answer different questions.
 
 import pytest
 import waffle.testutils
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from badges import display
 from badges.enums import BadgeLabel
 from badges.models import Achievement, Badge, UserAchievement
+from badges.summary import user_badge_summary
 
 
 @pytest.fixture(autouse=True)
@@ -90,6 +93,51 @@ def test_an_achievement_feeding_two_badges_is_one_card(plain_user):
     (card,) = display.achievement_cards(plain_user)
 
     assert card["points"] == 3
+
+
+def test_supplied_rows_are_read_instead_of_queried(
+    plain_user, django_assert_num_queries
+):
+    """Both readers take the same rows, so the owner's page reads them once.
+
+    The cards and the dialog's counts are the same underlying summary. Each
+    reading it for itself cost the owner's own profile a second copy of every
+    query behind it.
+    """
+    _grant(plain_user, "library-review", count=3)
+    rows = user_badge_summary(plain_user)
+
+    with django_assert_num_queries(0):
+        cards = display.achievement_cards(plain_user, rows=rows)
+    # One, not none: the dialog lists the whole catalogue, which is a read of
+    # its own and nothing to do with this member's grants.
+    with django_assert_num_queries(1):
+        counts = display.achievement_dialog_rows(plain_user, rows=rows)
+
+    assert cards == display.achievement_cards(plain_user)
+    assert counts == display.achievement_dialog_rows(plain_user)
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_the_owners_page_reads_the_summary_once(plain_user, tp):
+    """A regression guard on the page, not just on the functions.
+
+    The owner's page is the only one wanting both the cards and the dialog
+    counts, so it is the only one that could pay twice.
+    """
+    _grant(plain_user, "library-review", count=3)
+    tp.client.force_login(plain_user)
+
+    with CaptureQueriesContext(connection) as queries:
+        response = tp.get(tp.reverse("profile-account"))
+
+    tp.response_200(response)
+    grant_reads = [
+        query
+        for query in queries.captured_queries
+        if "badges_userachievement" in query["sql"]
+    ]
+    assert len(grant_reads) == 1
 
 
 @waffle.testutils.override_flag("v3", active=True)

--- a/badges/tests/test_profile_achievements.py
+++ b/badges/tests/test_profile_achievements.py
@@ -119,17 +119,23 @@ def test_supplied_rows_are_read_instead_of_queried(
 
 
 @waffle.testutils.override_flag("v3", active=True)
-def test_the_owners_page_reads_the_summary_once(plain_user, tp):
+@pytest.mark.parametrize("route", ["profile-account", "routing-key"])
+def test_the_owners_page_reads_the_summary_once(plain_user, tp, route):
     """A regression guard on the page, not just on the functions.
 
     The owner's page is the only one wanting both the cards and the dialog
-    counts, so it is the only one that could pay twice.
+    counts, so it is the only one that could pay twice - by either route.
     """
     _grant(plain_user, "library-review", count=3)
     tp.client.force_login(plain_user)
+    url = (
+        tp.reverse("profile-account")
+        if route == "profile-account"
+        else plain_user.get_absolute_url()
+    )
 
     with CaptureQueriesContext(connection) as queries:
-        response = tp.get(tp.reverse("profile-account"))
+        response = tp.get(url)
 
     tp.response_200(response)
     grant_reads = [
@@ -138,6 +144,42 @@ def test_the_owners_page_reads_the_summary_once(plain_user, tp):
         if "badges_userachievement" in query["sql"]
     ]
     assert len(grant_reads) == 1
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_both_routes_to_your_own_profile_show_the_same_counts(plain_user, tp):
+    """`/users/me/` and your own routing-key page are the same page.
+
+    The dialog's counts used to be attached by the `/users/me/` view alone, so
+    reaching your own profile by its public URL showed the catalogue's
+    placeholder instead of what you had earned.
+    """
+    achievement = _grant(plain_user, "library-review", count=7)
+    tp.client.force_login(plain_user)
+
+    own = tp.get(tp.reverse("profile-account"))
+    public = tp.get(plain_user.get_absolute_url())
+
+    for response in (own, public):
+        tp.response_200(response)
+        # Boost Day rides along without a counter, so skip the countless rows.
+        counts = {
+            row["name"]: row["count"]
+            for row in response.context["achievement_dialog_items"]
+            if "count" in row
+        }
+        assert counts[achievement.name] == 7
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_a_visitor_gets_no_dialog_rows_of_the_members_own(plain_user, tp):
+    """Another member's tallies are not this dialog's to show."""
+    _grant(plain_user, "library-review", count=7)
+
+    response = tp.get(plain_user.get_absolute_url())
+
+    tp.response_200(response)
+    assert "achievement_dialog_items" not in response.context
 
 
 @waffle.testutils.override_flag("v3", active=True)

--- a/badges/tests/test_recognition_dialogs.py
+++ b/badges/tests/test_recognition_dialogs.py
@@ -66,9 +66,9 @@ def test_counts_are_the_members_own_valid_grants(
     rows = {row["name"]: row for row in achievement_dialog_rows(plain_user)}
 
     assert rows[review.name]["count"] == 3
-    # Untouched achievements stay at zero rather than borrowing the count.
+    # An untouched achievement shows the placeholder, not this row's count.
     commits = Achievement.objects.get(slug=AchievementSlug.CODE_COMMITS)
-    assert rows[commits.name]["count"] == 0
+    assert rows[commits.name]["count"] == PLACEHOLDER_ACHIEVEMENT_COUNT
 
 
 def test_invalidated_grants_do_not_count(catalogue, plain_user, grant_achievement):
@@ -82,11 +82,15 @@ def test_invalidated_grants_do_not_count(catalogue, plain_user, grant_achievemen
     assert rows[review.name]["count"] == 1
 
 
-def test_a_member_with_no_grants_counts_zero(catalogue, plain_user):
-    """Zero, not the placeholder: the answer for this member is known."""
+def test_a_member_with_no_grants_gets_the_placeholder(catalogue, plain_user):
+    """The placeholder, not a zero, so the dialog reads the same as the demo.
+
+    A member who has earned nothing would otherwise see every row at ``00``,
+    which reads as a broken counter rather than as an explainer.
+    """
     rows = achievement_dialog_rows(plain_user)[:-1]
 
-    assert {row["count"] for row in rows} == {0}
+    assert {row["count"] for row in rows} == {PLACEHOLDER_ACHIEVEMENT_COUNT}
 
 
 def test_without_a_member_the_placeholder_stands(catalogue):

--- a/static/css/v3/achivement-card.css
+++ b/static/css/v3/achivement-card.css
@@ -32,10 +32,6 @@
     gap: var(--space-default);
 }
 
-.achievement-card__achivement-example {
-    opacity: 0.7;
-}
-
 @media screen and (max-width: 1279px) {
     .achievement-card__achievement {
         flex: 1 1 51%;

--- a/templates/v3/includes/_achievement_card.html
+++ b/templates/v3/includes/_achievement_card.html
@@ -1,11 +1,10 @@
 {% comment %}
-  This card lists the achievements for a user. If not provided a list of achievements, instead give a demonstration of achievements and link to the about page
+  This card lists the achievements a user has earned. Given none, it shows an
+  empty state instead: a line of copy and a link out to the explainer, matching
+  how _badges_card.html handles the same situation.
     Inputs:
       Achievements - Optional: A list of achievements, each of which has points, a title, and a description
-      primary_button_url - Optional: target for the "Learn how achievements work" button, shown in both states
-
-  The empty state is a demonstration, so the profile page does not use it: it
-  drops the card instead and only the v3 component gallery renders it.
+      primary_button_url - Optional: target for the "Learn how achievements work" button, shown in the empty state only
 {% endcomment %}
 
 <div class="card wide-card">
@@ -14,41 +13,25 @@
   </div>
   <hr class="card__hr" />
   <div class="card__column px-large">
-    <div class="achievement-card__container">
-      {% for ach in achievements %}
-        <div class="achievement-card__achievement">
-          {% include "v3/includes/_count_badge.html" with value=ach.points size="medium" %}
-          <div class="achievement-card__description">
-            <p class="achievement-card__ach-text text-primary">{{ ach.title }}</p>
-            <p class="achievement-card__ach-text text-secondary">{{ ach.description }}</p>
+    {% if achievements %}
+      <div class="achievement-card__container">
+        {% for ach in achievements %}
+          <div class="achievement-card__achievement">
+            {% include "v3/includes/_count_badge.html" with value=ach.points size="medium" %}
+            <div class="achievement-card__description">
+              <p class="achievement-card__ach-text text-primary">{{ ach.title }}</p>
+              <p class="achievement-card__ach-text text-secondary">{{ ach.description }}</p>
+            </div>
           </div>
-        </div>
-      {% empty %}
-        <div class="achievement-card__achievement achievement-card__achivement-example">
-          {% include "v3/includes/_count_badge.html" with value=19 size="medium" %}
-          <div class="achievement-card__description">
-            <p class="achievement-card__ach-text text-primary">Patch Wizard</p>
-            <p class="achievement-card__ach-text text-secondary">Submitted patch that was reviewed and merged</p>
-          </div>
-        </div>
-        <div class="achievement-card__achievement achievement-card__achivement-example">
-          {% include "v3/includes/_count_badge.html" with value=7 size="medium" %}
-          <div class="achievement-card__description">
-            <p class="achievement-card__ach-text text-primary">Consensus Builder</p>
-            <p class="achievement-card__ach-text text-secondary">Guided technical discussion toward agreement</p>
-          </div>
-        </div>
-      {% endfor %}
-    </div>
-    {% if not achievements %}
+        {% endfor %}
+      </div>
+    {% else %}
       <span class="achievement-card__bold-text">Showcase your contributions and milestones as you participate in the community.</span>
     {% endif %}
   </div>
-  {% comment %}
-    Unguarded, unlike the two blocks above: it is the only trigger for the
-    achievements dialog, which an empty-state guard would hide from everyone.
-  {% endcomment %}
-  <div class="px-large card__cta_section">
-    {% include 'v3/includes/_button.html' with style=primary_style url=primary_button_url label='Learn how achievements work' only %}
-  </div>
+  {% if not achievements %}
+    <div class="px-large card__cta_section">
+      {% include 'v3/includes/_button.html' with style=primary_style url=primary_button_url label='Learn how achievements work' only %}
+    </div>
+  {% endif %}
 </div>

--- a/templates/v3/includes/_achievement_card.html
+++ b/templates/v3/includes/_achievement_card.html
@@ -2,6 +2,10 @@
   This card lists the achievements for a user. If not provided a list of achievements, instead give a demonstration of achievements and link to the about page
     Inputs:
       Achievements - Optional: A list of achievements, each of which has points, a title, and a description
+      primary_button_url - Optional: target for the "Learn how achievements work" button, shown in both states
+
+  The empty state is a demonstration, so the profile page does not use it: it
+  drops the card instead and only the v3 component gallery renders it.
 {% endcomment %}
 
 <div class="card wide-card">
@@ -40,9 +44,11 @@
       <span class="achievement-card__bold-text">Showcase your contributions and milestones as you participate in the community.</span>
     {% endif %}
   </div>
-  {% if not achievements %}
-    <div class="px-large card__cta_section">
-      {% include 'v3/includes/_button.html' with style=primary_style url=primary_button_url label='Learn how achievements work' only %}
-    </div>
-  {% endif %}
+  {% comment %}
+    Unguarded, unlike the two blocks above: it is the only trigger for the
+    achievements dialog, which an empty-state guard would hide from everyone.
+  {% endcomment %}
+  <div class="px-large card__cta_section">
+    {% include 'v3/includes/_button.html' with style=primary_style url=primary_button_url label='Learn how achievements work' only %}
+  </div>
 </div>

--- a/templates/v3/user_profile_page.html
+++ b/templates/v3/user_profile_page.html
@@ -53,14 +53,19 @@
         An empty column would otherwise leave the bio at half width beside a
         blank gap.
 
-        Both recognition cards render on the member's own page even with
-        nothing in them: their empty states carry the only CTAs that open the
-        badge and achievement dialogs, so suppressing them would leave no way
-        in. A visitor sees each card only once it has real data.
+        The badges card renders on the member's own page even with nothing in
+        it: its empty state carries the only CTA that opens the badges dialog,
+        so suppressing it would leave no way in. A visitor sees it only once it
+        has real data.
+
+        Achievements are not treated that way (issue #2702). The card is shown
+        only to a member who has earned something, owner included, rather than
+        offering an example dressed up as their own; its CTA rides on the filled
+        card, which is what keeps the achievements dialog reachable.
       {% endcomment %}
       {% if profile_is_owner or achievements_data.achievements or profile_badges or posts or account_connections_none_connected %}
       <div class="user-profile__col">
-        {% if profile_is_owner or achievements_data.achievements %}
+        {% if achievements_data.achievements %}
         <div class="user-profile__achievements">
           {% include "v3/includes/_achievement_card.html" with achievements=achievements_data.achievements primary_button_url="#achievements-modal" %}
         </div>

--- a/templates/v3/user_profile_page.html
+++ b/templates/v3/user_profile_page.html
@@ -53,19 +53,14 @@
         An empty column would otherwise leave the bio at half width beside a
         blank gap.
 
-        The badges card renders on the member's own page even with nothing in
-        it: its empty state carries the only CTA that opens the badges dialog,
-        so suppressing it would leave no way in. A visitor sees it only once it
+        Both recognition cards render on the member's own page even with
+        nothing in them: their empty states carry the only CTAs that open the
+        badge and achievement dialogs. A visitor sees each card only once it
         has real data.
-
-        Achievements are not treated that way (issue #2702). The card is shown
-        only to a member who has earned something, owner included, rather than
-        offering an example dressed up as their own; its CTA rides on the filled
-        card, which is what keeps the achievements dialog reachable.
       {% endcomment %}
       {% if profile_is_owner or achievements_data.achievements or profile_badges or posts or account_connections_none_connected %}
       <div class="user-profile__col">
-        {% if achievements_data.achievements %}
+        {% if profile_is_owner or achievements_data.achievements %}
         <div class="user-profile__achievements">
           {% include "v3/includes/_achievement_card.html" with achievements=achievements_data.achievements primary_button_url="#achievements-modal" %}
         </div>

--- a/users/forms.py
+++ b/users/forms.py
@@ -362,7 +362,7 @@ class V3UserProfileForm(forms.Form):
         required=False,
     )
     hide_ach = forms.BooleanField(
-        label="Hide badges on your profile",
+        label="Hide badges and achievements on your profile",
         required=False,
     )
 

--- a/users/mixins.py
+++ b/users/mixins.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 
 from badges import display as badge_display
+from badges.summary import user_badge_summary
 from core.context_processors import edit_profile_url
 from users.profile_cards import github_activity_card_context
 
@@ -93,20 +94,19 @@ class V3UserProfileContextMixin:
         buttons.extend(self.get_trailing_buttons(user))
         return buttons
 
-    def get_v3_public_context(self, user, summary_rows=None):
+    def get_v3_public_context(self, user):
         """Context for the read-only v3 profile view.
 
         Renders real user data. Sections with no underlying data (GitHub
         activity, mailing list activity, posts) are left out of the context so
         the template omits them entirely; achievements are present but empty,
         which the template treats the same way. The bio section is always
-        rendered, falling back to an empty state.
-
-        `summary_rows` lets a caller that needs the badge summary for something
-        else hand over the rows it already read, rather than paying for a second
-        read of the same thing. `CurrentUserProfileView` does, for the
-        achievements dialog's counts."""
+        rendered, falling back to an empty state."""
         is_owner = user == self.request.user
+        # Read once and used twice below: the achievements card and the
+        # dialog's counters are the same query. Both readers live here so that
+        # every route to a page gets the same answer for the same cost.
+        summary_rows = user_badge_summary(user)
         context = {
             "user_info": {
                 "user_name": user.display_name,
@@ -147,6 +147,15 @@ class V3UserProfileContextMixin:
             "bio": user.biography or None,
             "top_links": self.get_v3_profile_link_buttons(user),
         }
+        # Owner-only, and keyed on who is looking rather than which URL was
+        # used: `/users/me/` and your own `/users/<routing-key>/` page are the
+        # same page, so both show your real tallies. A visitor gets no rows at
+        # all and the dialog falls back to the catalogue, another member's
+        # tallies not being this dialog's to show.
+        if is_owner:
+            context["achievement_dialog_items"] = badge_display.achievement_dialog_rows(
+                user, rows=summary_rows
+            )
         # Rendered on anyone's profile, not just your own, and omitted entirely
         # without a linked GitHub account so a profile with no data stays the
         # bio card alone. include_hidden for the owner, for the same reason as

--- a/users/mixins.py
+++ b/users/mixins.py
@@ -106,7 +106,11 @@ class V3UserProfileContextMixin:
         # Read once and used twice below: the achievements card and the
         # dialog's counters are the same query. Both readers live here so that
         # every route to a page gets the same answer for the same cost.
-        summary_rows = user_badge_summary(user)
+        #
+        # `hide_badges` covers achievements too, so a visitor to a profile that
+        # hid them has nothing to read the summary for.
+        show_recognition = is_owner or not user.hide_badges
+        summary_rows = user_badge_summary(user) if show_recognition else None
         context = {
             "user_info": {
                 "user_name": user.display_name,
@@ -128,10 +132,13 @@ class V3UserProfileContextMixin:
             },
             "profile_badges": badge_display.badge_cards(user, include_hidden=is_owner),
             # Dict-wrapped to match the shape the v3 component gallery feeds
-            # the same card. Empty for a member who has earned nothing, and the
-            # card is then left out rather than shown as an example.
+            # the same card. Empty for a member who has earned nothing - or hid
+            # them - and the card is then left out rather than shown as an
+            # example.
             "achievements_data": {
-                "achievements": badge_display.achievement_cards(user, rows=summary_rows)
+                "achievements": badge_display.achievement_cards(
+                    user, rows=summary_rows, include_hidden=is_owner
+                )
             },
             # The recognition cards render on the owner's own page even when
             # empty, because their empty states are the way in to the badge and

--- a/users/mixins.py
+++ b/users/mixins.py
@@ -93,14 +93,19 @@ class V3UserProfileContextMixin:
         buttons.extend(self.get_trailing_buttons(user))
         return buttons
 
-    def get_v3_public_context(self, user):
+    def get_v3_public_context(self, user, summary_rows=None):
         """Context for the read-only v3 profile view.
 
         Renders real user data. Sections with no underlying data (GitHub
         activity, mailing list activity, posts) are left out of the context so
         the template omits them entirely; achievements are present but empty,
         which the template treats the same way. The bio section is always
-        rendered, falling back to an empty state."""
+        rendered, falling back to an empty state.
+
+        `summary_rows` lets a caller that needs the badge summary for something
+        else hand over the rows it already read, rather than paying for a second
+        read of the same thing. `CurrentUserProfileView` does, for the
+        achievements dialog's counts."""
         is_owner = user == self.request.user
         context = {
             "user_info": {
@@ -126,7 +131,7 @@ class V3UserProfileContextMixin:
             # the same card. Empty for a member who has earned nothing, and the
             # card is then left out rather than shown as an example.
             "achievements_data": {
-                "achievements": badge_display.achievement_cards(user)
+                "achievements": badge_display.achievement_cards(user, rows=summary_rows)
             },
             # The recognition cards render on the owner's own page even when
             # empty, because their empty states are the way in to the badge and

--- a/users/mixins.py
+++ b/users/mixins.py
@@ -128,10 +128,9 @@ class V3UserProfileContextMixin:
             "achievements_data": {
                 "achievements": badge_display.achievement_cards(user)
             },
-            # The badges card renders on the owner's own page even when empty,
-            # because its empty state is the way in to the badges dialog. A
-            # visitor sees it only with real data. Achievements do not use this:
-            # that card is hidden whenever it is empty, owner or not.
+            # The recognition cards render on the owner's own page even when
+            # empty, because their empty states are the way in to the badge and
+            # achievement dialogs. A visitor sees them only with real data.
             "profile_is_owner": is_owner,
             # Library contributions grouped by role, rendered as the
             # contributions section of the bio card. An empty dict means no

--- a/users/mixins.py
+++ b/users/mixins.py
@@ -97,9 +97,10 @@ class V3UserProfileContextMixin:
         """Context for the read-only v3 profile view.
 
         Renders real user data. Sections with no underlying data (GitHub
-        activity, mailing list activity, posts, achievements) are left out
-        of the context so the template omits them entirely. The bio section
-        is always rendered, falling back to an empty state."""
+        activity, mailing list activity, posts) are left out of the context so
+        the template omits them entirely; achievements are present but empty,
+        which the template treats the same way. The bio section is always
+        rendered, falling back to an empty state."""
         is_owner = user == self.request.user
         context = {
             "user_info": {
@@ -121,9 +122,16 @@ class V3UserProfileContextMixin:
                 ),
             },
             "profile_badges": badge_display.badge_cards(user, include_hidden=is_owner),
-            # The recognition cards render on the owner's own page even when
-            # empty, because their empty states are the way in to the badge and
-            # achievement dialogs. A visitor sees them only with real data.
+            # Dict-wrapped to match the shape the v3 component gallery feeds
+            # the same card. Empty for a member who has earned nothing, and the
+            # card is then left out rather than shown as an example.
+            "achievements_data": {
+                "achievements": badge_display.achievement_cards(user)
+            },
+            # The badges card renders on the owner's own page even when empty,
+            # because its empty state is the way in to the badges dialog. A
+            # visitor sees it only with real data. Achievements do not use this:
+            # that card is hidden whenever it is empty, owner or not.
             "profile_is_owner": is_owner,
             # Library contributions grouped by role, rendered as the
             # contributions section of the bio card. An empty dict means no

--- a/users/tests/test_profile_dialogs.py
+++ b/users/tests/test_profile_dialogs.py
@@ -34,9 +34,7 @@ def profile_body(owner):
 def decorated_profile_body(owner, grant_achievement):
     """The page of a member who has earned something.
 
-    The achievements card is hidden while it is empty, so its CTA - the only
-    trigger for the achievements dialog - is only on the page of a member with
-    an achievement to show.
+    A filled achievements card, which is the state that drops the CTA.
     """
     review = Achievement.objects.get(slug=AchievementSlug.LIBRARY_REVIEW)
     grant_achievement(owner, review)
@@ -48,10 +46,10 @@ def test_profile_page_renders_both_dialogs(profile_body):
     assert 'id="badges-modal"' in profile_body
 
 
-def test_achievements_cta_opens_its_dialog(decorated_profile_body):
+def test_achievements_cta_opens_its_dialog(profile_body):
     (href,) = re.findall(
         r'<a[^>]*href="([^"]*)"[^>]*>(?:(?!</a>).)*Learn how achievements work',
-        decorated_profile_body,
+        profile_body,
         re.S,
     )
 
@@ -90,15 +88,16 @@ def test_a_single_digit_count_is_padded(owner, grant_achievement):
     assert ">03<" in row
 
 
-def test_an_untouched_achievement_counts_zero(owner):
-    """Zero on the owner's page, where the answer is known."""
+def test_an_untouched_achievement_shows_the_placeholder(owner):
+    """Never ``00`` on the owner's page - the counter is the dialog's artwork."""
     body = render_profile(owner)
     dialog = body[body.index('id="achievements-modal"') :]
 
-    assert ">00<" in dialog
+    assert ">00<" not in dialog
+    assert ">01<" in dialog
 
 
-def test_the_achievements_cta_rides_on_the_filled_card(decorated_profile_body):
-    """The CTA used to be empty-state only, which hid it from every real member."""
-    assert "Learn how achievements work" in decorated_profile_body
-    assert "achievement-card__achivement-example" not in decorated_profile_body
+def test_a_filled_achievements_card_drops_the_cta(decorated_profile_body):
+    """The button is the empty state's, the same way the badges card works."""
+    assert "Showcase your contributions" not in decorated_profile_body
+    assert "Learn how achievements work" not in decorated_profile_body

--- a/users/tests/test_profile_dialogs.py
+++ b/users/tests/test_profile_dialogs.py
@@ -30,15 +30,28 @@ def profile_body(owner):
     return render_profile(owner)
 
 
+@pytest.fixture
+def decorated_profile_body(owner, grant_achievement):
+    """The page of a member who has earned something.
+
+    The achievements card is hidden while it is empty, so its CTA - the only
+    trigger for the achievements dialog - is only on the page of a member with
+    an achievement to show.
+    """
+    review = Achievement.objects.get(slug=AchievementSlug.LIBRARY_REVIEW)
+    grant_achievement(owner, review)
+    return render_profile(owner)
+
+
 def test_profile_page_renders_both_dialogs(profile_body):
     assert 'id="achievements-modal"' in profile_body
     assert 'id="badges-modal"' in profile_body
 
 
-def test_achievements_cta_opens_its_dialog(profile_body):
+def test_achievements_cta_opens_its_dialog(decorated_profile_body):
     (href,) = re.findall(
         r'<a[^>]*href="([^"]*)"[^>]*>(?:(?!</a>).)*Learn how achievements work',
-        profile_body,
+        decorated_profile_body,
         re.S,
     )
 
@@ -83,3 +96,9 @@ def test_an_untouched_achievement_counts_zero(owner):
     dialog = body[body.index('id="achievements-modal"') :]
 
     assert ">00<" in dialog
+
+
+def test_the_achievements_cta_rides_on_the_filled_card(decorated_profile_body):
+    """The CTA used to be empty-state only, which hid it from every real member."""
+    assert "Learn how achievements work" in decorated_profile_body
+    assert "achievement-card__achivement-example" not in decorated_profile_body

--- a/users/views.py
+++ b/users/views.py
@@ -62,8 +62,6 @@ from .forms import (
     CustomSignUpForm,
     SLACK_PROFILE_URL_PREFIX,
 )
-from badges.summary import user_badge_summary
-
 from .mixins import V3UserProfileContextMixin
 from .models import (
     NO_PUBLIC_ROLE_OPTION,
@@ -414,17 +412,7 @@ class CurrentUserProfileView(
     def get_v3_context_data(self, **kwargs):
         if self.request.GET.get("edit", "").lower() == "true":
             return self.get_v3_edit_context()
-        # Read once and handed to both readers below. The cards and the
-        # dialog's counts are the same query, and this page is the only one
-        # that wants both.
-        summary_rows = user_badge_summary(self.request.user)
-        ctx = self.get_v3_public_context(self.request.user, summary_rows=summary_rows)
-        # Counted here rather than in the shared context so only the owner's own
-        # page can produce real tallies.
-        ctx["achievement_dialog_items"] = badge_display.achievement_dialog_rows(
-            self.request.user, rows=summary_rows
-        )
-        return ctx
+        return self.get_v3_public_context(self.request.user)
 
     def get_template_names(self):
         if (

--- a/users/views.py
+++ b/users/views.py
@@ -62,6 +62,8 @@ from .forms import (
     CustomSignUpForm,
     SLACK_PROFILE_URL_PREFIX,
 )
+from badges.summary import user_badge_summary
+
 from .mixins import V3UserProfileContextMixin
 from .models import (
     NO_PUBLIC_ROLE_OPTION,
@@ -412,11 +414,15 @@ class CurrentUserProfileView(
     def get_v3_context_data(self, **kwargs):
         if self.request.GET.get("edit", "").lower() == "true":
             return self.get_v3_edit_context()
-        ctx = self.get_v3_public_context(self.request.user)
+        # Read once and handed to both readers below. The cards and the
+        # dialog's counts are the same query, and this page is the only one
+        # that wants both.
+        summary_rows = user_badge_summary(self.request.user)
+        ctx = self.get_v3_public_context(self.request.user, summary_rows=summary_rows)
         # Counted here rather than in the shared context so only the owner's own
         # page can produce real tallies.
         ctx["achievement_dialog_items"] = badge_display.achievement_dialog_rows(
-            self.request.user
+            self.request.user, rows=summary_rows
         )
         return ctx
 


### PR DESCRIPTION
# Issue: #2702

## Summary & Context

The Achievements section never appeared on any profile because the data behind it was never sent to the page. This connects it to each member's real achievements, gives it the same empty state the Badges card already has, and stops the Badges card from listing the same badge once per tier the member climbed through.

- **Figma link**: [User Profile](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1995-46465)
- **Link to components/page:**
    - `localhost:8000/users/<routing-key>/`
    - `localhost:8000/users/me/`
    - `localhost:8000/v3/demo/components/`

## Changes

1. Added `badges.display.achievement_cards(user, rows=None, include_hidden=False)`, which turns a member's valid achievement grants into the rows the Achievements card renders: name, description, and how many times they earned it. Achievements they have never earned are left out, and an achievement that feeds two badges counts once. Ordered by tally, biggest first.
2. Sent those rows to the profile page as `achievements_data` from `V3UserProfileContextMixin`, so both the public profile and `/users/me/` get them.
3. The Achievements card now behaves like the Badges card beside it: the owner always sees it, and a visitor sees it only once there is something in it. Its empty state dropped the two fake examples ("Patch Wizard 19", "Consensus Builder 7") that looked like the member's own achievements, keeping the copy line and the button. The CSS rule that dimmed those example rows went with them.
4. Removed the "Learn how achievements work" button so it shows ONLY on empty cards.
5. The counters in the Achievements dialog no longer read `00`. An achievement with nothing earned shows the placeholder `01`, the same figure the demo page uses; a real tally still shows through (3 renders `03`, 12 renders `12`).
6. The Badges card now shows one badge per category, at the highest tier the member reached.
7. A member's featured badge (the one beside their name on the profile card) now falls back to their highest badge when they have not picked one. This is why Marshall Clow showed no badge at all despite holding 11.
8. "Hide badges on your profile" now hides achievements as well, so the checkbox is one control over the recognition column rather than one over half of it. Its label changed to "Hide badges and achievements on your profile" to match.
9. The owner's own profile reads the badge summary once instead of twice. The Achievements card and the dialog's counters come from the same query, and each was reading it for itself, so `/users/me/` paid for all five queries behind it twice over. It now drops from 27 queries to 22.
10. The achievements dialog now shows your real tallies on both routes to your own profile. Its counts were attached by the `/users/me/` view alone, so reaching your own profile by its public `/users/<routing-key>/` URL showed the catalogue placeholder instead of what you had earned.
11. The badge you pick as your display badge now leads the Badges card. Everything behind the pick keeps rank order. 

## ‼️ Risks & Considerations ‼️

**A revoked pick now falls back instead of showing nothing.** If a member picked a badge and staff later revoked it, they now show their next-highest badge. Flagging it because it is a judgment call, not something the issue specifies.

**Members will see their Badges card shrink.** Anyone who climbed several tiers loses rows. This is the intended fix.

**The dialog counter now shows `01` for an achievement you have none of.**

**The visibility checkbox changed wording, and copy is design-owned.** Making it cover achievements made "Hide badges on your profile" wrong, so it now reads "Hide badges and achievements on your profile".

**Verified against a decorated account** holding 13 badges across 5 categories and 27 achievement grants. With the box unticked, owner and visitor both see 5 badge rows and 5 achievement rows. With it ticked, the visitor sees 0 and 0 while the owner still sees 5 and 5. 

## Screenshots

### Hide and Show Badges & Achievements

https://github.com/user-attachments/assets/3b755169-0ab0-40db-b15c-d4ef5922064b

### Display Badge Functionality

https://github.com/user-attachments/assets/0767a975-1150-4565-bca8-1a0ca0902ddc

### User with No Badges and no Achievements

https://github.com/user-attachments/assets/a03130ee-f090-4cd9-9485-9e2d5fa881ef

### User with Badges & Achievements

<img width="1331" height="1080" alt="UserWithAchievementsAndBadges" src="https://github.com/user-attachments/assets/3fe8eb31-5355-4327-9b09-26c4ab8e698c" />

### Referenced User by QA

<img width="1331" height="1080" alt="ReferencedUser" src="https://github.com/user-attachments/assets/c2133f62-ef03-4908-8186-fd02520dd2b4" />

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend

- [ ] UI implementation matches Figma design
- [ ] Tested in light and dark mode
- [ ] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [ ] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added achievement cards to profiles, showing earned achievements with counts and consistent ordering.
  * Selected badges now appear first, while each badge displays its highest earned tier.
  * Profiles now fall back to the highest held badge when no featured badge is selected.
* **Bug Fixes**
  * Corrected achievement counts to show the appropriate placeholder for empty or unavailable totals.
  * Improved badge and achievement visibility rules for profile owners and visitors.
* **UI Improvements**
  * Added a clear empty state for profiles without achievements.
  * Updated profile settings to clarify that hiding badges also hides achievements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->