### PR TITLE
Assessment: #2700 - Libraries: Authors are displayed as "Unknown" under Latest and some versions

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -131,6 +131,7 @@ INSTALLED_APPS += [
     "patches",
     "pages",
     "asciidoctor_sandbox",
+    "release_tools",
 ]
 
 AUTH_USER_MODEL = "users.User"

--- a/core/admin.py
+++ b/core/admin.py
@@ -256,7 +256,8 @@ def get_buttons():
 
     # Order is the checklist: commits are imported, their authors are bound to
     # members, reviews are re-scraped against those authors, and only then does
-    # the backfill read all of it.
+    # the backfill read all of it. The release synchronization is not part of that
+    # sequence - it is the repair for one release, run on its own.
     return [
         CONVERT_NEW_ENTRIES_BUTTON,
         UPDATE_INDEX_BUTTON,

--- a/core/admin_buttons.py
+++ b/core/admin_buttons.py
@@ -70,7 +70,12 @@ class TaskButton:
 
     ``choices`` makes the button a scoped run: the pairs become a select beside it
     and the chosen value reaches the task as ``argument``. Choosing nothing runs the
-    task with no arguments.
+    task with no arguments. It may also be a callable returning those pairs, for a
+    button whose options come from the database and so cannot be settled at import.
+
+    ``require_choice`` drops the "all" option and refuses an empty submission, for a
+    job that has no meaningful unscoped run - one whose whole point is that it does
+    not touch everything.
 
     ``permission`` names what authorises the job, for a task doing something the
     model's change permission does not cover - a sweep that deletes rows wants
@@ -97,8 +102,9 @@ class TaskButton:
     busy_message: str
     argument: str = ""
     choice_label: str = ""
-    choices: tuple = ()
+    choices: Any = ()
     all_label: str = "All"
+    require_choice: bool = False
     permission: str = ""
     confirm: Any = None
     description: str = ""
@@ -111,6 +117,19 @@ class TaskButton:
                 f"TaskButton {self.name!r} has choices but no argument to pass "
                 "the chosen value as."
             )
+        if self.require_choice and not self.choices:
+            raise ValueError(
+                f"TaskButton {self.name!r} requires a choice but offers none."
+            )
+
+    def resolved_choices(self):
+        """The select's pairs, resolving ``choices`` if it is a callable.
+
+        Read once per request rather than held on the button, so a database-backed
+        list is current and an import-time query is never made.
+        """
+        choices = self.choices() if callable(self.choices) else self.choices
+        return tuple(choices)
 
 
 def task_status(task_id):
@@ -176,7 +195,8 @@ class TaskButtonAdminMixin:
                 "label": button.label,
                 "argument": button.argument,
                 "choice_label": button.choice_label,
-                "choices": button.choices,
+                "choices": button.resolved_choices(),
+                "require_choice": button.require_choice,
                 "all_label": button.all_label,
                 "description": button.description,
                 "field_id": f"task-button-{button.name}-{button.argument}",
@@ -297,8 +317,16 @@ class TaskButtonAdminMixin:
             if not self._task_button_allows(request, button):
                 raise PermissionDenied
 
-            choices = dict(button.choices)
+            choices = dict(button.resolved_choices())
             value = request.POST.get(button.argument, "") if choices else ""
+            if button.require_choice and not value:
+                self.message_user(
+                    request,
+                    f"Choose {button.choice_label.lower() or 'an option'} first; "
+                    "this job has no unscoped run.",
+                    level=messages.WARNING,
+                )
+                return HttpResponseRedirect(redirect_url)
             # ``call_command`` does not enforce an argument's ``choices``, so an
             # unvetted value would only fail inside the worker, where nobody is
             # looking.

--- a/core/admin_buttons.py
+++ b/core/admin_buttons.py
@@ -251,6 +251,30 @@ class TaskButtonAdminMixin:
         status = task_status(task_id)
         return status is None or status[0] in RUNNING_STATES
 
+    def _task_button_running_labels(self, button, values):
+        """``{value: label}`` for the jobs among ``values`` that are unfinished.
+
+        Read per job rather than from ``_task_button_cache_key``, because one
+        button can have several jobs in flight at once and that key remembers
+        only the most recent of them. One ``get_many`` for the whole page, and
+        the result backend is asked only about the jobs that have an id.
+
+        A finished job is left out, so the control it belongs to is offered
+        again; so is one whose state the backend cannot report, which is the
+        same choice ``_task_button_status`` makes when it has nothing to poll
+        for.
+        """
+        keys = {self._task_button_job_key(button, value): value for value in values}
+        labels = {}
+        for key, task_id in cache.get_many(list(keys)).items():
+            result = task_status(task_id)
+            if result is None:
+                continue
+            state = result[0]
+            if state not in FINISHED_STATES:
+                labels[keys[key]] = TASK_STATE_LABELS.get(state, state)
+        return labels
+
     def _task_button_status(self, button):
         """What to say about ``button``'s last run, if there was one.
 

--- a/core/githubhelper.py
+++ b/core/githubhelper.py
@@ -324,10 +324,18 @@ class GithubAPIClient:
             ref = self.get_ref()
         tree_sha = ref["object"]["sha"]
 
+        # Most Boost release tags are lightweight, so the ref points straight at a
+        # commit. A few are annotated (boost-1.61.0 is), and there the ref points at
+        # the tag object instead, which the tree endpoint rejects with a 422. One
+        # extra call turns it into the commit the tag names.
+        if ref["object"].get("type") == "tag":
+            tree_sha = self.get_tag(repo_slug=repo_slug, tag_sha=tree_sha)["object"][
+                "sha"
+            ]
+
         try:
             tree = self.get_tree(tree_sha=tree_sha)
         except HTTP422UnprocessableEntityError as e:
-            # Only happens for version 1.61.0; uncertain why.
             self.logger.exception(
                 "get_gitmodules_failed", repo=repo_slug, exc_msg=str(e)
             )
@@ -541,6 +549,18 @@ class GithubAPIClient:
             page += 1
 
         return tags
+
+    def get_tag(self, repo_slug: str = None, tag_sha: str = None) -> dict:
+        """
+        Get an annotated tag object from the GitHub API.
+
+        :param repo_slug: str, the repository slug
+        :param tag_sha: str, the sha of the tag object itself
+        :return: dict, the tag object, whose "object" is the commit it points at
+        """
+        if not repo_slug:
+            repo_slug = self.repo_slug
+        return self.api.git.get_tag(owner=self.owner, repo=repo_slug, tag_sha=tag_sha)
 
     def get_tree(self, repo_slug: str = None, tree_sha: str = None) -> dict:
         """

--- a/libraries/management/commands/update_library_version_authors.py
+++ b/libraries/management/commands/update_library_version_authors.py
@@ -2,14 +2,33 @@ import djclick as click
 
 from django.db import transaction
 
-from libraries.models import Library
+from libraries.models import Library, LibraryVersion
 from libraries.github import LibraryUpdater
+
+
+def release_version_names(release):
+    """The version names ``--release`` should be read as, or an empty set.
+
+    Callers say "1.92.0" and callers say "boost-1.92.0"; the admin passes the
+    stored name and an operator types the number. Both are matched exactly, so a
+    release cannot quietly widen into its neighbours the way a substring match
+    would turn "1.9" into 1.90, 1.91 and 1.92.
+    """
+    if not release:
+        return set()
+    bare = release.removeprefix("boost-")
+    return {release, bare, f"boost-{bare}"}
 
 
 @click.command()
 @click.option("--library-name", is_flag=False, help="Library name (case-insensitive)")
+@click.option(
+    "--release",
+    is_flag=False,
+    help="Boost version to limit the run to (example: 1.92.0)",
+)
 @click.option("--clean", is_flag=True, help="Clear authors before importing new ones?")
-def command(library_name, clean):
+def command(library_name, release, clean):
     """Cycles through all LibrariesVersions in the database, and for each,
     uses the data in its `data` field to load the authors of that LibraryVersion.
 
@@ -18,27 +37,44 @@ def command(library_name, clean):
     the library at the version.name ref tag.
 
     If `--library-name` is specified, then only authors for that library will be loaded.
+    If `--release` is specified, then only authors for that version will be loaded, and
+    the retroactive backfill is skipped: a run scoped to one release must not reach
+    into the releases either side of it.
     If `--clean` is specified, then authors will be removed before being added back in.
     """
     click.secho("Adding libraryVersion authors...", fg="green")
     updater = LibraryUpdater()
