### PR TITLE
Story 2703: display only related posts in library subpage

### DIFF
--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -420,6 +420,56 @@ def test_library_docs_redirect(tp, library, library_version):
     tp.response_302(resp)
 
 
+@waffle.testutils.override_flag("v3", active=True)
+def test_library_detail_v3_latest_posts_are_scoped_to_the_library(
+    tp, library_version, make_post_page, wagtail_site
+):
+    """The posts card shows this library's posts, not the newest ones site-wide."""
+    library = library_version.library
+    make_post_page(title="Tagged post", tags=[library.slug])
+    make_post_page(title="Unrelated post")
+
+    url = tp.reverse("library-detail", "latest", library.slug)
+    tp.response_200(tp.get(url))
+
+    titles = [card["title"] for card in tp.get_context("library_posts")]
+    assert titles == ["Tagged post"]
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_library_detail_v3_latest_posts_cta_points_at_the_news_index(
+    tp, library_version, make_post_page, post_index_page, wagtail_site
+):
+    """Unset, the card's "View all posts" button renders an empty href.
+
+    It has to resolve to the Wagtail index rather than `reverse("news")`,
+    which is the legacy entry list that v3 no longer links anywhere.
+    """
+    library = library_version.library
+    make_post_page(title="Tagged post", tags=[library.slug])
+
+    url = tp.reverse("library-detail", "latest", library.slug)
+    tp.response_200(tp.get(url))
+
+    cta_url = tp.get_context("library_posts_cta_url")
+    assert cta_url == post_index_page.get_url()
+    assert cta_url != tp.reverse("news")
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_library_detail_v3_hides_the_posts_card_without_tagged_posts(
+    tp, library_version, make_post_page, wagtail_site
+):
+    """An empty list is what the template checks to drop the card entirely."""
+    library = library_version.library
+    make_post_page(title="Unrelated post")
+
+    url = tp.reverse("library-detail", "latest", library.slug)
+    tp.response_200(tp.get(url))
+
+    assert tp.get_context("library_posts") == []
+
+
 def test_library_detail_context_get_commit_data_(tp, library_version):
     """
     GET /library/latest/{library_slug}/

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -25,6 +25,7 @@ from core.githubhelper import GithubAPIClient
 from core.mixins import V3Mixin
 from mailing_list.mixins import MailingListCardMixin
 from news.services import get_latest_post_cards
+from pages.routing import post_index_url
 from core.mock_data import SharedResources
 from users.models import User
 from versions.exceptions import BoostImportedDataException
@@ -643,7 +644,10 @@ class LibraryDetail(
             version_str,
         )
 
-        context["library_posts"] = get_latest_post_cards(limit=3, request=self.request)
+        context["library_posts"] = get_latest_post_cards(
+            limit=3, request=self.request, library_slug=self.object.slug
+        )
+        context["library_posts_cta_url"] = post_index_url(self.request)
 
         this_release = _build_release_contributors(context)
         context["this_release_contributors"] = (

--- a/news/services.py
+++ b/news/services.py
@@ -1,5 +1,4 @@
 from badges.display import active_badges_prefetch
-from pages.models import PostPage
 from pages.routing import v3_posts_active
 
 
@@ -89,45 +88,3 @@ def get_latest_post_cards(
         post.to_v3_post_card_dict()
         for post in _latest_posts(limit, request, library_slug)
     ]
-
-
-def _post_page_to_post_card(page: PostPage) -> dict:
-    author = page.author
-    return {
-        "title": page.title,
-        "url": page.get_absolute_url(),
-        "date": page.first_published_at,
-        "category": (
-            news_type_label(page.post_content_type) if page.post_content_type else ""
-        ),
-        "tag": "",
-        "author": author.to_v3_profile_dict() if author else None,
-    }
-
-
-def get_library_post_cards(library_slug: str, limit: int = 3) -> list[dict]:
-    """Return the latest posts tagged with `library_slug` as post-card dicts.
-
-    Posts are linked to a library through a `ContentTag` whose slug mirrors the
-    library slug (see the create-post view). Only Wagtail `PostPage` posts carry
-    that link; legacy news `Entry` rows have no library relation, so they are
-    deliberately excluded rather than shown unfiltered.
-
-    The filter goes through `tagged_items` rather than the `tags` manager: the
-    tag's parental key points at `wagtailcore.Page`, so filtering `tags__slug`
-    on a child page model builds a join against a `pages_postpage.id` column
-    that does not exist.
-
-    Returns an empty list when nothing is tagged, which is what hides the card.
-    """
-    if not library_slug:
-        return []
-
-    queryset = (
-        PostPage.objects.live()
-        .public()
-        .filter(tagged_items__tag__slug=library_slug)
-        .select_related("owner", "owner__displayed_profile_role_library")
-        .order_by("-first_published_at")[:limit]
-    )
-    return [_post_page_to_post_card(page) for page in queryset]

--- a/news/services.py
+++ b/news/services.py
@@ -23,22 +23,36 @@ def news_type_label(news_type: str) -> str:
 # return it, so downstream templates never branch on which one produced it.
 
 
-def _latest_posts(limit: int, request):
-    """Newest published posts, from whichever model the `v3` flag selects."""
+def _latest_posts(limit: int, request, library_slug=None):
+    """Newest published posts, from whichever model the `v3` flag selects.
+
+    `library_slug` narrows the result to posts tagged with that library.
+    """
     if v3_posts_active(request):
         from pages.models import PostPage
 
+        queryset = PostPage.objects.live()
+        if library_slug is not None:
+            # Posts are linked to a library through a `ContentTag` whose slug
+            # mirrors the library slug (see the create-post view). The filter
+            # goes through `tagged_items` rather than the `tags` manager: the
+            # tag's parental key points at `wagtailcore.Page`, so filtering
+            # `tags__slug` on a child page model builds a join against a
+            # `pages_postpage.id` column that does not exist.
+            queryset = queryset.filter(tagged_items__tag__slug=library_slug)
         return (
-            PostPage.objects.live()
-            .select_related("owner", "owner__displayed_profile_role_library")
+            queryset.select_related("owner", "owner__displayed_profile_role_library")
             # Badges per card, and the author's routing keys for the profile
             # link: one query for the page rather than one per card.
             .prefetch_related(
                 active_badges_prefetch("owner__badges"),
                 "owner__profile_routing_keys",
-            )
-            .order_by("-first_published_at")[:limit]
+            ).order_by("-first_published_at")[:limit]
         )
+    if library_slug is not None:
+        # Legacy entries carry no library relation, so there is nothing to
+        # filter on; showing them unfiltered would be worse than showing none.
+        return Entry.objects.none()
     return (
         Entry.objects.published()
         .filter(deleted_at__isnull=True)
@@ -53,7 +67,9 @@ def _latest_posts(limit: int, request):
     )
 
 
-def get_latest_post_cards(limit: int = 3, request=None) -> list[dict]:
+def get_latest_post_cards(
+    limit: int = 3, request=None, library_slug=None
+) -> list[dict]:
     """Return the most recent published posts as v3 post-card dicts.
 
     Shared by the Learn page, library detail, community page, and any other
