### PR TITLE
Story 2708: show the author badge on v3 Post and Contributor cards 

### DIFF
--- a/badges/display.py
+++ b/badges/display.py
@@ -260,10 +260,19 @@ def held_badges(user, include_hidden=False):
     Returns an empty list when the user has hidden their badges, unless
     ``include_hidden`` is set - which only the owner's own views should do.
 
+    An unclaimed account shows nothing either way. Those are stubs the library
+    importer minted to stand in for historical authors: nobody can log into one,
+    so a badge on a stub credits a placeholder rather than a member. Unlike
+    ``hide_badges`` this is not something ``include_hidden`` can bypass. That
+    exists so an owner can see their own hidden badges, and a stub has no owner
+    to be looking.
+
     Retiring a tier keeps the badges already awarded against it, so a user who
     also qualifies under its replacement holds the same rank twice. Both rows are
     real history; only one of them is a badge to show.
     """
+    if not user.claimed:
+        return []
     if user.hide_badges and not include_hidden:
         return []
     if "badges" in getattr(user, "_prefetched_objects_cache", {}):

--- a/badges/display.py
+++ b/badges/display.py
@@ -260,18 +260,19 @@ def held_badges(user, include_hidden=False):
     Returns an empty list when the user has hidden their badges, unless
     ``include_hidden`` is set - which only the owner's own views should do.
 
-    An unclaimed account shows nothing either way. Those are stubs the library
-    importer minted to stand in for historical authors: nobody can log into one,
-    so a badge on a stub credits a placeholder rather than a member. Unlike
-    ``hide_badges`` this is not something ``include_hidden`` can bypass. That
-    exists so an owner can see their own hidden badges, and a stub has no owner
-    to be looking.
+    An unclaimed or deactivated account shows nothing either way. Unclaimed ones
+    are stubs the library importer minted to stand in for historical authors;
+    deactivated ones are deleted accounts, whose badge rows the legacy delete
+    leaves behind while it scrubs the name and email. Neither has a member behind
+    it for a badge to credit. Unlike ``hide_badges`` this is not something
+    ``include_hidden`` can bypass. That exists so an owner can see their own
+    hidden badges, and neither of these has an owner to be looking.
 
     Retiring a tier keeps the badges already awarded against it, so a user who
     also qualifies under its replacement holds the same rank twice. Both rows are
     real history; only one of them is a badge to show.
     """
-    if not user.claimed:
+    if not (user.claimed and user.is_active):
         return []
     if user.hide_badges and not include_hidden:
         return []

--- a/badges/tests/test_profile.py
+++ b/badges/tests/test_profile.py
@@ -386,6 +386,8 @@ def test_hide_badges_suppresses_every_public_accessor(plain_user):
     assert display.featured_badge(plain_user) is None
     assert display.badge_cards(plain_user) == []
     assert plain_user.featured_badge is None
+    assert plain_user.badge is None
+    assert plain_user.badge_label == ""
     assert plain_user.to_v3_profile_dict()["badge"] is None
 
 