-    libraries = Library.objects.all().prefetch_related("library_version")
+    libraries = Library.objects.all()
     if library_name is not None:
-        libraries = libraries.filter(library__name__iexact=library_name)
+        libraries = libraries.filter(name__iexact=library_name)
+
+    version_names = release_version_names(release)
+    library_versions = LibraryVersion.objects.filter(library__in=libraries)
+    if version_names:
+        library_versions = library_versions.filter(version__name__in=version_names)
 
     with transaction.atomic():
-        for library in libraries.order_by("name"):
-            for library_version in library.library_version.all():
-                if not library_version.data:
-                    continue
+        for library_version in library_versions.select_related(
+            "library", "version"
+        ).order_by("library__name", "version__name"):
+            if not library_version.data:
+                continue
 
-                if clean:
-                    library_version.authors.clear()
-                updater.update_authors(
-                    library_version,
-                    authors=library_version.data.get("authors", []),
-                )
-            retroactively_apply_authors_to_previous_versions(library)
+            if clean:
+                library_version.authors.clear()
+            updater.update_authors(
+                library_version,
+                authors=library_version.data.get("authors", []),
+            )
+
+        # Only for a sweep. The backfill copies a newer release's authors onto an
+        # older one, so running it after a single-release pass would push that
+        # release's authors backwards over versions that are already correct.
+        if not version_names:
+            for library in libraries.order_by("name").prefetch_related(
+                "library_version"
+            ):
+                retroactively_apply_authors_to_previous_versions(library)
 
     click.secho("Finished adding library version authors.", fg="green")
 

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -142,7 +142,9 @@ def get_and_store_library_version_documentation_urls_for_version(version_pk):
         )
         return
 
-    base_path = f"doc/libs/{version.boost_url_slug}/libs/"
+    # A point release ships no docs archive of its own; its libraries are
+    # documented by the base release.
+    base_path = f"doc/libs/{version.base_release_url_slug}/libs/"
     boost_stripped_base_path = base_path.replace("doc/libs/boost_", "doc/libs/")
     key = f"{base_path}libraries.htm"
     result = get_content_from_s3(key)
@@ -193,7 +195,7 @@ def get_and_store_library_version_documentation_urls_for_version(version_pk):
         documentation_url = None
         for exception in exceptions:
             if version_within_range(
-                library_version.version.boost_url_slug,
+                library_version.version.base_release_url_slug,
                 min_version=exception.get("min_version"),
                 max_version=exception.get("max_version"),
             ):
@@ -204,7 +206,7 @@ def get_and_store_library_version_documentation_urls_for_version(version_pk):
                     library_version.library.slug.lower().replace("-", "_"),
                 )
                 documentation_url = exception_url_generator(
-                    version.boost_url_slug,
+                    version.base_release_url_slug,
                     slug,
                 )
                 break  # Stop looking once a matching version is found
@@ -280,6 +282,65 @@ def update_authors_and_maintainers():
     call_command("update_maintainers")
     call_command("update_library_version_authors", "--clean")
     app.signature("users.tasks.recompute_displayed_profile_roles").apply_async()