@@ -63,8 +79,16 @@ def get_latest_post_cards(limit: int = 3, request=None) -> list[dict]:
     The source is picked by the `v3` waffle flag: Wagtail post pages when V3
     is on, legacy news entries when it is off. The two are never mixed, so
     turning the flag off puts every surface back on legacy content.
+
+    Pass `library_slug` to get only the posts tagged with that library. Legacy
+    entries have no library relation, so a library-scoped call returns an empty
+    list when the flag is off rather than falling back to unfiltered posts.
+    An empty list is also what hides the card on the library subpage.
     """
-    return [post.to_v3_post_card_dict() for post in _latest_posts(limit, request)]
+    return [
+        post.to_v3_post_card_dict()
+        for post in _latest_posts(limit, request, library_slug)
+    ]
 
 
 def _post_page_to_post_card(page: PostPage) -> dict:

--- a/news/tests/test_services.py
+++ b/news/tests/test_services.py
@@ -9,7 +9,6 @@ from wagtail.models import Page
 from waffle.testutils import override_flag
 
 from news.services import get_latest_post_cards
-from news.services import get_library_post_cards
 from pages.mixins import ContentTag
 from pages.models import PostIndexPage
 from pages.models import PostPage
@@ -60,6 +59,31 @@ class TestLatestPostCardsScopedToALibrary:
         cards = get_latest_post_cards(request=rf.get("/"), library_slug="multi_array")
 
         assert [card["title"] for card in cards] == ["Tagged post"]
+
+    @override_flag("v3", active=True)
+    def test_card_shape(self, rf, make_post_page):
+        page = make_post_page("Tagged post", tag_slugs=["multi_array"])
+
+        (card,) = get_latest_post_cards(request=rf.get("/"), library_slug="multi_array")
+
+        assert card["title"] == "Tagged post"
+        assert card["url"] == page.get_absolute_url()
+        assert card["date"] == page.first_published_at
+        assert card["tag"] == ""
+        assert card["author"] == page.owner.to_v3_profile_dict()
+
+    @pytest.mark.xfail(
+        reason="PostPage.tag returns the library ContentTag, so the chip shows "
+        "the library name instead of the post type. Tracked separately.",
+        strict=True,
+    )
+    @override_flag("v3", active=True)
+    def test_card_category_is_the_post_type(self, rf, make_post_page):
+        make_post_page("Tagged post", tag_slugs=["multi_array"])
+
+        (card,) = get_latest_post_cards(request=rf.get("/"), library_slug="multi_array")
+
+        assert card["category"] == "News"
 
     @override_flag("v3", active=True)
     def test_omitting_the_slug_still_returns_every_post(self, rf, make_post_page):
@@ -119,59 +143,6 @@ class TestLatestPostCardsScopedToALibrary:
         cards = get_latest_post_cards(request=rf.get("/"), library_slug="multi_array")
 
         assert cards == []
-
-
-class TestGetLibraryPostCards:
-    def test_returns_only_posts_tagged_with_the_library(self, make_post_page):
-        make_post_page("Tagged post", tag_slugs=["multi_array"])
-        make_post_page("Other library post", tag_slugs=["beast"])
-        make_post_page("Untagged post")
-
-        cards = get_library_post_cards("multi_array")
-
-        assert [card["title"] for card in cards] == ["Tagged post"]
-
-    def test_card_shape(self, make_post_page):
-        page = make_post_page("Tagged post", tag_slugs=["multi_array"])
-
-        (card,) = get_library_post_cards("multi_array")
-
-        assert card["title"] == "Tagged post"
-        assert card["url"] == page.get_absolute_url()
-        assert card["date"] == page.first_published_at
-        assert card["category"] == "News"
-        assert card["tag"] == ""
-        assert card["author"] == page.owner.to_v3_profile_dict()
-
-    def test_excludes_unpublished_posts(self, make_post_page):
-        make_post_page("Draft post", tag_slugs=["multi_array"], live=False)
-
-        assert get_library_post_cards("multi_array") == []
-
-    def test_newest_first_and_limited(self, make_post_page):
-        import datetime
-
-        base = now()
-        for index in range(4):
-            make_post_page(
-                f"Post {index}",
-                tag_slugs=["multi_array"],
-                published_at=base - datetime.timedelta(days=index),
-            )
-
-        cards = get_library_post_cards("multi_array", limit=3)
-
-        assert [card["title"] for card in cards] == ["Post 0", "Post 1", "Post 2"]
-
-    def test_no_matching_posts_returns_empty_list(self, make_post_page):
-        make_post_page("Other library post", tag_slugs=["beast"])
-
-        assert get_library_post_cards("multi_array") == []
-
-    def test_blank_slug_returns_empty_list(self, make_post_page):
-        make_post_page("Tagged post", tag_slugs=["multi_array"])
-
-        assert get_library_post_cards("") == []
 
 
 def test_post_card_links_the_author_profile(make_entry):

--- a/news/tests/test_services.py
+++ b/news/tests/test_services.py
@@ -6,6 +6,7 @@ from model_bakery import baker
 from wagtail.models import Collection
 from wagtail.models import Locale
 from wagtail.models import Page
+from waffle.testutils import override_flag
 
 from news.services import get_latest_post_cards
 from news.services import get_library_post_cards
@@ -47,6 +48,77 @@ def make_post_page(post_index_page, make_user):
         return page
 
     return _make_it
+
+
+class TestLatestPostCardsScopedToALibrary:
+    @override_flag("v3", active=True)
+    def test_returns_only_posts_tagged_with_the_library(self, rf, make_post_page):
+        make_post_page("Tagged post", tag_slugs=["multi_array"])
+        make_post_page("Other library post", tag_slugs=["beast"])
+        make_post_page("Untagged post")
+
+        cards = get_latest_post_cards(request=rf.get("/"), library_slug="multi_array")
+
+        assert [card["title"] for card in cards] == ["Tagged post"]
+
+    @override_flag("v3", active=True)
+    def test_omitting_the_slug_still_returns_every_post(self, rf, make_post_page):
+        make_post_page("Tagged post", tag_slugs=["multi_array"])
+        make_post_page("Untagged post")
+
+        cards = get_latest_post_cards(request=rf.get("/"))
+
+        assert len(cards) == 2
+
+    @override_flag("v3", active=True)
+    def test_excludes_unpublished_posts(self, rf, make_post_page):
+        make_post_page("Draft post", tag_slugs=["multi_array"], live=False)
+
+        cards = get_latest_post_cards(request=rf.get("/"), library_slug="multi_array")
+
+        assert cards == []
+
+    @override_flag("v3", active=True)
+    def test_newest_first_and_limited(self, rf, make_post_page):
+        import datetime
+
+        base = now()
+        for index in range(4):
+            make_post_page(
+                f"Post {index}",
+                tag_slugs=["multi_array"],
+                published_at=base - datetime.timedelta(days=index),
+            )
+
+        cards = get_latest_post_cards(
+            limit=3, request=rf.get("/"), library_slug="multi_array"
+        )
+
+        assert [card["title"] for card in cards] == ["Post 0", "Post 1", "Post 2"]
+
+    @override_flag("v3", active=True)
+    def test_no_matching_posts_returns_empty_list(self, rf, make_post_page):
+        make_post_page("Other library post", tag_slugs=["beast"])
+
+        cards = get_latest_post_cards(request=rf.get("/"), library_slug="multi_array")
+
+        assert cards == []
+
+    @override_flag("v3", active=True)
+    def test_blank_slug_returns_empty_list(self, rf, make_post_page):
+        make_post_page("Tagged post", tag_slugs=["multi_array"])
+
+        assert get_latest_post_cards(request=rf.get("/"), library_slug="") == []
+
+    @override_flag("v3", active=False)
+    def test_legacy_entries_are_never_returned_unfiltered(
+        self, rf, make_post_page, make_entry
+    ):
+        make_entry()
+
+        cards = get_latest_post_cards(request=rf.get("/"), library_slug="multi_array")
+
+        assert cards == []
 
 
 class TestGetLibraryPostCards:

--- a/news/tests/test_services.py
+++ b/news/tests/test_services.py
@@ -69,21 +69,17 @@ class TestLatestPostCardsScopedToALibrary:
         assert card["title"] == "Tagged post"
         assert card["url"] == page.get_absolute_url()
         assert card["date"] == page.first_published_at
-        assert card["tag"] == ""
         assert card["author"] == page.owner.to_v3_profile_dict()
 
-    @pytest.mark.xfail(
-        reason="PostPage.tag returns the library ContentTag, so the chip shows "
-        "the library name instead of the post type. Tracked separately.",
-        strict=True,
-    )
     @override_flag("v3", active=True)
-    def test_card_category_is_the_post_type(self, rf, make_post_page):
+    def test_card_meta_matches_the_post_list(self, rf, make_post_page):
+        """Type in one slot, library in the other, as rendered at /news/."""
         make_post_page("Tagged post", tag_slugs=["multi_array"])
 
         (card,) = get_latest_post_cards(request=rf.get("/"), library_slug="multi_array")
 
         assert card["category"] == "News"
+        assert card["tag"] == "multi_array"
 
     @override_flag("v3", active=True)
     def test_omitting_the_slug_still_returns_every_post(self, rf, make_post_page):

--- a/pages/models.py
+++ b/pages/models.py
@@ -328,21 +328,19 @@ class PostPage(BasePage):
         return reverse_lazy("v3-news-delete", kwargs={"slug": self.slug})
 
     def to_v3_post_card_dict(self, author_role=None):
-        """Dict shape consumed by `v3/includes/_post_card.html` items."""
-        from news.models import POST_CARD_TAG_LABELS
+        """Dict shape consumed by `v3/includes/_post_card.html` items.
 
