### PR TITLE
Task 2684: Prevent Long Description from Breaking Layout

### DIFF
--- a/libraries/constants.py
+++ b/libraries/constants.py
@@ -421,3 +421,9 @@ COMMIT_EMAIL_STALE_ACTION_ERROR = (
 # redirected GET to regenerate its error, so this covers the race where the
 # blocking condition cleared in between and validation now passes.
 COMMIT_EMAIL_ADD_FAILED_ERROR = "That email address could not be added."
+
+# Library descriptions come from the library's own metadata and are unbounded,
+# so a long one grows the detail-page hero until its actions row overlaps the
+# cards beneath it. Capped for layout until a real content solution lands.
+# See https://github.com/boostorg/website-v2/issues/2684.
+LIBRARY_DESCRIPTION_MAX_CHARS = 230

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -7,7 +7,11 @@ from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from model_bakery import baker
 
-from ..constants import README_MISSING, SELECTED_LIBRARY_VIEW_COOKIE_NAME
+from ..constants import (
+    LIBRARY_DESCRIPTION_MAX_CHARS,
+    README_MISSING,
+    SELECTED_LIBRARY_VIEW_COOKIE_NAME,
+)
 from ..models import Library
 from ..utils import benchmark_sets, designed_for_html
 from ..views import LibraryListBase, _build_quick_start_links, _is_boost_url
@@ -264,6 +268,52 @@ def test_library_detail(library_version, tp):
     url = tp.reverse("library-detail", "latest", library.slug)
     response = tp.get(url)
     tp.response_200(response)
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_library_detail_caps_a_long_description(library_version, tp):
+    """A long description is capped so the hero cannot grow into the cards below.
+
+    The cap is on the rendered value rather than the model, so the full text is
+    still available to anything else that wants it.
+    """
+    library_version.description = "word " * 200
+    library_version.save()
+    url = tp.reverse("library-detail", "latest", library_version.library.slug)
+
+    response = tp.get(url)
+
+    tp.response_200(response)
+    rendered = response.context["hero_description"]
+    assert len(rendered) <= LIBRARY_DESCRIPTION_MAX_CHARS
+    assert rendered.endswith("\u2026")
+    assert len(library_version.description) > LIBRARY_DESCRIPTION_MAX_CHARS
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_library_detail_leaves_a_short_description_alone(library_version, tp):
+    """Anything already inside the cap passes through without an ellipsis."""
+    library_version.description = "Short and sweet."
+    library_version.save()
+    url = tp.reverse("library-detail", "latest", library_version.library.slug)
+
+    response = tp.get(url)
+
+    assert response.context["hero_description"] == "Short and sweet."
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_library_detail_description_falls_back_to_the_library(library_version, tp):
+    """The version's description wins; the library's is the fallback."""
+    library_version.description = ""
+    library_version.save()
+    library_version.library.description = "From the library record."
+    library_version.library.save()
+    url = tp.reverse("library-detail", "latest", library_version.library.slug)
+
+    response = tp.get(url)
+
+    assert response.context["hero_description"] == "From the library record."
 
 
 def test_library_detail_404(library, old_version, tp):

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -15,6 +15,7 @@ from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
+from django.utils.text import Truncator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import DetailView, ListView, FormView, TemplateView
@@ -63,7 +64,7 @@ from .utils import (
     designed_for_html,
     benchmark_sets,
 )
-from .constants import LATEST_RELEASE_URL_PATH_STR
+from .constants import LATEST_RELEASE_URL_PATH_STR, LIBRARY_DESCRIPTION_MAX_CHARS
 
 logger = structlog.get_logger()
 
@@ -623,6 +624,17 @@ class LibraryDetail(
             context["website_adoc"].get("benchmarks")
         )
         context["slack_url"] = self.object.slack_url or SLACK_JOIN_URL
+
+        # Mirrors the template's old `library_version.description|default:...`,
+        # capped so the hero cannot grow into the cards below it.
+        description = (
+            getattr(library_version, "description", None) or self.object.description
+        )
+        context["hero_description"] = (
+            Truncator(description).chars(LIBRARY_DESCRIPTION_MAX_CHARS)
+            if description
+            else ""
+        )
 
         context["category_tags_v3"] = [
             {"label": cat.name, "url": cat.get_filter_url(version_str)}

--- a/templates/v3/libraries/library-subpage.html
+++ b/templates/v3/libraries/library-subpage.html
@@ -15,9 +15,9 @@
 {% else %}
   {% with cpp_ver=library_version.get_cpp_standard_minimum_display|default:"C++03" %}
       {% if is_flagship_lib %}
-        {% include "v3/includes/_hero_library.html" with title=object.display_name description=library_version.description|default:object.description category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url is_flagship_lib=True hero_image_url_light=library_hero_image_url_light hero_image_url_dark=library_hero_image_url_dark extra_classes="hero--library" fullbleed_fg=True show_branch_buttons=True %}
+        {% include "v3/includes/_hero_library.html" with title=object.display_name description=hero_description category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url is_flagship_lib=True hero_image_url_light=library_hero_image_url_light hero_image_url_dark=library_hero_image_url_dark extra_classes="hero--library" fullbleed_fg=True show_branch_buttons=True %}
       {% else %}
-        {% include "v3/includes/_hero_library.html" with title=object.display_name description=library_version.description|default:object.description category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url show_branch_buttons=True %}
+        {% include "v3/includes/_hero_library.html" with title=object.display_name description=hero_description category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url show_branch_buttons=True %}
       {% endif %}
   {% endwith %}
 


### PR DESCRIPTION
# Issue: #2684

## Summary & Context

Long library descriptions grew the detail-page hero until its actions row sat on top of the cards below it. Adds the 230 character cap the ticket asks for, as a short-term hold while a proper content and layout answer is worked out.

- **Figma link**: none, this is a layout bug rather than a design change
- **Link to components/page:** `/library/master/foreach/`, the worst case in the catalogue at 606 characters

## Changes

- `libraries/constants.py`: `LIBRARY_DESCRIPTION_MAX_CHARS = 230`.
- `libraries/views.py`: `LibraryDetail.get_v3_context_data` builds `hero_description`, mirroring the template's previous `library_version.description|default:object.description` fallback and capping it.
- `templates/v3/libraries/library-subpage.html`: both hero includes now pass `description=hero_description`.
- `libraries/tests/test_views.py`: three tests, one per branch the view decides between.

The cap sits in the view, not in `_hero_library.html`, because that include is shared with the community, release-detail and examples heroes and its doc comment already asks for a short description. Worth knowing for review: the text usually comes from `LibraryVersion.description` rather than `Library.description`, so the cap has to sit downstream of that fallback.

## ‼️ Risks & Considerations ‼️

**The cut lands mid-word and the tail is unrecoverable.** Foreach ends `"...into a predica…"` and loses 376 characters with no "read more" affordance. `Truncator.words` would read better but cannot honour an exact character count, which is what the ticket specifies. Say the word if the number is softer than it reads.

**Only the detail hero is capped.** `_library_item.html` on the library list renders descriptions from the same unbounded fields. It was not in the report and is untouched here.

## Screenshots

Overlap is how far the hero's actions row extended past the top of the first card beneath it.

Width | Before | After
-- | -- | --
1400, the width in the ticket | 37px | **0**
1024 | 65px | **0**

The overlap was worse at 1024 than at the width the ticket captured.

Desktop | Tablet | Mobile
-- | -- | --
<img alt="issue-2684-desktop" src="https://github.com/user-attachments/assets/4aafc1ed-f059-4886-9cd8-a3fceec3c3fa" /> | <img alt="issue-2684-tablet" src="https://github.com/user-attachments/assets/c017736a-493f-47b8-b40e-159b2bd77b77" /> | <img alt="issue-2684-mobile" src="https://github.com/user-attachments/assets/f62e8cb2-7cd7-41f3-8595-48c7f36c4e3b" />

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [ ] UI implementation matches Figma design — no Figma for this ticket
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified — 1440, 1400, 1280, 1024, 768, 390, both themes, no horizontal overflow
- [ ] Accessibility checked (keyboard navigation, etc.) — not done, though nothing interactive changes
- [x] Ensure design tokens are used — no CSS changed
- [x] Test without JavaScript — truncation is server-side, the capped string is in the delivered HTML
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Library detail pages now display descriptions trimmed to a consistent length, with fallback content when needed.
  * Library listings now default to a list layout.

* **Improvements**
  * Author badges are now included more consistently in library listings.
  * Library hero images are no longer displayed on library subpages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->