+
+
+@app.task
+def synchronize_release_library_data(release=""):
+    """Re-import one release's library data, then bind its authors.
+
+    The repair for a release whose libraries render with no author: the authors
+    live in ``LibraryVersion.data``, written by the import, and the author command
+    can only read what the import has already written. So the two run here in that
+    order, in one task, synchronously - the import's own management command
+    ``.delay()``s a task per version and returns, which would leave the author pass
+    racing the data it needs.
+
+    Additive by construction and safe to repeat. Nothing is cleared, nothing is
+    copied between releases, and only the chosen release is touched; the sweep
+    behind "Update Authors & Maintainers" is neither of those things.
+    """
+    from versions.tasks import import_library_versions
+
+    version = Version.objects.with_partials().filter(name=release).first()
+    if version is None:
+        logger.warning(
+            "synchronize_release_library_data_version_not_found", release=release
+        )
+        return
+
+    # master and develop are moving refs, and importing one garbage-collects the
+    # library versions that have left its .gitmodules. That is a delete, which is
+    # the one thing this job promises not to do.
+    if version.slug in settings.BOOST_BRANCHES:
+        logger.warning(
+            "synchronize_release_library_data_branch_refused", release=version.name
+        )
+        return
+
+    # The import ends by scraping documentation URLs, which raises when a release
+    # has no docs archive in S3. That has nothing to do with authorship, and
+    # losing the author pass to it is what leaves the release rendering "Unknown",
+    # the exact state this job exists to repair. So a raise here is tolerated: it
+    # can only come from after the libraries were read and written.
+    try:
+        imported = import_library_versions(version.name, version_type="tag")
+    except Exception:
+        logger.exception(
+            "synchronize_release_library_data_import_incomplete",
+            release=version.name,
+        )
+    else:
+        # A falsy return is the other shape of failure, and the one worth failing
+        # on: the import gave up before reading any library, so there is nothing
+        # for the author pass to bind and reporting success would be a lie.
+        if not imported:
+            raise ValueError(
+                f"Could not read the libraries of {version.name} from GitHub; "
+                "nothing has been changed."
+            )
+
+    call_command("update_library_version_authors", "--release", version.name)
+    logger.info("synchronize_release_library_data_finished", release=version.name)
 
 
 @app.task

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -299,6 +299,7 @@ def synchronize_release_library_data(release=""):
     copied between releases, and only the chosen release is touched; the sweep
     behind "Update Authors & Maintainers" is neither of those things.
     """
+    from versions.exceptions import PostImportStepFailed
     from versions.tasks import import_library_versions
 
     version = Version.objects.with_partials().filter(name=release).first()
@@ -320,24 +321,29 @@ def synchronize_release_library_data(release=""):
     # The import ends by scraping documentation URLs, which raises when a release
     # has no docs archive in S3. That has nothing to do with authorship, and
     # losing the author pass to it is what leaves the release rendering "Unknown",
-    # the exact state this job exists to repair. So a raise here is tolerated: it
-    # can only come from after the libraries were read and written.
+    # the exact state this job exists to repair. So that one failure is tolerated,
+    # and only that one: it is raised as `PostImportStepFailed` precisely because
+    # it can only come from after the libraries were read and written. Anything
+    # else - a tag that cannot be resolved, a GitHub client that cannot be built,
+    # a write that failed halfway - leaves `LibraryVersion.data` as stale as it
+    # was found, and binding authors over it and reporting success would be a lie.
     try:
         imported = import_library_versions(version.name, version_type="tag")
-    except Exception:
+    except PostImportStepFailed as exc:
         logger.exception(
             "synchronize_release_library_data_import_incomplete",
             release=version.name,
         )
-    else:
-        # A falsy return is the other shape of failure, and the one worth failing
-        # on: the import gave up before reading any library, so there is nothing
-        # for the author pass to bind and reporting success would be a lie.
-        if not imported:
-            raise ValueError(
-                f"Could not read the libraries of {version.name} from GitHub; "
-                "nothing has been changed."
-            )
+        imported = exc.library_keys
+
+    # A falsy result is the other shape of failure, and the one worth failing on:
+    # the import gave up before reading any library, so there is nothing for the
+    # author pass to bind and reporting success would be a lie.
+    if not imported:
+        raise ValueError(
+            f"Could not read the libraries of {version.name} from GitHub; "
+            "nothing has been changed."
+        )
 
     call_command("update_library_version_authors", "--release", version.name)
     logger.info("synchronize_release_library_data_finished", release=version.name)

--- a/libraries/tests/test_release_sync.py
+++ b/libraries/tests/test_release_sync.py
@@ -1,0 +1,360 @@
+"""The targeted, per-release library data synchronization.
+
+Three things are asserted here, because a repair that reaches further than the
+release it was pointed at is worse than no repair at all: that
+``update_library_version_authors --release`` touches one release and leaves the
+retroactive backfill alone, that the task runs the import before the authors it
+feeds, and that the changelist button cannot be submitted without a release.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from django.core.cache import cache
+from django.core.management import call_command
+from django.urls import reverse
+from model_bakery import baker
+
+from libraries.tasks import synchronize_release_library_data
+
+pytestmark = pytest.mark.django_db
+
+BUTTON_URL = "admin:release_tools_releaselibrarydata_synchronize_release_library_data"
+CHANGELIST_URL = "admin:release_tools_releaselibrarydata_changelist"
+TASK_PATH = "release_tools.admin.synchronize_release_library_data.delay"
+
+
+@pytest.fixture(autouse=True)
+def _clear_task_button_locks():
+    """The changelist buttons lock through the cache; isolate tests."""
+    cache.clear()
+
+
+def make_library_version(library, version_name, authors=None, slug=None):
+    """A LibraryVersion at ``version_name`` carrying ``authors`` in its data."""
+    version = baker.make(
+        "versions.Version",
+        name=version_name,
+        slug=slug or version_name.replace("boost-", "").replace(".", "-"),
+        fully_imported=True,
+        active=True,
+    )
+    return baker.make(
+        "libraries.LibraryVersion",
+        library=library,
+        version=version,
+        data={"authors": authors} if authors is not None else {},
+    )
+
+
+def test_release_scope_leaves_the_other_releases_alone(library):
+    """The named release gains its authors; its neighbour gains nothing.
+
+    The neighbour is the assertion that matters: without the scope the
+    retroactive backfill would copy 1.92.0's authors onto 1.90.0.
+    """
+    older = make_library_version(library, "boost-1.90.0")
+    newer = make_library_version(
+        library, "boost-1.92.0", ["Jane Smith <jane -at- x.com>"]
+    )
+
+    call_command("update_library_version_authors", "--release", "1.92.0")
+
+    assert newer.authors.count() == 1
+    assert newer.authors.filter(email="jane@x.com").exists()
+    assert older.authors.count() == 0
+
+
+def test_release_scope_accepts_the_stored_version_name(library):
+    """The admin passes ``boost-1.92.0``; an operator types ``1.92.0``."""
+    newer = make_library_version(
+        library, "boost-1.92.0", ["Jane Smith <jane -at- x.com>"]
+    )
+
+    call_command("update_library_version_authors", "--release", "boost-1.92.0")
+
+    assert newer.authors.filter(email="jane@x.com").exists()
+
+
+def test_release_scope_does_not_widen_into_neighbouring_versions(library):
+    """``1.9`` is not a release, and must not be read as every 1.9x release."""
+    newer = make_library_version(
+        library, "boost-1.92.0", ["Jane Smith <jane -at- x.com>"]
+    )
+
+    call_command("update_library_version_authors", "--release", "1.9")
+
+    assert newer.authors.count() == 0
+
+
+def test_the_unscoped_sweep_still_backfills_earlier_releases(library):
+    """No release named, so the pre-existing sweep behaviour is unchanged."""
+    older = make_library_version(library, "boost-1.90.0")
+    make_library_version(library, "boost-1.92.0", ["Jane Smith <jane -at- x.com>"])
+
+    call_command("update_library_version_authors")
+
+    assert older.authors.filter(email="jane@x.com").exists()
+
+
+def test_library_name_filters_instead_of_raising(library):
+    """``--library-name`` filtered on a field Library does not have."""
+    other = baker.make("libraries.Library", name="asio", slug="asio")
+    wanted = make_library_version(
+        library, "boost-1.92.0", ["Jane Smith <jane -at- x.com>"]
+    )
+    unwanted = make_library_version(
+        other, "boost-1.91.0", ["Juan Rodrigo <juan -at- x.com>"]
+    )
+
+    call_command("update_library_version_authors", "--library-name", library.name)
+
+    assert wanted.authors.filter(email="jane@x.com").exists()
+    assert unwanted.authors.count() == 0
+
+
+def test_the_task_imports_the_data_before_binding_its_authors():
+    """The author pass can only read what the import has already written."""
+    baker.make("versions.Version", name="boost-1.92.0", slug="1-92-0")
+    calls = Mock()
+    with patch("versions.tasks.import_library_versions", calls.import_versions), patch(
+        "libraries.tasks.call_command", calls.call_command
+    ):
+        synchronize_release_library_data("boost-1.92.0")
+
+    assert calls.mock_calls == [
+        ("import_versions", ("boost-1.92.0",), {"version_type": "tag"}),
+        (
+            "call_command",
+            ("update_library_version_authors", "--release", "boost-1.92.0"),
+            {},
+        ),
+    ]
+
+
+def test_the_task_refuses_a_moving_branch():
+    """Importing master or develop deletes library versions; this job does not."""
+    baker.make("versions.Version", name="develop", slug="develop")
+    calls = Mock()
+    with patch("versions.tasks.import_library_versions", calls.import_versions), patch(
+        "libraries.tasks.call_command", calls.call_command
+    ):
+        synchronize_release_library_data("develop")
+
+    assert calls.mock_calls == []
+
+
+def test_the_task_does_nothing_for_a_release_that_is_not_stored():
+    calls = Mock()
+    with patch("versions.tasks.import_library_versions", calls.import_versions), patch(
+        "libraries.tasks.call_command", calls.call_command
+    ):
+        synchronize_release_library_data("boost-9.99.0")
+
+    assert calls.mock_calls == []
+
+
+def test_the_button_refuses_a_submission_with_no_release(client, super_user):
+    """There is no unscoped run: an empty select must not start a sweep."""
+    baker.make("versions.Version", name="boost-1.92.0", slug="1-92-0")
+    client.force_login(super_user)
+
+    with patch(TASK_PATH) as delay:
+        response = client.post(reverse(BUTTON_URL), {"release": ""}, follow=True)
+
+    delay.assert_not_called()
+    assert "this job has no unscoped run" in response.content.decode()
+
+
+def test_the_button_refuses_a_release_it_did_not_offer(client, super_user):
+    baker.make("versions.Version", name="boost-1.92.0", slug="1-92-0")
+    client.force_login(super_user)
+
+    with patch(TASK_PATH) as delay:
+        client.post(reverse(BUTTON_URL), {"release": "boost-9.99.0"}, follow=True)
+
+    delay.assert_not_called()
+
+
+def test_the_button_enqueues_the_release_it_was_pointed_at(client, super_user):
+    baker.make("versions.Version", name="boost-1.92.0", slug="1-92-0")
+    client.force_login(super_user)
+
+    with patch(TASK_PATH, return_value=Mock(id="a-task-id")) as delay:
+        client.post(reverse(BUTTON_URL), {"release": "boost-1.92.0"}, follow=True)
+
+    delay.assert_called_once_with(release="boost-1.92.0")
+
+
+def test_the_allowlist_holds_the_stored_releases_and_not_the_branches(
+    client, super_user
+):
+    """The row buttons post a release, and this is the list it is checked against.
+
+    Read from the database, so a release imported today can be pressed today, and
+    a moving branch cannot be posted at all: importing one deletes library
+    versions, which this job promises not to do.
+    """
+    baker.make("versions.Version", name="boost-1.92.0", slug="1-92-0")
+    baker.make("versions.Version", name="develop", slug="develop")
+    client.force_login(super_user)
+
+    response = client.get(reverse(CHANGELIST_URL))
+
+    button = next(
+        b
+        for b in response.context["task_buttons"]
+        if b["argument"] == "release" and b["require_choice"]
+    )
+    assert ("boost-1.92.0", "1.92.0") in button["choices"]
+    assert all(value != "develop" for value, _ in button["choices"])
+
+
+def test_the_task_binds_authors_even_when_the_import_fails():
+    """A point release ships no docs archive, and the import ends by scraping it.
+
+    That raise has nothing to do with authorship, so losing the author pass to it
+    would leave the release rendering "Unknown", which is what this job repairs.
+    """
+    baker.make("versions.Version", name="boost-1.91.0-1", slug="1-91-0-1")
+    calls = Mock()
+    calls.import_versions.side_effect = ValueError(
+        "Could not get content from S3 for doc/libs/boost_1_91_0_1/libs/libraries.htm"
+    )
+    with patch("versions.tasks.import_library_versions", calls.import_versions), patch(
+        "libraries.tasks.call_command", calls.call_command
+    ):
+        synchronize_release_library_data("boost-1.91.0-1")
+
+    assert calls.call_command.call_args_list == [
+        (("update_library_version_authors", "--release", "boost-1.91.0-1"), {}),
+    ]
+
+
+def _release_rows(rf, user):
+    """The page's own annotated rows, keyed by release name."""
+    from django.contrib.admin.sites import site
+
+    from release_tools.models import ReleaseLibraryData
+
+    model_admin = site._registry[ReleaseLibraryData]
+    request = rf.get("/")
+    request.user = user
+    return model_admin, {
+        version.name: version for version in model_admin.get_queryset(request)
+    }
+
+
+def test_the_page_reports_which_releases_need_repairing(rf, super_user, library):
+    """The list exists to answer "which release needs this" before running it."""
+    healthy = baker.make(
+        "versions.Version", name="boost-1.92.0", slug="1-92-0", active=True
+    )
+    broken = baker.make(
+        "versions.Version", name="boost-1.91.0-1", slug="1-91-0-1", active=True
+    )
+    bound = baker.make(
+        "libraries.LibraryVersion",
+        library=library,
+        version=healthy,
+        data={"authors": ["Jane"]},
+    )
+    bound.authors.add(super_user)
+    baker.make(
+        "libraries.LibraryVersion",
+        library=library,
+        version=broken,
+        data={"authors": ["Jane"]},
+    )
+
+    model_admin, rows = _release_rows(rf, super_user)
+
+    assert model_admin.needs_synchronizing(rows["boost-1.91.0-1"]) == "1 of 1"
+    assert model_admin.needs_synchronizing(rows["boost-1.92.0"]) == "none"
+
+
+def test_a_library_with_no_upstream_author_is_counted_apart(rf, super_user, library):
+    """Three libraries name no author in their own metadata, on every release.
+
+    Counting them as work to do reads as a fault on an otherwise healthy release,
+    and no amount of synchronizing would ever clear it.
+    """
+    release = baker.make(
+        "versions.Version", name="boost-1.92.0", slug="1-92-0", active=True
+    )
+    baker.make(
+        "libraries.LibraryVersion",
+        library=library,
+        version=release,
+        data={"authors": ""},
+    )
+
+    model_admin, rows = _release_rows(rf, super_user)
+    row = rows["boost-1.92.0"]
+
+    assert model_admin.needs_synchronizing(row) == "none"
+    assert model_admin.no_author_upstream(row) == 1
+
+
+def test_an_unimported_release_is_not_reported_as_healthy(rf, super_user):
+    """No libraries at all is a different problem from no missing authors."""
+    baker.make("versions.Version", name="boost-1.92.0", slug="1-92-0", active=True)
+
+    model_admin, rows = _release_rows(rf, super_user)
+
+    assert model_admin.needs_synchronizing(rows["boost-1.92.0"]) == (
+        "no libraries imported"
+    )
+
+
+def test_each_release_gets_its_own_synchronize_button(client, super_user):
+    """The job is pressed on the release it acts on; there is no select to mis-set."""
+    baker.make("versions.Version", name="boost-1.92.0", slug="1-92-0", active=True)
+    baker.make("versions.Version", name="boost-1.91.0-1", slug="1-91-0-1", active=True)
+    client.force_login(super_user)
+
+    body = client.get(reverse(CHANGELIST_URL)).content.decode()
+
+    assert '<select name="release"' not in body
+    for name in ("boost-1.92.0", "boost-1.91.0-1"):
+        assert f'<input type="hidden" name="release" value="{name}">' in body
+
+
+def test_a_library_whose_metadata_was_never_read_counts_as_work(
+    rf, super_user, library
+):
+    """An absent `authors` key is what a failed import leaves behind.
+
+    It is also the shape a JSON exclusion silently drops: SQL reads `NOT
+    (data->>'authors' = '')` as unknown when the key is missing, so these rows
+    fall out of a `~Q` filter and the release reports itself healthy.
+    """
+    release = baker.make(
+        "versions.Version", name="boost-1.92.0", slug="1-92-0", active=True
+    )
+    baker.make("libraries.LibraryVersion", library=library, version=release, data={})
+
+    model_admin, rows = _release_rows(rf, super_user)
+    row = rows["boost-1.92.0"]
+
+    assert model_admin.needs_synchronizing(row) == "1 of 1"
+    assert model_admin.no_author_upstream(row) == ""
+
+
+def test_the_task_fails_when_the_import_reads_nothing():
+    """A release whose libraries could not be read must not report success.
+
+    `import_library_versions` logs and returns on a bad ref or unreadable
+    .gitmodules rather than raising, so without this the button says Finished
+    over a run that changed nothing.
+    """
+    baker.make("versions.Version", name="boost-1.61.0", slug="1-61-0")
+    calls = Mock()
+    calls.import_versions.return_value = None
+    with patch("versions.tasks.import_library_versions", calls.import_versions), patch(
+        "libraries.tasks.call_command", calls.call_command
+    ):
+        with pytest.raises(ValueError, match="Could not read the libraries"):
+            synchronize_release_library_data("boost-1.61.0")
+
+    calls.call_command.assert_not_called()

