### PR TITLE
Bug 2667: Add post types to post detail page cards

### DIFF
--- a/templates/v3/includes/_post_card.html
+++ b/templates/v3/includes/_post_card.html
@@ -39,10 +39,10 @@
                       <h3 class="post-card__title">{{ item.title }}</h3>
                     {% endif %}
                   {% endif %}
-                  {% if item.date or item.category or item.tag %}
+                  {% if item.date or item.type_label or item.tag %}
                     <div class="post-card__meta">
                       {% if item.date %}<time datetime="{{ item.date|date:'c' }}">{{ item.date|date:"M jS, Y" }}</time>{% endif %}
-                      {% if item.category %}<span>{{ item.category|capfirst }}</span>{% endif %}
+                      {% if item.type_label %}<span>{{ item.type_label|capfirst }}</span>{% endif %}
                       {% if item.tag %}<span>#{{ item.tag }}</span>{% endif %}
                     </div>
                   {% endif %}


### PR DESCRIPTION
# Issue: #2667 

## Summary & Context
<!-- *1-2 sentences describing what this PR does and why* -->
Adds the post type as a value to the post cards on the post detail page.

- **Figma link**: <!-- Add link to relevant Figma design here --> https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=1644-111293&m=dev
- **Link to components/page:** <!-- e.g. localhost:8000/news/add --> http://localhost:8000/news/new-library-boostopenmethod/


## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*
None

## Screenshots

<!-- Before | After
-- | -- -->

Before: 
<img width="733" height="746" alt="image" src="https://github.com/user-attachments/assets/232246d7-e9ce-464c-ab48-ebd19b7d9529" />

After:
<img width="738" height="687" alt="image" src="https://github.com/user-attachments/assets/2ff8645e-9cbb-4e56-9abf-e622b221f2ab" />


## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