@@ -634,6 +636,89 @@ def test_v3_news_list_renders_no_badge_without_one(
 
     tp.response_200(response)
     assert "user-card__badge" not in response.content.decode()
+
+
+def test_a_user_fills_the_profile_component_badge_slots(plain_user):
+    """`_user_profile.html` reads `badge` and `badge_label` off whatever it is
+    handed, and the v3 post cards hand it a User rather than the dict
+    `to_v3_profile_dict` builds. Both shapes have to answer the same (#2708)."""
+    assert plain_user.badge is None
+    assert plain_user.badge_label == ""
+
+    plain_user = _feature(plain_user, "library-authoring")
+    profile = plain_user.to_v3_profile_dict()
+
+    assert plain_user.badge == BadgeToken.TIER_1 == profile["badge"]
+    assert plain_user.badge_label == "Library Author" == profile["badge_label"]
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_v3_news_list_renders_the_author_badge_on_a_post_card(
+    plain_user, tp, post_index_page, wagtail_site, make_post_page
+):
+    """The feed lists PostPages, whose `author` is the owning User.
+
+    Anonymous on purpose: the sidebar card renders the same label for a signed-in
+    member, and would pass this whether or not the author card had a badge.
+    """
+    plain_user.display_name = "Vinnie Falco"
+    plain_user.save(update_fields=["display_name"])
+    plain_user = _feature(plain_user, "library-authoring")
+    make_post_page(title="A Post", owner=plain_user)
+
+    response = tp.get(post_index_page.get_url())
+
+    tp.response_200(response)
+    body = response.content.decode()
+    assert "user-card__badge" not in body, "signed out, so no sidebar card badge"
+    assert 'aria-label="Library Author"' in body
+    assert "badge-v3--tier-1" in body
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_v3_post_detail_renders_the_author_badge(
+    plain_user, tp, wagtail_site, make_post_page
+):
+    """The detail page's own header reads `post_author`, which is the same User."""
+    plain_user.display_name = "Vinnie Falco"
+    plain_user.save(update_fields=["display_name"])
+    plain_user = _feature(plain_user, "library-authoring")
+    post = make_post_page(title="A Post", owner=plain_user)
+
+    response = tp.get(post.get_url())
+
+    tp.response_200(response)
+    body = response.content.decode()
+    assert 'aria-label="Library Author"' in body
+    assert "badge-v3--tier-1" in body
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_v3_feed_author_badge_query_is_constant(
+    plain_user, tp, post_index_page, wagtail_site, make_post_page
+):
+    """The feed loads author badges once, not once per card.
+
+    `owner` is select_related, so the badges have to be asked for through the
+    path - see `badges.display.active_badges_prefetch`.
+    """
+    plain_user = _feature(plain_user, "library-authoring")
+    make_post_page(title="Post 0", owner=plain_user)
+
+    def feed():
+        return tp.get(post_index_page.get_url())
+
+    one_post, one_badge_query = _badge_queries(feed)
+
+    for index in range(1, 4):
+        author = baker.make("users.User", email=f"feed-{index}@example.com")
+        author = _feature(author, "library-authoring")
+        make_post_page(title=f"Post {index}", owner=author)
+    four_posts, four_badge_queries = _badge_queries(feed)
+
+    assert one_badge_query == four_badge_queries == 1
+    assert len(one_post.context["entry_list"]) == 1
+    assert len(four_posts.context["entry_list"]) == 4
 
 
 @waffle.testutils.override_flag("v3", active=True)

--- a/badges/tests/test_profile.py
+++ b/badges/tests/test_profile.py
@@ -932,9 +932,10 @@ def test_v3_post_detail_badge_query_is_constant(
     post's and the related posts'. None may grow with how many posts exist.
 
     Wagtail resolves the page being viewed by itself, so its author is not part
-    of the prefetched queryset the next and related cards come from. Prefetching
-    that one user would cost exactly the query it saves, so the count is pinned
-    here instead of adding a prefetch that buys nothing.
+    of the prefetched queryset the next and related cards come from; the page
+    prefetches that author separately. One author costs the same single query
+    either way, so the number below does not move when that prefetch is removed -
+    what this pins is that none of the three grows with the post count.
     """
     plain_user = _feature(plain_user, "library-authoring")
     post = make_post_page(title="Main Post", owner=plain_user)

--- a/badges/tests/test_profile.py
+++ b/badges/tests/test_profile.py
@@ -423,6 +423,42 @@ def test_an_unclaimed_stub_is_not_bypassed_by_include_hidden(plain_user):
     assert display.badge_cards(plain_user, include_hidden=True) == []
 
 
+def test_a_deactivated_account_shows_no_badges(plain_user):
+    """A legacy account deletion scrubs the name and email but leaves the badge
+    rows behind - only `extended_scrub` drops them. Without this the deleted
+    member keeps a badge on every public card their commits still appear on."""
+    plain_user = _feature(plain_user, "library-authoring")
+    plain_user.delete_account()
+    plain_user = _reload(plain_user)
+
+    assert plain_user.badges.filter(revoked_at=None).exists(), (
+        "legacy delete is expected to leave the rows; this test is about hiding "
+        "them, so it would pass vacuously if they were gone"
+    )
+    assert display.held_badges(plain_user) == []
+    assert display.held_badges(plain_user, include_hidden=True) == []
+    assert display.featured_badge(plain_user) is None
+    assert plain_user.badge is None
+    assert plain_user.badge_label == ""
+    assert plain_user.to_v3_profile_dict()["badge"] is None
+
+
+def test_a_contributor_linked_to_a_deactivated_account_shows_no_badge(plain_user):
+    """Contributor rows resolve their badge through the linked account, and a
+    deleted member's commits stay attributed to them."""
+    plain_user = _feature(plain_user, "library-authoring")
+    author = _commit_author(user=plain_user)
+    assert author.to_v3_profile_dict("Contributor")["badge"] == BadgeToken.TIER_1
+
+    plain_user.delete_account()
+    author.refresh_from_db()
+
+    profile = author.to_v3_profile_dict("Contributor")
+
+    assert profile["badge"] is None
+    assert profile["badge_label"] == ""
+
+
 def test_claiming_the_account_restores_its_badges(plain_user):
     """The badges were never revoked, only withheld while the stub was unowned."""
     plain_user = _feature(plain_user, "library-authoring")

--- a/badges/tests/test_profile.py
+++ b/badges/tests/test_profile.py
@@ -391,6 +391,67 @@ def test_hide_badges_suppresses_every_public_accessor(plain_user):
     assert plain_user.to_v3_profile_dict()["badge"] is None
 
 
+def test_an_unclaimed_stub_shows_no_badges(plain_user):
+    """Stubs stand in for historical authors and nobody can log into them, so a
+    badge on one credits a placeholder rather than a member."""
+    plain_user = _feature(plain_user, "library-authoring")
+    assert plain_user.featured_badge is not None
+
+    plain_user.claimed = False
+    plain_user.save(update_fields=["claimed"])
+    plain_user = _reload(plain_user)
+
+    assert display.held_badges(plain_user) == []
+    assert display.featured_badge(plain_user) is None
+    assert display.badge_cards(plain_user) == []
+    assert plain_user.featured_badge is None
+    assert plain_user.badge is None
+    assert plain_user.badge_label == ""
+    assert plain_user.to_v3_profile_dict()["badge"] is None
+
+
+def test_an_unclaimed_stub_is_not_bypassed_by_include_hidden(plain_user):
+    """`include_hidden` lets an owner see their own hidden badges. A stub has no
+    owner to be looking, so it is the one case the bypass must not reach."""
+    plain_user = _feature(plain_user, "library-authoring")
+    plain_user.claimed = False
+    plain_user.save(update_fields=["claimed"])
+    plain_user = _reload(plain_user)
+
+    assert display.held_badges(plain_user, include_hidden=True) == []
+    assert display.featured_badge(plain_user, include_hidden=True) is None
+    assert display.badge_cards(plain_user, include_hidden=True) == []
+
+
+def test_claiming_the_account_restores_its_badges(plain_user):
+    """The badges were never revoked, only withheld while the stub was unowned."""
+    plain_user = _feature(plain_user, "library-authoring")
+    plain_user.claimed = False
+    plain_user.save(update_fields=["claimed"])
+    assert _reload(plain_user).featured_badge is None
+
+    _reload(plain_user).claim()
+
+    assert _reload(plain_user).featured_badge["icon"] == BadgeToken.TIER_1
+
+
+def test_a_contributor_linked_to_an_unclaimed_stub_shows_no_badge(plain_user):
+    """The case this filter exists for: contributor rows resolve their badge
+    through the linked account, and some of those accounts are importer stubs."""
+    plain_user = _feature(plain_user, "library-authoring")
+    author = _commit_author(user=plain_user)
+    assert author.to_v3_profile_dict("Contributor")["badge"] == BadgeToken.TIER_1
+
+    plain_user.claimed = False
+    plain_user.save(update_fields=["claimed"])
+    author.refresh_from_db()
+
+    profile = author.to_v3_profile_dict("Contributor")
+
+    assert profile["badge"] is None
+    assert profile["badge_label"] == ""
+
+
 def test_hide_badges_can_be_bypassed_for_the_owner(plain_user):
     """include_hidden lets the owner still see badges they have hidden."""
     plain_user = _feature(plain_user, "library-authoring")

--- a/badges/tests/test_profile.py
+++ b/badges/tests/test_profile.py
@@ -570,6 +570,92 @@ def test_library_detail_user_badge_query_is_constant(library_version, plain_user
     assert {card["badge_label"] for card in four_cards} == {"Library Author"}
 
 
+def _commit_author(user=None, **kwargs):
+    """A human commit author, optionally linked to a Boost account."""
+    return baker.make("libraries.CommitAuthor", user=user, is_bot=False, **kwargs)
+
+
+def test_a_commit_author_shows_its_linked_members_badge(plain_user):
+    """Release and library contributor rows are CommitAuthors, not Users, and
+    their card hardcoded no badge even for a linked account (#2708)."""
+    plain_user = _feature(plain_user, "library-authoring")
+    author = _commit_author(user=plain_user)
+
+    profile = author.to_v3_profile_dict("Contributor")
+
+    assert profile["badge"] == BadgeToken.TIER_1
+    assert profile["badge_label"] == "Library Author"
+
+
+def test_a_git_only_contributor_has_no_badge():
+    """Badges are awarded to the account, so an unlinked git identity has none.
+
+    The empty case the template skips, not a placeholder medal.
+    """
+    profile = _commit_author().to_v3_profile_dict("Contributor")
+
+    assert profile["badge"] is None
+    assert profile["badge_label"] == ""
+
+
+def test_a_contributor_matched_by_github_username_keeps_its_badge(plain_user):
+    """`prefer_boost_profile_links` repoints a contributor at their Boost
+    profile off the GitHub username when the commit email never matched. The
+    badge has to travel with the link, or the same member renders as an
+    account beside a badgeless stranger."""
+    from libraries.utils import prefer_boost_profile_links
+
+    plain_user.github_username = "vinniefalco"
+    plain_user.claimed = True
+    plain_user.save(update_fields=["github_username", "claimed"])
+    plain_user = _feature(plain_user, "library-authoring")
+    author = _commit_author(github_profile_url="https://github.com/VinnieFalco")
+
+    profile = author.to_v3_profile_dict("Contributor")
+    assert profile["badge"] is None, "unlinked, so nothing to show yet"
+
+    prefer_boost_profile_links([profile])
+
+    assert profile["profile_url"] == plain_user.profile_url
+    assert profile["badge"] == BadgeToken.TIER_1
+    assert profile["badge_label"] == "Library Author"
+
+
+def test_release_contributor_badge_query_is_constant(plain_user, version):
+    """The downloads page loads contributor badges once, not once per row.
+
+    `user` is select_related on the contributor queryset, so the badges have to
+    be asked for through the path - see `badges.display.active_badges_prefetch`.
+    """
+    from versions.views import VersionDetail
+
+    def add_contributor(user):
+        """One commit against this release, authored by `user`'s git identity."""
+        baker.make(
+            "libraries.Commit",
+            library_version=baker.make("libraries.LibraryVersion", version=version),
+            author=_commit_author(user=user),
+        )
+
+    plain_user = _feature(plain_user, "library-authoring")
+    add_contributor(plain_user)
+
+    def contributors():
+        return VersionDetail().get_v3_contributors(version)
+
+    one_row, one_badge_query = _badge_queries(contributors)
+
+    for index in range(1, 4):
+        user = baker.make("users.User", email=f"release-{index}@example.com")
+        add_contributor(_feature(user, "library-authoring"))
+    four_rows, four_badge_queries = _badge_queries(contributors)
+
+    assert one_badge_query == four_badge_queries == 1
+    assert len(one_row) == 1
+    assert len(four_rows) == 4
+    assert {row["badge_label"] for row in four_rows} == {"Library Author"}
+
+
 @waffle.testutils.override_flag("v3", active=True)
 def test_own_profile_page_shows_hidden_badges(plain_user, tp):
     """The owner's own v3 profile still renders badges they have hidden."""

--- a/badges/tests/test_profile.py
+++ b/badges/tests/test_profile.py
@@ -841,6 +841,43 @@ def test_v3_post_detail_renders_the_author_badge(
 
 
 @waffle.testutils.override_flag("v3", active=True)
+def test_v3_post_detail_badge_query_is_constant(
+    plain_user, tp, wagtail_site, make_post_page
+):
+    """A post detail page reads three sets of badges: the author's, the next
+    post's and the related posts'. None may grow with how many posts exist.
+
+    Wagtail resolves the page being viewed by itself, so its author is not part
+    of the prefetched queryset the next and related cards come from. Prefetching
+    that one user would cost exactly the query it saves, so the count is pinned
+    here instead of adding a prefetch that buys nothing.
+    """
+    plain_user = _feature(plain_user, "library-authoring")
+    post = make_post_page(title="Main Post", owner=plain_user)
+    for index in range(3):
+        author = baker.make("users.User", email=f"detail-a-{index}@example.com")
+        make_post_page(
+            title=f"Related A {index}", owner=_feature(author, "library-authoring")
+        )
+
+    def detail():
+        return tp.get(post.get_url())
+
+    few, few_badge_queries = _badge_queries(detail)
+
+    for index in range(7):
+        author = baker.make("users.User", email=f"detail-b-{index}@example.com")
+        make_post_page(
+            title=f"Related B {index}", owner=_feature(author, "library-authoring")
+        )
+    many, many_badge_queries = _badge_queries(detail)
+
+    tp.response_200(few)
+    tp.response_200(many)
+    assert few_badge_queries == many_badge_queries == 3
+
+
+@waffle.testutils.override_flag("v3", active=True)
 def test_v3_feed_author_badge_query_is_constant(
     plain_user, tp, post_index_page, wagtail_site, make_post_page
 ):

--- a/badges/tests/test_profile.py
+++ b/badges/tests/test_profile.py
@@ -615,6 +615,54 @@ def test_homepage_ranked_post_badge_query_is_constant(plain_user, make_post_page
     assert {card["author"]["badge_label"] for card in four_cards} == {"Library Author"}
 
 
+def test_library_card_author_shows_their_badge(library_version, plain_user):
+    """The Libraries page builds its own author dict rather than going through
+    `to_v3_profile_dict`, and it set a `badge_url` key nothing reads - so the
+    card showed the tenure star and no badge."""
+    plain_user = _feature(plain_user, "library-authoring")
+    library_version.authors.add(plain_user)
+
+    details = library_version.author_details
+
+    assert details["badge"] == BadgeToken.TIER_1
+    assert details["badge_label"] == "Library Author"
+    assert "badge_url" not in details
+
+
+def test_library_card_without_an_author_has_no_badge(library_version):
+    """The empty case the template skips, not a placeholder medal."""
+    details = library_version.author_details
+
+    assert details["badge"] is None
+    assert details["badge_label"] == ""
+
+
+def test_library_list_author_badge_query_is_constant(library_version, plain_user):
+    """The Libraries page reads one author badge per card, so the list view
+    prefetches them through its `authors` Prefetch."""
+    from libraries.views import LibraryListBase
+
+    plain_user = _feature(plain_user, "library-authoring")
+    library_version.authors.add(plain_user)
+
+    def author_cards():
+        rows = list(LibraryListBase.queryset.all())
+        return [lv.author_details for lv in rows]
+
+    one_card, one_badge_query = _badge_queries(author_cards)
+
+    for index in range(1, 4):
+        author = baker.make("users.User", email=f"lib-list-{index}@example.com")
+        other = baker.make("libraries.LibraryVersion")
+        other.authors.add(_feature(author, "library-authoring"))
+    four_cards, four_badge_queries = _badge_queries(author_cards)
+
+    assert one_badge_query == four_badge_queries == 1
+    assert len(one_card) == 1
+    assert len(four_cards) == 4
+    assert {card["badge_label"] for card in four_cards} == {"Library Author"}
+
+
 def test_library_intro_badge_query_is_constant(library_version, plain_user):
     """The homepage library intro prefetches its User authors and maintainers."""
     from libraries.utils import build_library_intro_context

--- a/libraries/mixins.py
+++ b/libraries/mixins.py
@@ -326,10 +326,15 @@ class ContributorMixin:
             qs = qs.exclude(id__in=exclude)
         qs = (
             qs.annotate(count=Count("commit"))
-            # A claimed contributor links to their Boost profile, which reads
-            # the user and their routing keys.
+            # A claimed contributor links to their Boost profile and shows
+            # their badge, which reads the user, their routing keys and their
+            # badge rows. Badges are asked for through the path because `user`
+            # is select_related - see `badges.display.active_badges_prefetch`.
             .select_related("user")
-            .prefetch_related("user__profile_routing_keys")
+            .prefetch_related(
+                "user__profile_routing_keys",
+                active_badges_prefetch("user__badges"),
+            )
             .order_by("-count")
         )
         return qs
@@ -389,10 +394,15 @@ class ContributorMixin:
             CommitAuthor.humans.filter(commit__library_version__in=library_versions)
             .exclude(id__in=author_ca_ids + maintainer_ca_ids)
             .annotate(count=Count("commit"))
-            # A claimed contributor links to their Boost profile, which reads
-            # the user and their routing keys.
+            # A claimed contributor links to their Boost profile and shows
+            # their badge, which reads the user, their routing keys and their
+            # badge rows. Badges are asked for through the path because `user`
+            # is select_related - see `badges.display.active_badges_prefetch`.
             .select_related("user")
-            .prefetch_related("user__profile_routing_keys")
+            .prefetch_related(
+                "user__profile_routing_keys",
+                active_badges_prefetch("user__badges"),
+            )
             .order_by("-count")
         )
         return (

--- a/libraries/models.py
+++ b/libraries/models.py
@@ -19,7 +19,6 @@ from django.db.models.functions import Upper
 
 from config import settings
 from core.custom_model_fields import NullableFileField
-from core.templatetags.custom_static import large_static
 from core.markdown import process_md
 from core.models import RenderedContent
 from core.asciidoc import convert_adoc_to_html
@@ -851,7 +850,11 @@ class LibraryVersion(models.Model):
             "role": "Author",
             "profile_url": author.profile_url if author else None,
             "avatar_url": author.get_avatar_url() if author else "",
-            "badge_url": large_static("img/v3/badges/badge-first-place.png"),
+            # `badge_url` used to sit here, pointing at a fixed first-place PNG.
+            # Nothing read it: `_user_profile.html` takes `badge` and
+            # `badge_label`, so the card showed the tenure star and no badge.
+            "badge": author.badge if author else None,
+            "badge_label": author.badge_label if author else "",
             **(author.profile_stamps if author else {}),
         }
 

--- a/libraries/models.py
+++ b/libraries/models.py
@@ -137,6 +137,10 @@ class CommitAuthor(models.Model):
         one who has not falls back to their GitHub page, which is all this site
         knows about them. A deactivated account falls back the same way, since
         its profile 404s.
+
+        Badges are awarded to the account, not to the git identity, so a
+        contributor with no linked account has none to show - it is the same
+        empty case as a member who has earned nothing (issue #2708).
         """
         user_profile_url = self.user.profile_url if self.user else None
         return {
@@ -146,7 +150,8 @@ class CommitAuthor(models.Model):
             "avatar_url": self.avatar_url or "",
             "tenure_stamp": self.user.tenure_stamp if self.user else None,
             "boost_day_stamp": self.user.boost_day_stamp if self.user else None,
-            "badge": None,
+            "badge": self.user.badge if self.user else None,
+            "badge_label": self.user.badge_label if self.user else "",
             "bio": None,
         }
 

--- a/libraries/tests/test_utils.py
+++ b/libraries/tests/test_utils.py
@@ -485,8 +485,10 @@ class TestPreferBoostProfileLinks:
                 github_username=f"user{i}",
             )
         rows = [self.author_dict(f"user{i}") for i in range(3)]
-        # One for the users, one for their prefetched routing keys.
-        with django_assert_num_queries(2):
+        # One for the users, one for their prefetched routing keys, one for
+        # their prefetched badges. Three rows and a fixed count: drop any of
+        # the prefetches and this grows with the list rather than staying put.
+        with django_assert_num_queries(3):
             prefer_boost_profile_links(rows)
         assert all(r["profile_url"].startswith("/users/") for r in rows)
 

--- a/libraries/utils.py
+++ b/libraries/utils.py
@@ -537,9 +537,15 @@ def prefer_boost_profile_links(author_dicts):
     profile. GitHub username is a second signal for the same identity, and both
     records usually carry it.
 
+    The badge travels with the link, for the same reason: a contributor we are
+    confident enough to point at a Boost profile is that member, so showing
+    their profile but not their badge would split one identity across two cards
+    (issue #2708).
+
     Resolves the whole list in one query. Mutates each dict in place and returns
     the same list.
     """
+    from badges.display import active_badges_prefetch
     from users.models import User
 
     by_username = {}
@@ -560,7 +566,7 @@ def prefer_boost_profile_links(author_dicts):
         User.objects.filter(is_active=True, claimed=True)
         .annotate(github_username_lower=Lower("github_username"))
         .filter(github_username_lower__in=by_username)
-        .prefetch_related("profile_routing_keys")
+        .prefetch_related("profile_routing_keys", active_badges_prefetch())
     )
     for user in users:
         profile_url = user.profile_url
@@ -568,6 +574,8 @@ def prefer_boost_profile_links(author_dicts):
             continue
         for author in by_username.get(user.github_username.lower(), []):
             author["profile_url"] = profile_url
+            author["badge"] = user.badge
+            author["badge_label"] = user.badge_label
 
     return author_dicts
 
@@ -644,6 +652,7 @@ def build_library_intro_context(
     slots; set it False to show authors and maintainers only. `max_authors`
     caps the number shown; pass None to show all.
     """
+    from badges.display import active_badges_prefetch
     from libraries.models import CommitAuthor
 
     library = library_version.library
@@ -661,8 +670,6 @@ def build_library_intro_context(
 
     combined = (authors + maintainers)[:max_authors]
     if combined:
-        from badges.display import active_badges_prefetch
-
         prefetch_related_objects(combined, active_badges_prefetch())
     roles = {}
     for user in combined:
@@ -683,10 +690,15 @@ def build_library_intro_context(
             CommitAuthor.humans.filter(commit__library_version=library_version)
             .exclude(id__in=exclude_commit_author_ids)
             .annotate(count=Count("commit"))
-            # A claimed contributor links to their Boost profile, which reads the
-            # user and their routing keys.
+            # A claimed contributor links to their Boost profile and shows
+            # their badge, which reads the user, their routing keys and their
+            # badge rows. Badges are asked for through the path because `user`
+            # is select_related - see `badges.display.active_badges_prefetch`.
             .select_related("user")
-            .prefetch_related("user__profile_routing_keys")
+            .prefetch_related(
+                "user__profile_routing_keys",
+                active_badges_prefetch("user__badges"),
+            )
             .order_by("-count")[:remaining]
         )
 

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -20,6 +20,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import DetailView, ListView, FormView, TemplateView
 from waffle import flag_is_active
 
+from badges.display import active_badges_prefetch
 from core.constants import SLACK_JOIN_URL
 from core.githubhelper import GithubAPIClient
 from core.mixins import V3Mixin
@@ -199,7 +200,7 @@ class LibraryListBase(BoostVersionMixin, V3Mixin, VersionAlertMixin, ListView):
         Prefetch(
             "authors",
             queryset=User.objects.order_by("pk").prefetch_related(
-                "profile_routing_keys"
+                "profile_routing_keys", active_badges_prefetch()
             ),
         ),
         "library",

--- a/pages/models.py
+++ b/pages/models.py
@@ -23,6 +23,7 @@ from modelcluster.contrib.taggit import ClusterTaggableManager
 from waffle import flag_is_active
 
 
+from badges.display import active_badges_prefetch
 from libraries.utils import library_filter_options
 from pages.blocks import POST_BLOCKS
 from pages.feed import (
@@ -122,8 +123,15 @@ class PostIndexPage(BasePage):
             PostPage.objects.child_of(self)
             .live()
             .select_related("owner")
-            # tags per card, and the author's routing keys for the profile link.
-            .prefetch_related("tags", "owner__profile_routing_keys")
+            # tags per card, the author's badge rows for the badge beside their
+            # role, and their routing keys for the profile link. The badges are
+            # asked for through the path because `owner` is select_related - see
+            # `badges.display.active_badges_prefetch`.
+            .prefetch_related(
+                "tags",
+                active_badges_prefetch("owner__badges"),
+                "owner__profile_routing_keys",
+            )
         )
         if filters.post_type:
             posts = posts.filter(content__0__type__in=filters.post_type.block_name)
@@ -149,7 +157,11 @@ class PostIndexPage(BasePage):
         return (
             PostPage.objects.filter(pk__in=posts.order_by().values("pk"))
             .select_related("owner")
-            .prefetch_related("tags", "owner__profile_routing_keys")
+            .prefetch_related(
+                "tags",
+                active_badges_prefetch("owner__badges"),
+                "owner__profile_routing_keys",
+            )
             .search(filters.q)
         )
 
@@ -281,7 +293,17 @@ class PostPage(BasePage):
 
     def get_context(self, request, *args, **kwargs):
         ctx = super().get_context(request, *args, **kwargs)
-        pages: models.QuerySet = PostPage.objects.live().order_by("-first_published_at")
+        # Each card renders its author, which reads their badges and routing
+        # keys: one query for the page rather than one per card.
+        pages: models.QuerySet = (
+            PostPage.objects.live()
+            .select_related("owner")
+            .prefetch_related(
+                active_badges_prefetch("owner__badges"),
+                "owner__profile_routing_keys",
+            )
+            .order_by("-first_published_at")
+        )
         if self.first_published_at:
             next_objects = pages.filter(first_published_at__gt=self.first_published_at)
         else:

--- a/pages/models.py
+++ b/pages/models.py
@@ -9,7 +9,14 @@ from wagtail.search import index
 
 from django.conf import settings
 from django.core.paginator import Paginator
-from django.db.models import ExpressionWrapper, FloatField, F, Func, Value
+from django.db.models import (
+    ExpressionWrapper,
+    FloatField,
+    F,
+    Func,
+    Value,
+    prefetch_related_objects,
+)
 from django.db.models.functions import Coalesce, Greatest, Now, Power
 from django.db import models
 from django.urls import reverse_lazy
@@ -318,6 +325,12 @@ class PostPage(BasePage):
             :3
         ]
         ctx["object"] = self.specific
+        # Wagtail resolves the page being viewed by itself, so its author is not
+        # one of the rows the queryset above prefetched.
+        if self.owner_id is not None:
+            prefetch_related_objects(
+                [self.owner], active_badges_prefetch(), "profile_routing_keys"
+            )
         ctx["post_author"] = self.author
         ctx["user_can_edit"] = self.user_can_edit(request.user)
         ctx["user_can_delete"] = self.user_can_delete(request.user)

--- a/users/models.py
+++ b/users/models.py
@@ -609,15 +609,14 @@ class User(BaseUser):
         A deactivated account's profile 404s, so `profile_url` leaves it
         unlinked.
         """
-        featured = self.featured_badge
         return {
             "name": self.display_name or str(self),
             "profile_url": self.profile_url,
             "role": role if role is not None else self.role,
             "avatar_url": self.get_avatar_url(),
             **self.profile_stamps,
-            "badge": featured["icon"] if featured else None,
-            "badge_label": featured["name"] if featured else "",
+            "badge": self.badge,
+            "badge_label": self.badge_label,
             "bio": None,
         }
 
@@ -710,6 +709,25 @@ class User(BaseUser):
         from badges.display import featured_badge
 
         return featured_badge(self)
+
+    @property
+    def badge(self):
+        """Featured badge token, or None, as `_user_profile.html` reads it.
+
+        Named for the template slot rather than for `featured_badge` because
+        that is the contract being satisfied: the v3 posts feed and the post
+        detail cards pass a User straight into that component (see
+        `profile_url`), and without these two the badge was the one field it
+        could not resolve - issue #2708.
+        """
+        featured = self.featured_badge
+        return featured["icon"] if featured else None
+
+    @property
+    def badge_label(self):
+        """Hover label for `badge`, or "" - the empty case the template skips."""
+        featured = self.featured_badge
+        return featured["name"] if featured else ""
 
     def _effective_role(self, ignore_hidden=False):
         """The (role_type, library) currently displayed, or (None, None).

--- a/versions/views.py
+++ b/versions/views.py
@@ -20,6 +20,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from waffle import flag_is_active
 
+from badges.display import active_badges_prefetch
 from core.hero import release_hero_context
 from core.mixins import V3Mixin
 from mailing_list.mixins import MailingListCardMixin
@@ -146,10 +147,15 @@ class VersionDetail(
                 count=Count("commit", filter=Q(commit__in=version_commits)),
             )
             .filter(count__gte=1)
-            # A claimed contributor links to their Boost profile, which reads
-            # the user and their routing keys.
+            # A claimed contributor links to their Boost profile and shows
+            # their badge, which reads the user, their routing keys and their
+            # badge rows. Badges are asked for through the path because `user`
+            # is select_related - see `badges.display.active_badges_prefetch`.
             .select_related("user")
-            .prefetch_related("user__profile_routing_keys")
+            .prefetch_related(
+                "user__profile_routing_keys",
+                active_badges_prefetch("user__badges"),
+            )
             .order_by("-count")
         )
         return qs


### PR DESCRIPTION
# Issue: #2708

## Summary & Context

The badge that sits beside a person's name was missing on post cards and on the release and library contributor lists. The original report read it as a badge tied to the user's **role**, but it isn't. It's the member's featured badge (the Display Badge they picked on Edit Profile, or their highest earned tier if they never picked one), and it only _looks_ role-related because the layout puts the two next to each other. So the role part of the report is a misunderstanding, but the badge really was missing on those cards, and this fixes that.

- **Figma link**: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=7616-78083&t=WVJ4JD7aSUGzdpcP-4
- **Link to components/page:**
    - `localhost:8000/news/`
    - `localhost:8000/news/<post-slug>/`
    - `localhost:8000/releases/latest/`
    - `localhost:8000/library/latest/<library-slug>/`
    - `localhost:8000/libraries/latest/list/`

## Changes

1. **Post cards now show the author's badge:** the posts feed, the post detail header, and the Next Post and Related Posts cards all pass the author's user record straight to the shared profile component. That record could already supply the name, role, avatar and tenure stars, but had nothing for the badge, so every other field rendered and only the badge went missing. Added the two missing fields to the user record (`users/models.py`).

2. **Release and library contributor rows now show the badge of the contributor's Boost account:** these rows are commit authors, not accounts, and their card data set the badge to "none" unconditionally, even when the commit author was already linked to an account. It now reads the linked account's badge (`libraries/models.py`). A contributor with no Boost account still shows no badge: badges are earned by the account, not by the git identity.

3. **A contributor matched to an account by GitHub username now keeps their badge:** when someone's commit email never matched the address they signed up with, we already repoint their link from GitHub to their Boost profile using their GitHub username instead. The badge now follows that same match.

4. **Badge data is loaded once per page instead of once per card:** making the badge render would otherwise add a database read for every card on the page, so each affected page now loads them in a single read. A post's own author is fetched separately from the cards around it, so that one is asked for on its own.

5. **Unclaimed accounts show no badges anywhere:** applied in the one place every badge display goes through (`badges/display.py`), so it covers the contributor lists, the post cards and the profile page together. Tenure stars were already withheld from the same accounts, so badges now match that rule. Claiming the account brings the badges back.

6. **Deactivated accounts show no badges either:** the legacy account deletion scrubs the name and email but leaves the badge rows behind, so without this a deleted member kept a badge on every public card their commits still appear on. 

7. **The Libraries list page shows the author's badge.** 

## ‼️ Risks & Considerations ‼️

1. **:warning: The GitHub username match in the third bullet is a judgement call :warning:**, and it's self-contained in one function (`prefer_boost_profile_links`). If we'd rather only ever trust an exact email match, that piece can be dropped on its own without touching anything else here.

2. **"Hide my badges" still wins.** Every badge on these cards is resolved by the same code that honours that opt-out, so a member who hid their badges shows none here. No change in behaviour, but it's the kind of thing worth confirming when badges start appearing in new places.

3. **Downloads has an open design question that this PR does not settle.** Figma shows an _achievement counter_ on the Downloads contributor list rather than a badge. Raised with @henryajisegiri and @herzog0 on the issue.

4. **The unclaimed and deactivated filters are absolute, and neither is something the "show my own hidden badges" path can bypass.** That path exists so an owner can see badges they have hidden on their own profile, and neither a stub nor a deleted account has an owner who could be looking, so they never overlap. Worth confirming that no real member's account is sitting at `claimed = False` in production, since it would silently lose its badges. The field defaults to `True` and is only set false by the importer's stub creation, so this should be limited to stubs.

5. **This PR removes badges that are showing today, and the affected names are prominent ones:** on `/releases/latest/` the contributor list goes from 34 badges to 15: the 19 that disappear are unclaimed accounts belonging to historical contributors (see the note under Screenshots). 

## Screenshots

### Posts User Cards

<img width="649" height="803" alt="Posts" src="https://github.com/user-attachments/assets/82c0c76a-20ba-4abe-808c-ef3cd242ea4c" />

### Post User Cards

<img width="1332" height="959" alt="Post" src="https://github.com/user-attachments/assets/a18c4a47-41ed-4376-bee6-b953bdea15cf" />

### Libraries

<img width="1431" height="798" alt="Libraries" src="https://github.com/user-attachments/assets/27512018-65f2-4c4e-90d3-3d5cdef5af4f" />

### Downloads Contributor User Cards

<img width="1358" height="495" alt="Downloads" src="https://github.com/user-attachments/assets/2f56f8bb-25be-4aa8-8cf8-225b7f7ac74a" />

> [!NOTE]
> I've highlighted the users who used to show their badges, but no longer do so because they're unclaimed accounts.
> These are a few accounts you can test this PR with: Peter Dimov, John Maddock, Robert Ramey, Antony Polukhin, Andrey Semashev, Chris Kohlhoff, Oliver Kowalke, Barend Gehrels.

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend

- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Contributor profiles now display featured badges and labels across library, news, post, feed, and release views.
    - Badges follow contributors when profile links are redirected to matching Boost profiles.
    - Users and contributors without a featured badge continue to display no badge.

- **Bug Fixes**
    - Badges are no longer shown for unclaimed or deactivated accounts, including when hidden badges are explicitly requested.
    - Anonymous authors and unlinked identities remain badge-free.
      <!-- end of auto-generated comment: release notes by coderabbit.ai -->