--- a/libraries/tests/test_release_sync.py
+++ b/libraries/tests/test_release_sync.py
@@ -320,6 +320,40 @@ def test_each_release_gets_its_own_synchronize_button(client, super_user):
         assert f'<input type="hidden" name="release" value="{name}">' in body
 
 
+def test_a_release_synchronizing_does_not_hide_another_rows_button(client, super_user):
+    """Two releases can be in flight at once; each row reports its own job.
+
+    The key holding the button's last run remembers only the most recent of
+    them, so a row read from it showed the release started second as running and
+    offered the first one a button its own lock would have refused.
+    """
+    started = ("boost-1.92.0", "task-92"), ("boost-1.91.0", "task-91")
+    finished = ("boost-1.90.0", "task-90")
+    for name, _ in (*started, finished):
+        baker.make(
+            "versions.Version",
+            name=name,
+            slug=name.removeprefix("boost-").replace(".", "-"),
+            active=True,
+        )
+    client.force_login(super_user)
+
+    states = {task_id: ("STARTED", "") for _, task_id in started}
+    states[finished[1]] = ("SUCCESS", "")
+    for name, task_id in (*started, finished):
+        with patch(TASK_PATH, return_value=Mock(id=task_id)):
+            client.post(reverse(BUTTON_URL), {"release": name}, follow=True)
+
+    with patch("core.admin_buttons.task_status", states.get):
+        body = client.get(reverse(CHANGELIST_URL)).content.decode()
+
+    for name, _ in started:
+        assert f'<input type="hidden" name="release" value="{name}">' not in body
+    assert body.count('<span class="release-tools-running">Running</span>') == 2
+    # The finished one is offered again, rather than left reading as running.
+    assert f'<input type="hidden" name="release" value="{finished[0]}">' in body
+
+
 def test_a_library_whose_metadata_was_never_read_counts_as_work(
     rf, super_user, library
 ):

--- a/libraries/tests/test_release_sync.py
+++ b/libraries/tests/test_release_sync.py
@@ -16,6 +16,7 @@ from django.urls import reverse
 from model_bakery import baker
 
 from libraries.tasks import synchronize_release_library_data
+from versions.exceptions import PostImportStepFailed
 
 pytestmark = pytest.mark.django_db
 