-        category = ""
-
-        if self.tag:
-            tag_key = str(self.tag).lower()
-            category = POST_CARD_TAG_LABELS.get(tag_key, self.tag.name.capitalize())
-
+        The two meta slots match the post list at /news/: the type of the post
+        ("News", "Video") and the library it is tagged with, rendered as
+        "#beast". `self.tag` is a library `ContentTag`, not a post type, so it
+        belongs in the second slot rather than the first.
+        """
         return {
             "title": self.title,
             "url": self.get_absolute_url(),
             "date": self.date or self.publish_at,
-            "category": category,
-            "tag": "",
+            "category": self.type_label,
+            "tag": str(self.tag) if self.tag else "",
             "author": (
                 self.author.to_v3_profile_dict(role=author_role)
                 if self.author


### PR DESCRIPTION
# Issue: #2703

## Summary & Context

The "Latest Posts" card on a library subpage showed the newest posts from the whole site instead of the posts tagged with the library you were looking at. This restores the filtering, and fixes the card's "View all posts" button, which had been rendering with an empty link.

This is a regression, not a new bug. It was fixed once before in #2552 / #2660, then undone by #2649, which replaced the library-filtered call with the unfiltered one and deleted the line that set the button's URL. Both have been live since 2026-08-28.

It also corrects what each card shows under the title. Cards now read the same way as the post list at `/news/`: the type of the post ("News", "Video") followed by the library it is tagged with ("#Asio"). Previously the type slot showed the library's name and the library slot was always blank.

- **Figma link**: n/a
- **Link to components/page:** `localhost:8000/library/latest/<selected-library>/` (see note under Screenshots. The section only appears if posts are tagged with that library).

## Changes

- `get_latest_post_cards()` takes an optional `library_slug`. When passed, it returns only the posts tagged with that library. Every other caller is unaffected.
- The library subpage passes its library's slug, so the card is filtered again.
- The "View all posts" button gets its URL back. It now points at the Wagtail posts index (`/news/`) via the existing `post_index_url()` helper, not at the legacy list (`/news/entry/`). Simply restoring the deleted line would have sent people to the legacy page, because #2649 also changed where posts live.
- Deleted `get_library_post_cards()`, which did this job before #2649 and has had no callers since. The filtering now runs through the same function every other post card uses, so the two can't drift apart again, which is how the card shapes diverged in the first place.
- Post cards show the post's type and the library tag, matching `/news/`. The card template always had a slot for each, but the code filling them put the library in the type slot and left the tag slot empty, so a card on the Asio page read "Asio" where it should read "Video" and "#Asio".
- That last fix is in shared card code, so the same correction applies to Learn, Community, the home page and user profiles. See Risk 3.
- Added the tests that were missing. The old tests all passed throughout the regression because none of them checked what the subpage actually renders.

## ‼️ Risks & Considerations ‼️

**1. :warning: On production, this section may disappear from most or all library pages. :warning:**

This is the intended behaviour agreed in #2552 ("The card will not be displayed"), but it will look like something broke. The card only appears when posts are tagged with that library, and posts only get tagged when an author picks related libraries in the create-post form. Any post that predates that form, or was imported, has no tag.

For reference: my local database has 115 published posts and **zero** of them are tagged with any library. If production looks similar, the section will vanish everywhere.

> [!WARNING]
> **Worth checking the production tag data before merging**, so the team isn't surprised.

**2. Private posts.**

The old function excluded posts that are private or password-protected. The shared function it was replaced with doesn't. If anyone uses Wagtail's page privacy settings on posts, one could now appear on a library page. Nobody appears to be using that feature, so this isn't in scope, but flagging it as it's a small behaviour difference.

**3. Post cards change on other pages too.**

The label fix is in shared code (`PostPage.to_v3_post_card_dict`), so it applies anywhere v3 post cards appear: Learn, Community, the home page and user profiles. Two visible differences on those pages:

- The type label is now correct. It previously showed the library name on any post that had one, and nothing at all on posts that didn't.
- A `#library` label appears on posts that are tagged with one. That slot already existed in the template and was simply never filled, so a tagged card now carries one more label than before.

The filtering itself is not shared. Only the library subpage passes a library, so which posts appear on those other pages is unchanged.

Legacy news entries are unaffected either way. Their cards already showed the right type, and they have no library to show. When the `v3` flag is off the subpage doesn't render at all, so there's no legacy path to check.

## Screenshots

To reproduce locally you need at least one post tagged with a library (Risk 1).

Run the following command in a terminal after booting the application with `docker compose up`:

```sh
docker compose exec -T web python manage.py shell -c "
from libraries.models import Library
from pages.mixins import ContentTag
from pages.models import PostPage
def tag(pid, slug):
    lib = Library.objects.get(slug=slug)
    t, _ = ContentTag.objects.get_or_create(slug=lib.slug, defaults={'name': lib.name})
    p = PostPage.objects.get(id=pid); p.tags.add(t); p.save()
for pid in (48, 88, 110, 55): tag(pid, 'asio')
tag(38, 'beast')
```

Then navigate to the following endpoints:
/library/latest/asio/ -> 3 Asio posts (4 are tagged, the card caps at 3)
/library/latest/beast/ -> 1 post
/library/latest/array/ -> no card at all

### Asio Related Posts
<img width="910" height="912" alt="AsioLibrary" src="https://github.com/user-attachments/assets/04955698-9300-4721-9281-9badf7712f47" />

### Beast Related Posts
<img width="915" height="881" alt="BeastLibrary" src="https://github.com/user-attachments/assets/694c871f-07e4-449a-b523-fbcf8884944e" />

### Array Library with no Related Posts
<img width="912" height="544" alt="ArrayLibrary" src="https://github.com/user-attachments/assets/8fa4842b-6379-4bfa-bbdf-487c87856bf8" />

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend

- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Library detail pages now display posts tagged specifically for that library.
  - Added a “View all posts” link directing readers to the post index.
  - Post cards now display the post type and associated library tag.
  - The posts card is hidden when no matching library posts are available.

- **Bug Fixes**
  - Prevented unrelated, unpublished, or legacy posts from appearing in library-specific post cards.
  - Improved post card behavior under the v3 experience flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->