@@ -210,17 +211,17 @@ def test_the_allowlist_holds_the_stored_releases_and_not_the_branches(
     assert all(value != "develop" for value, _ in button["choices"])
 
 
-def test_the_task_binds_authors_even_when_the_import_fails():
+def test_the_task_binds_authors_even_when_a_post_import_step_fails():
     """A point release ships no docs archive, and the import ends by scraping it.
 
     That raise has nothing to do with authorship, so losing the author pass to it
     would leave the release rendering "Unknown", which is what this job repairs.
+    The import raises it as `PostImportStepFailed`, which says the library
+    metadata the author pass reads was written before the step that failed.
     """
     baker.make("versions.Version", name="boost-1.91.0-1", slug="1-91-0-1")
     calls = Mock()
-    calls.import_versions.side_effect = ValueError(
-        "Could not get content from S3 for doc/libs/boost_1_91_0_1/libs/libraries.htm"
-    )
+    calls.import_versions.side_effect = PostImportStepFailed(["array", "asio"])
     with patch("versions.tasks.import_library_versions", calls.import_versions), patch(
         "libraries.tasks.call_command", calls.call_command
     ):
@@ -229,6 +230,40 @@ def test_the_task_binds_authors_even_when_the_import_fails():
     assert calls.call_command.call_args_list == [
         (("update_library_version_authors", "--release", "boost-1.91.0-1"), {}),
     ]
+
+
+def test_the_task_aborts_when_the_import_fails_before_writing_anything():
+    """A failure that is not the documentation scrape leaves the data untouched.
+
+    Resolving the tag, building the GitHub client and writing the rows can all
+    raise, and none of them has written a thing when they do. Binding authors
+    over metadata that is as stale as it was found and reporting success would
+    tell the operator the release was repaired when nothing was read at all.
+    """
+    baker.make("versions.Version", name="boost-1.92.0", slug="1-92-0")
+    calls = Mock()
+    calls.import_versions.side_effect = RuntimeError("no GitHub token configured")
+    with patch("versions.tasks.import_library_versions", calls.import_versions), patch(
+        "libraries.tasks.call_command", calls.call_command
+    ):
+        with pytest.raises(RuntimeError, match="no GitHub token"):
+            synchronize_release_library_data("boost-1.92.0")
+
+    calls.call_command.assert_not_called()
+
+
+def test_a_post_import_failure_that_read_nothing_still_fails():
+    """The two shapes of failure can arrive together, and the stricter one wins."""
+    baker.make("versions.Version", name="boost-1.61.0", slug="1-61-0")
+    calls = Mock()
+    calls.import_versions.side_effect = PostImportStepFailed([])
+    with patch("versions.tasks.import_library_versions", calls.import_versions), patch(
+        "libraries.tasks.call_command", calls.call_command
+    ):
+        with pytest.raises(ValueError, match="Could not read the libraries"):
+            synchronize_release_library_data("boost-1.61.0")
+
+    calls.call_command.assert_not_called()
 
 
 def _release_rows(rf, user):

--- a/libraries/tests/test_tasks.py
+++ b/libraries/tests/test_tasks.py
@@ -164,3 +164,43 @@ def test_update_library_version_website_adoc_no_stable_release():
     with patch("libraries.tasks.store_library_version_website_adoc") as mock_store:
         update_library_version_website_adoc()
     mock_store.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch("core.boostrenderer.get_s3_client")
+def test_point_release_docs_urls_address_the_base_release(
+    mock_get_s3_client, mock_s3_client, tp
+):
+    """A point release publishes no docs archive of its own.
+
+    Both the alphabetical scrape and the LIBRARY_DOCS_EXCEPTIONS fallback have to
+    address the base release, or the generated key fails its S3 validation and the
+    library is left with no documentation URL at all.
+    """
+    from model_bakery import baker
+
+    version = baker.make(
+        "versions.Version", name="boost-1.91.0-1", slug="boost-1-91-0-1"
+    )
+    library = baker.make("libraries.Library", name="Detail", slug="detail")
+    library_version = baker.make(
+        "libraries.LibraryVersion",
+        version=version,
+        library=library,
+        documentation_url="",
+    )
+
+    mock_get_s3_client.return_value = mock_s3_client
+    # No alphabetical listing, so only the exceptions fallback can fill this in.
+    mock_s3_response = {
+        "content": "<h2>Libraries Listed</h2>",
+        "content_type": "text/html",
+    }
+    with patch("core.boostrenderer.get_file_data", return_value=mock_s3_response):
+        get_and_store_library_version_documentation_urls_for_version(version.pk)
+
+    library_version.refresh_from_db()
+    assert "1_91_0_1" not in library_version.documentation_url
+    assert library_version.documentation_url == (
+        "/doc/libs/1_91_0/libs/detail/doc/html/index.html"
+    )

--- a/release_tools/admin.py
+++ b/release_tools/admin.py
@@ -1,0 +1,179 @@
+"""The release tools admin page.
+
+One page, because these jobs are operator tooling rather than the
+administration of any single model, and because the destructive alternative
+sits on the Library changelist: an operator who has to choose between them
+should be able to read what each one does without leaving the page.
+"""
+
+from django.conf import settings
+from django.contrib import admin
+from django.db.models import Count, F, Q
+from django.middleware.csrf import get_token
+from django.urls import reverse
+from django.utils.html import format_html
+
+from core.admin_buttons import TaskButton, TaskButtonAdminMixin
+from libraries.tasks import synchronize_release_library_data
+from .models import ReleaseLibraryData
+
+
+def syncable_releases():
+    """The releases the scoped synchronization may be pointed at.
+
+    One definition, so the table on the page and the select beside the button
+    cannot disagree about what is on offer. The moving branches are left out:
+    importing one garbage-collects the library versions that have left its
+    .gitmodules, and this job is offered on the promise that it deletes nothing.
+    """
+    return (
+        ReleaseLibraryData.objects.with_partials()
+        .active()
+        .exclude(slug__in=settings.BOOST_BRANCHES)
+    )
+
+
+def release_choices():
+    """The select's pairs, read per request.
+
+    A release imported this morning has to be selectable this afternoon.
+    """
+    return [
+        (version.name, version.display_name)
+        for version in syncable_releases().order_by("-name")
+    ]
+
+
+SYNCHRONIZE_RELEASE_LIBRARY_DATA_BUTTON = TaskButton(
+    name="synchronize_release_library_data",
+    label="Synchronize Release Library Data",
+    task=synchronize_release_library_data,
+    success_message="The release is being synchronized in the background.",
+    busy_message=(
+        "That release is already queued or running; not starting another one."
+    ),
+    argument="release",
+    choice_label="Release",
+    choices=release_choices,
+    require_choice=True,
+    description=(
+        "Takes a few minutes: it reads the release from GitHub before it can bind "
+        "anything."
+    ),
+)
+
+
+@admin.register(ReleaseLibraryData)
+class ReleaseLibraryDataAdmin(TaskButtonAdminMixin, admin.ModelAdmin):
+    """Release maintenance jobs, one row per release.
+
+    The job is offered on the release it would act on rather than through a
+    select, so the release an operator reads the numbers for is the release they
+    press. `Needs synchronizing` counts only what this job can actually repair;
+    a library whose upstream metadata names no author is counted separately,
+    because no amount of synchronizing will give it one.
+    """
+
+    change_list_template = "admin/release_tools/change_list.html"
+    task_buttons = (SYNCHRONIZE_RELEASE_LIBRARY_DATA_BUTTON,)
+    list_display_links = None
+    ordering = ("-name",)
+    search_fields = ("name",)
+
+    # A library version can only be given an author if its imported metadata
+    # names one. An absent `authors` key means the import never read that far, so
+    # synchronizing is the thing to try; a key that is present and empty means
+    # upstream declares no author at all and never will.
+    UNBOUND = Q(library_version__authors__isnull=True)
+    NO_UPSTREAM_AUTHOR = Q(library_version__data__has_key="authors") & (
+        Q(library_version__data__authors="") | Q(library_version__data__authors=[])
+    )
+
+    def get_list_display(self, request):
+        """Built per request, because the action column needs a CSRF token."""
+        return (
+            "display_name",
+            "release_date",
+            "needs_synchronizing",
+            "no_author_upstream",
+            self._synchronize_column(request),
+        )
+
+    def get_queryset(self, request):
+        """Annotate the counts, so no per-row query is needed to show them.
+
+        Both filters match positively and the difference is taken afterwards. A
+        `~Q` over a JSON key would read as NOT NULL for every row whose `data`
+        does not carry the key at all, which SQL evaluates as unknown rather than
+        true, and those rows would fall out of both counts. They are the ones that
+        matter most: an absent key is what a failed import leaves behind.
+        """
+        return (
+            syncable_releases()
+            .annotate(
+                _libraries=Count("library_version", distinct=True),
+                _unbound=Count("library_version", filter=self.UNBOUND, distinct=True),
+                _no_upstream=Count(
+                    "library_version",
+                    filter=self.UNBOUND & self.NO_UPSTREAM_AUTHOR,
+                    distinct=True,
+                ),
+            )
+            .annotate(_repairable=F("_unbound") - F("_no_upstream"))
+        )
+
+    @admin.display(description="Needs synchronizing", ordering="_repairable")
+    def needs_synchronizing(self, obj):
+        if not obj._libraries:
+            return "no libraries imported"
+        if not obj._repairable:
+            return "none"
+        return f"{obj._repairable} of {obj._libraries}"
+
+    @admin.display(description="No author upstream", ordering="_no_upstream")
+    def no_author_upstream(self, obj):
+        """Libraries this job cannot help, kept out of the column beside it."""
+        return obj._no_upstream or ""
+
+    def _synchronize_column(self, request):
+        """A submit button per row, posting that row's release.
+
+        A closure rather than a method so the CSRF token and the permission
+        check are taken from this request; a `ModelAdmin` instance is shared
+        between them and must not carry either.
+        """
+        button = SYNCHRONIZE_RELEASE_LIBRARY_DATA_BUTTON
+        allowed = self._task_button_allows(request, button)
+        url = reverse(f"admin:{self._task_button_url_name(button)}")
+        token = get_token(request)
+        # One cache read for the whole page: per row would be one read and one
+        # result-backend call each, on a list of every release.
+        status = self._task_button_status(button)
+        running = status["scope"] if status["poll"] else ""
+
+        def synchronize(obj):
+            if not allowed:
+                return ""
+            if running and obj.display_name == running:
+                return format_html(
+                    '<span class="release-tools-running">{}</span>', status["label"]
+                )
+            return format_html(
+                '<form action="{}" method="post" class="release-tools-action">'
+                '<input type="hidden" name="csrfmiddlewaretoken" value="{}">'
+                '<input type="hidden" name="release" value="{}">'
+                '<button type="submit">Synchronize</button>'
+                "</form>",
+                url,
+                token,
+                obj.name,
+            )
+
+        synchronize.short_description = "Action"
+        return synchronize
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False

--- a/release_tools/admin.py
+++ b/release_tools/admin.py
@@ -146,17 +146,24 @@ class ReleaseLibraryDataAdmin(TaskButtonAdminMixin, admin.ModelAdmin):
         allowed = self._task_button_allows(request, button)
         url = reverse(f"admin:{self._task_button_url_name(button)}")
         token = get_token(request)
-        # One cache read for the whole page: per row would be one read and one
-        # result-backend call each, on a list of every release.
-        status = self._task_button_status(button)
-        running = status["scope"] if status["poll"] else ""
+        # Per release, in one cache read for the whole page: two releases can be
+        # synchronizing at once, and the key holding the button's last run
+        # remembers only the most recent of them.
+        running = (
+            self._task_button_running_labels(
+                button, syncable_releases().values_list("name", flat=True)
+            )
+            if allowed
+            else {}
+        )
 
         def synchronize(obj):
             if not allowed:
                 return ""
-            if running and obj.display_name == running:
+            label = running.get(obj.name)
+            if label:
                 return format_html(
-                    '<span class="release-tools-running">{}</span>', status["label"]
+                    '<span class="release-tools-running">{}</span>', label
                 )
             return format_html(
                 '<form action="{}" method="post" class="release-tools-action">'

--- a/release_tools/apps.py
+++ b/release_tools/apps.py
@@ -1,0 +1,17 @@
+"""App wiring for the release maintenance tools in the admin."""
+
+from django.apps import AppConfig
+
+
+class ReleaseToolsConfig(AppConfig):
+    """Gives the release maintenance jobs their own admin section.
+
+    An app of its own only so the admin index has somewhere to put them: the
+    index groups by app, and these jobs are operator tooling rather than part of
+    any one model's administration. No models of its own beyond the proxy the
+    admin page hangs off.
+    """
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "release_tools"
+    verbose_name = "Release tools"

--- a/release_tools/migrations/0001_initial.py
+++ b/release_tools/migrations/0001_initial.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        ("versions", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ReleaseLibraryData",
+            fields=[],
+            options={
+                "verbose_name": "release library data",
+                "verbose_name_plural": "Library data",
+                "proxy": True,
+                "indexes": [],
+                "constraints": [],
+            },
+            bases=("versions.version",),
+        ),
+    ]

--- a/release_tools/models.py
+++ b/release_tools/models.py
@@ -1,0 +1,16 @@
+"""Admin-only proxies. Nothing here adds a table."""
+
+from versions.models import Version
+
+
+class ReleaseLibraryData(Version):
+    """A `Version` seen from the release tools page.
+
+    A proxy, not a model: the page needs somewhere to hang its own admin URLs and
+    permissions, and the thing an operator picks on it is a release.
+    """
+
+    class Meta:
+        proxy = True
+        verbose_name = "release library data"
+        verbose_name_plural = "Library data"

--- a/static/css/admin/controls.css
+++ b/static/css/admin/controls.css
@@ -148,3 +148,66 @@
 #content .submit-row a.cancel-link:hover {
     background: var(--close-button-hover-bg);
 }
+
+.release-tools-help {
+    max-width: 78ch;
+    margin: 0;
+    padding: 12px 15px;
+    border: 1px solid var(--hairline-color);
+    border-radius: 4px;
+    background: var(--darkened-bg);
+}
+
+.release-tools-help h2 {
+    margin: 0 0 8px;
+    font-size: 0.8125rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.release-tools-help p,
+.release-tools-help ol {
+    margin: 0 0 8px;
+    font-size: 0.8125rem;
+    line-height: 1.5;
+}
+
+.release-tools-help ol {
+    padding-left: 20px;
+}
+
+.release-tools-help > :last-child {
+    margin-bottom: 0;
+}
+
+.release-tools-help .help {
+    font-size: 0.6875rem;
+    color: var(--body-quiet-color);
+}
+
+.release-tools-help h3 {
+    margin: 12px 0 6px;
+    font-size: 0.8125rem;
+}
+
+.release-tools-help ul {
+    margin: 0 0 8px;
+    padding-left: 20px;
+    font-size: 0.8125rem;
+    line-height: 1.5;
+}
+
+.release-tools-action {
+    margin: 0;
+}
+
+.release-tools-action button {
+    padding: 4px 10px;
+    font-size: 0.75rem;
+    cursor: pointer;
+}
+
+.release-tools-running {
+    font-size: 0.75rem;
+    color: var(--body-quiet-color);
+}

--- a/templates/admin/release_tools/change_list.html
+++ b/templates/admin/release_tools/change_list.html
@@ -1,0 +1,64 @@
+{% extends "admin/task_buttons_change_list.html" %}
+
+{% block admin-actions-extra %}
+  <div class="release-tools-help">
+    <h2>Synchronize release library data</h2>
+    <p>
+      Repairs a release whose libraries show <strong>Unknown</strong> where an
+      author should be. Press <strong>Synchronize</strong> on the release you want
+      to repair; each row has its own button.
+    </p>
+    <p>
+      Authors are not stored on the library. They are stored per release, and they
+      come from the <code>meta/libraries.json</code> that each library ships in the
+      release's own Git tag. So the job does two things, in this order:
+    </p>
+    <ol>
+      <li>re-reads that release's libraries from GitHub into the database, and</li>
+      <li>binds the authors named in what it just read.</li>
+    </ol>
+    <p>
+      The order matters: the second step can only bind what the first step wrote.
+      A release left with the first step done and not the second is exactly how one
+      ends up rendering <strong>Unknown</strong>.
+    </p>
+    <p>
+      <strong>It only touches the release you press.</strong> No author is removed,
+      and no author is copied from one release to another. It is safe to run twice.
+    </p>
+    <h3>Reading the columns</h3>
+    <ul>
+      <li>
+        <strong>Needs synchronizing</strong> is libraries with no author that this
+        job is worth running for: either their authors are named upstream but not
+        stored here yet, or their metadata was never read at all. On old releases a
+        residue can remain after a successful run, because some libraries shipped
+        no <code>meta/libraries.json</code> at that tag for anything to be read
+        from. Whatever is left after one run will not clear on a second.
+      </li>
+      <li>
+        <strong>No author upstream</strong> is a handful of libraries whose own
+        <code>meta/libraries.json</code> names no author at all. They show
+        <strong>Unknown</strong> on the site and always will. Synchronizing cannot
+        change them, so they are counted here and not in the column beside it. A
+        small number in this column is normal and is not a fault.
+      </li>
+    </ul>
+    <p class="help">
+      Point releases such as <code>1.91.0-1</code> are read from their base release,
+      because their libraries are not tagged separately and they ship no
+      documentation of their own.
+    </p>
+    <p class="help">
+      Not to be confused with <strong>Update Authors &amp; Maintainers</strong> on
+      the Library page, which rebuilds every release from scratch and can overwrite
+      the authors of older releases that are already correct.
+    </p>
+  </div>
+  {% for button in task_buttons %}
+    {% include "admin/task_button_status.html" with status=button.status %}
+    {% if button.description %}
+      <p class="help">{{ button.description }}</p>
+    {% endif %}
+  {% endfor %}
+{% endblock %}

--- a/templates/admin/task_buttons_change_list.html
+++ b/templates/admin/task_buttons_change_list.html
@@ -18,8 +18,8 @@
             {% csrf_token %}
             {% if button.choices %}
               <label for="{{ button.field_id }}">{{ button.choice_label }}</label>
-              <select name="{{ button.argument }}" id="{{ button.field_id }}">
-                <option value="">{{ button.all_label }}</option>
+              <select name="{{ button.argument }}" id="{{ button.field_id }}"{% if button.require_choice %} required{% endif %}>
+                <option value="">{% if button.require_choice %}---------{% else %}{{ button.all_label }}{% endif %}</option>
                 {% for value, label in button.choices %}
                   <option value="{{ value }}">{{ label }}</option>
                 {% endfor %}

--- a/versions/exceptions.py
+++ b/versions/exceptions.py
@@ -2,3 +2,22 @@ class BoostImportedDataException(Exception):
     """Custom exception for Boost data errors."""
 
     pass
+
+
+class PostImportStepFailed(Exception):
+    """A step that runs after a release's library metadata was written failed.
+
+    ``import_library_versions`` ends by scraping documentation URLs and loading
+    maintainers, both of which run only once every library's metadata is in the
+    database. A caller that needs that metadata and not those steps - the
+    per-release repair in ``libraries.tasks.synchronize_release_library_data`` -
+    has to be able to tell such a failure from one that wrote nothing at all, so
+    it is raised as this and carries the keys the import managed to read.
+    """
+
+    def __init__(self, library_keys):
+        super().__init__(
+            "A step after the library metadata was written failed; "
+            "the metadata itself is in place."
+        )
+        self.library_keys = library_keys

--- a/versions/models.py
+++ b/versions/models.py
@@ -177,6 +177,41 @@ class Version(models.Model):
         return self.slug.split("-beta")[0]
 
     @cached_property
+    def base_release_name(self):
+        """Return the release whose per-library artifacts describe this version.
+
+        A point release is tagged on the superproject only: the submodules keep
+        the base release's tag, and no separate docs archive is published for it.
+        Anything asking a library repo or the docs bucket about a point release
+        therefore has to ask about the base release instead.
+
+        Example:
+        - "boost-1.91.0-1" --> "boost-1.91.0"
+        - "boost-1.92.0" --> "boost-1.92.0"
+        - "develop" --> "develop"
+        """
+        match = re.fullmatch(r"(boost-\d+\.\d+\.\d+)-\d+", self.name)
+        return match.group(1) if match else self.name
+
+    @property
+    def is_point_release(self):
+        return self.base_release_name != self.name
+
+    @cached_property
+    def base_release_url_slug(self):
+        """Return `boost_url_slug` for this version's base release.
+
+        Identical to `boost_url_slug` for every version that is not a point
+        release, so it is safe to use wherever the docs bucket is addressed.
+
+        Example:
+        - "boost-1.91.0-1" --> "boost_1_91_0"
+        - "boost-1.92.0" --> "boost_1_92_0"
+        - "develop" --> "develop"
+        """
+        return self.base_release_name.replace("-", "_").replace(".", "_")
+
+    @cached_property
     def boost_url_slug(self):
         """Return the slug for the version that is used in the Boost URL to get to
         the existing Boost docs. The GitHub slug and the Boost slug don't match, so

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -368,10 +368,16 @@ def import_library_versions(version_name, token=None, version_type="tag"):
         logger.info(
             "import_library_versions_version_not_found", version_name=version_name
         )
+        return None
 
     client = GithubAPIClient(token=token)
     updater = LibraryUpdater(client=client)
     parser = GithubDataParser()
+
+    # The submodules of a point release carry the base release's tag, not the
+    # point release's, so every per-library lookup below has to use that one or
+    # it 404s for all of them and the rows land with no authors.
+    metadata_tag = version.base_release_name
 
     # Get the gitmodules file for the version, which contains library data
     # The master and develop branches are not tags, so we retrieve their data
@@ -381,14 +387,14 @@ def import_library_versions(version_name, token=None, version_type="tag"):
         ref = client.get_ref(ref=ref_s)
     except ValueError:
         logger.info(f"import_library_versions_invalid_ref {ref_s=}")
-        return
+        return None
 
     raw_gitmodules = client.get_gitmodules(ref=ref)
     if not raw_gitmodules:
         logger.info(
             "import_library_versions_invalid_gitmodules", version_name=version_name
         )
-        return
+        return None
 
     gitmodules = parser.parse_gitmodules(raw_gitmodules.decode("utf-8"))
 
@@ -405,7 +411,7 @@ def import_library_versions(version_name, token=None, version_type="tag"):
 
         try:
             libraries_json = client.get_libraries_json(
-                repo_slug=library_name, tag=version_name
+                repo_slug=library_name, tag=metadata_tag
             )
         except (
             requests.exceptions.JSONDecodeError,
@@ -478,7 +484,7 @@ def import_library_versions(version_name, token=None, version_type="tag"):
                     "cpp_standard_maximum": lib_data.get("cxxstd_max"),
                     "cpp20_module_support": lib_data.get("cpp20_module_support"),
                     "description": lib_data.get("description"),
-                    **fetch_website_adoc_fields(client, library_name, version_name),
+                    **fetch_website_adoc_fields(client, library_name, metadata_tag),
                 },
             )
             if not library.github_url:
@@ -497,6 +503,11 @@ def import_library_versions(version_name, token=None, version_type="tag"):
 
     # Load maintainers for library-versions
     call_command("update_maintainers", "--release", version.name)
+
+    # The keys it managed to read. Falsy means it read nothing at all, which a
+    # caller cannot otherwise tell from a successful run: every failure above
+    # this point is logged and returned from rather than raised.
+    return library_keys
 
 
 @app.task

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -31,7 +31,7 @@ from libraries.models import Library, LibraryVersion
 from libraries.website_adoc import fetch_website_adoc_fields
 from libraries.tasks import get_and_store_library_version_documentation_urls_for_version
 from libraries.utils import version_within_range
-from versions.exceptions import BoostImportedDataException
+from versions.exceptions import BoostImportedDataException, PostImportStepFailed
 from versions.models import Version
 from versions.releases import (
     store_release_notes_for_in_progress,
@@ -498,11 +498,18 @@ def import_library_versions(version_name, token=None, version_type="tag"):
         logger.info("Triggering removed submodules garbage collection")
         gc_removed_submodules.delay(library_keys, version_name)
 
-    # Retrieve and store the docs url for each library-version in this release
-    get_and_store_library_version_documentation_urls_for_version(version.pk)
+    # Both steps below run only once every library's metadata is written, and the
+    # first of them raises for a release with no docs archive in S3. Re-raised as
+    # ``PostImportStepFailed`` so a caller that needs the metadata and not the
+    # docs can tell that apart from a failure that left the metadata untouched.
+    try:
+        # Retrieve and store the docs url for each library-version in this release
+        get_and_store_library_version_documentation_urls_for_version(version.pk)
 
-    # Load maintainers for library-versions
-    call_command("update_maintainers", "--release", version.name)
+        # Load maintainers for library-versions
+        call_command("update_maintainers", "--release", version.name)
+    except Exception as exc:
+        raise PostImportStepFailed(library_keys) from exc
 
     # The keys it managed to read. Falsy means it read nothing at all, which a
     # caller cannot otherwise tell from a successful run: every failure above

--- a/versions/tests/test_models.py
+++ b/versions/tests/test_models.py
@@ -198,3 +198,44 @@ def test_get_dependency_stats_propagates_imported_data_exception(version):
     ):
         with pytest.raises(BoostImportedDataException):
             version.get_dependency_stats()
+
+
+@pytest.mark.parametrize(
+    "name,base,is_point",
+    [
+        ("boost-1.91.0-1", "boost-1.91.0", True),
+        ("boost-1.91.0-12", "boost-1.91.0", True),
+        ("boost-1.92.0", "boost-1.92.0", False),
+        ("boost-1.92.0.beta1", "boost-1.92.0.beta1", False),
+        ("develop", "develop", False),
+        ("master", "master", False),
+    ],
+)
+def test_base_release_name_resolves_point_releases(name, base, is_point):
+    """Point releases are tagged on the superproject only.
+
+    Their submodules keep the base release's tag and no docs archive is published
+    for them, so per-library and docs lookups have to resolve to the base release.
+    """
+    version = baker.prepare("versions.Version", name=name, slug=name.replace(".", "-"))
+    assert version.base_release_name == base
+    assert version.is_point_release is is_point
+
+
+@pytest.mark.parametrize(
+    "name,slug,expected",
+    [
+        ("boost-1.91.0-1", "boost-1-91-0-1", "boost_1_91_0"),
+        ("boost-1.92.0", "boost-1-92-0", "boost_1_92_0"),
+        ("boost-1.92.0.beta1", "boost-1-92-0-beta1", "boost_1_92_0_beta1"),
+        ("develop", "develop", "develop"),
+    ],
+)
+def test_base_release_url_slug_matches_boost_url_slug_off_point_releases(
+    name, slug, expected
+):
+    """Safe to substitute for `boost_url_slug`: only point releases differ."""
+    version = baker.prepare("versions.Version", name=name, slug=slug)
+    assert version.base_release_url_slug == expected
+    if not version.is_point_release:
+        assert version.base_release_url_slug == version.boost_url_slug

--- a/versions/tests/test_tasks.py
+++ b/versions/tests/test_tasks.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from unittest.mock import MagicMock, patch
+from libraries.models import LibraryVersion
 from versions.models import Version
 from versions.tasks import get_release_date_for_version, import_version, skip_tag
 from libraries.management.commands.release_tasks import ReleaseTasksManager
@@ -115,3 +116,53 @@ def test_import_reviews_task_backfills_the_review_source(mock_call):
     ]
     # The admin who pressed the button, so the sync log can name them.
     assert mock_call.call_args_list[-1].kwargs == {"actor_id": 7}
+
+
+@pytest.mark.django_db
+@patch("versions.tasks.call_command")
+@patch("versions.tasks.fetch_website_adoc_fields", return_value={})
+@patch("versions.tasks.get_and_store_library_version_documentation_urls_for_version")
+@patch("versions.tasks.GithubDataParser")
+@patch("versions.tasks.LibraryUpdater")
+@patch("versions.tasks.GithubAPIClient")
+def test_import_library_versions_marks_a_failure_after_the_metadata_was_written(
+    client_class,
+    updater_class,
+    parser_class,
+    docs_mock,
+    adoc_mock,
+    call_command_mock,
+    version,
+):
+    """The docs scrape runs last, and its failure has to be told from the others.
+
+    ``synchronize_release_library_data`` tolerates a raise from here only when
+    the library metadata it feeds to the author pass is already in place, and
+    this exception is how it knows that. A release with no docs archive in S3 is
+    the ordinary case: the rows are written, the scrape then raises.
+    """
+    from versions.exceptions import PostImportStepFailed
+    from versions.tasks import import_library_versions
+
+    parser_class.return_value.parse_gitmodules.return_value = [{"module": "array"}]
+    parser_class.return_value.parse_libraries_json.return_value = {
+        "key": "array",
+        "name": "Array",
+        "authors": ["Nicolai Josuttis"],
+        "cpp20_module_support": False,
+    }
+    client_class.return_value.get_repo.return_value = {
+        "html_url": "https://github.com/boostorg/array"
+    }
+    updater_class.return_value.skip_modules = []
+    updater_class.return_value.skip_libraries = []
+    docs_mock.side_effect = ValueError("Could not get content from S3")
+
+    with pytest.raises(PostImportStepFailed) as raised:
+        import_library_versions(version.name)
+
+    # The keys it read, so the caller can still tell an import that read nothing.
+    assert raised.value.library_keys == ["array"]
+    assert LibraryVersion.objects.filter(version=version, library__key="array").exists()
+    # The maintainers pass belongs to the same tail and never ran.
+    assert call_command_mock.call_args_list == []


### PR DESCRIPTION
# Issue: #2700

**Branch:** `teo/2700-authors-displayed-unknown` · **Base:** `origin/develop`

## Summary & Context

Adds a **Release tools** section to the admin, with a page that repairs one release's
library authors at a time, per the ticket's second comment. The "Unknown" authors are missing
data, not a rendering bug, and the only repair available before this swept every
library at every version with `--clean`, which can push one release's authors
backwards over older releases that are already correct.

Two releases could not be repaired at all until this, and both failed silently.
`1.91.0-1` is a point release, whose submodules keep the base release's tag and which
ships no docs archive; both lookups now resolve to the base release. `1.61.0` is the
only annotated tag of the 117 releases, and its ref names a tag object rather than a
commit, which the tree endpoint rejects. Each now imports and matches its neighbours.

**Worth reviewing on its own:** an import that read nothing used to be recorded as a
successful run, so the admin reported Finished over a job that changed nothing. That
is how both of the above stayed hidden, and how the reported 1.92.0 bug reached
production. An unreadable release now fails visibly.

- **Figma link**: n/a
- **Link to components/page:**
  - [http://localhost:8000/admin/release_tools/releaselibrarydata/](http://localhost:8000/admin/release_tools/releaselibrarydata/)
  - [http://localhost:8000/libraries/1.92.0/grid/](http://localhost:8000/libraries/1.92.0/grid/)

## Changes

- **`update_library_version_authors`** - new `--release` scopes a run to one version and skips the retroactive backfill; `--library-name` no longer raises `FieldError`.
- **`libraries/tasks.py`** - `synchronize_release_library_data` re-imports one release's data and then binds its authors, in that order, and still binds them if the import's docs step fails.
- **`release_tools/`** - new app, only so the admin index has a "Release tools" section to put operator jobs in. Its page explains the job and lists every release with its own Synchronize button, so the release you read the numbers for is the release you press.
- **the two count columns** - `Needs synchronizing` is what the job can repair; `No author upstream` is the handful of libraries whose own metadata names no author, kept apart so a healthy release does not report three faults it can never clear.
- **`core/admin_buttons.py`** - `choices` may be a callable, and `require_choice` drops the "all" option for a job with no meaningful unscoped run.
- **`versions/models.py`**, **`versions/tasks.py`** - point releases resolve to their base release for library metadata and documentation URLs; the import returns what it read, so a caller can tell a no-op from a run.
- **`core/githubhelper.py`** - an annotated release tag is dereferenced to its commit before the tree is fetched. `boost-1.61.0` is the one annotated tag in the set and used to fail with a 422, which is the "uncertain why" the old comment there described.
- **tests** - 30 new, over the scoping, the task, the button, the two columns, point releases and annotated tags.

## ‼️ Risks & Considerations ‼️

- A run calls the GitHub API per library and takes minutes, longer on old releases where most libraries need a documentation lookup too. It is queued on a worker and the row reports Running while it goes.
- The Library changelist's old "Update Authors & Maintainers" link still runs the `--clean` sweep. Untouched here; removing or gating it is a separate decision.
- Point releases now inherit the base release's authors and documentation links, which is correct for a patch re-release.

## Peer-review testing steps

1. Open Release tools > Library data as a superuser and read the explanation and the two count columns.
2. Confirm every release row has its own Synchronize button and there is no release dropdown.
3. Press Synchronize on `1.92.0`; the status line reports Queued, then Running, then finished, and `Needs synchronizing` reads "none".
4. `/libraries/1.92.0/grid/` shows real author names, `1.90.0` is unchanged, and `No author upstream` still reads 3 on both.
5. Repeat on `1.91.0-1` (a point release) and `1.61.0` (the annotated tag): both must finish without raising, and `1.91.0.1` must match `/libraries/1.91.0/grid/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an admin tool to synchronize library data for individual releases from GitHub.
  - Added release-specific status indicators for synchronization needs, missing authors, and running tasks.
  - Synchronization actions now require selecting a valid release and prevent branch-based runs.
  - Release author updates can target a single release.

- **Bug Fixes**
  - Point releases now correctly use base-release documentation and library metadata.

- **Documentation**
  - Added admin guidance explaining synchronization actions, results, and safe re-runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->