### PR TITLE
#2688: Author search fixes

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -427,6 +427,19 @@ HAYSTACK_CONNECTIONS = {
     },
 }
 
+# Postgres' stock `english` config makes "Perez" and "Pérez" different lexemes.
+# The unaccenting configs are created in core/migrations 0011 and 0012.
+# Undeclared, the backend passes config=None and Postgres silently falls back
+# to `default_text_search_config`. Wagtail vendors modelsearch under its own
+# app config, which is why the setting is not MODELSEARCH_BACKENDS.
+WAGTAILSEARCH_BACKENDS = {
+    "default": {
+        "BACKEND": "core.search_backends",
+        "SEARCH_CONFIG": "english_unaccent",
+        "AUTOCOMPLETE_SEARCH_CONFIG": "simple_unaccent",
+    }
+}
+
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 AUTHENTICATION_BACKENDS = (

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ import tempfile
 from PIL import Image
 
 from django.core.files import File as DjangoFile
+from django.db import connection
 
 # Include the various pytest fixtures from all of our Django apps tests
 # directories
@@ -17,6 +18,35 @@ pytest_plugins = [
     "users.tests.fixtures",
     "versions.tests.fixtures",
 ]
+
+
+# --no-migrations keeps core/migrations 0011 and 0012 off the test database.
+# Idempotent, because --reuse-db means this re-runs against an existing one.
+SEARCH_CONFIG_SQL = """
+CREATE EXTENSION IF NOT EXISTS unaccent;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_ts_config WHERE cfgname = 'english_unaccent')
+    THEN
+        CREATE TEXT SEARCH CONFIGURATION english_unaccent ( COPY = english );
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_ts_config WHERE cfgname = 'simple_unaccent')
+    THEN
+        CREATE TEXT SEARCH CONFIGURATION simple_unaccent ( COPY = simple );
+    END IF;
+END $$;
+ALTER TEXT SEARCH CONFIGURATION english_unaccent
+  ALTER MAPPING FOR hword, hword_part, word WITH unaccent, english_stem;
+ALTER TEXT SEARCH CONFIGURATION simple_unaccent
+  ALTER MAPPING FOR hword, hword_part, word WITH unaccent, simple;
+"""
+
+
+@pytest.fixture(scope="session")
+def django_db_setup(django_db_setup, django_db_blocker):
+    with django_db_blocker.unblock():
+        with connection.cursor() as cursor:
+            cursor.execute(SEARCH_CONFIG_SQL)
 
 
 @pytest.fixture

--- a/core/migrations/0011_english_unaccent_search_config.py
+++ b/core/migrations/0011_english_unaccent_search_config.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+# `english` with `unaccent` ahead of the stemmer, so "Perez" and "Pérez" reduce
+# to the same lexeme. `unaccent` is a filtering dictionary, so scripts it cannot
+# fold pass through untouched.
+CREATE = """
+CREATE TEXT SEARCH CONFIGURATION english_unaccent ( COPY = english );
+ALTER TEXT SEARCH CONFIGURATION english_unaccent
+  ALTER MAPPING FOR hword, hword_part, word WITH unaccent, english_stem;
+"""
+
+DROP = "DROP TEXT SEARCH CONFIGURATION IF EXISTS english_unaccent;"
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0010_wysiwygimage"),
+        # Installs the `unaccent` extension the configuration below maps to.
+        ("versions", "0012_review_reviewresult"),
+    ]
+
+    operations = [
+        migrations.RunSQL(sql=CREATE, reverse_sql=DROP),
+    ]

--- a/core/migrations/0012_simple_unaccent_search_config.py
+++ b/core/migrations/0012_simple_unaccent_search_config.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+# The autocomplete vector uses `simple` to avoid stemming a partial word down to
+# something it is no longer a prefix of. `simple` does not fold diacritics
+# either, which left "Lope" unable to reach "López" while "Lópe" could.
+CREATE = """
+CREATE TEXT SEARCH CONFIGURATION simple_unaccent ( COPY = simple );
+ALTER TEXT SEARCH CONFIGURATION simple_unaccent
+  ALTER MAPPING FOR hword, hword_part, word WITH unaccent, simple;
+"""
+
+DROP = "DROP TEXT SEARCH CONFIGURATION IF EXISTS simple_unaccent;"
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0011_english_unaccent_search_config"),
+    ]
+
+    operations = [
+        migrations.RunSQL(sql=CREATE, reverse_sql=DROP),
+    ]

--- a/core/search_backends.py
+++ b/core/search_backends.py
@@ -1,0 +1,18 @@
+"""Postgres search backend that unaccents the autocomplete vector too.
+
+The stock backend assigns `simple` in its own `__init__` rather than reading it
+from settings, so subclassing is the only seam.
+"""
+
+from modelsearch.backends.database.postgres.postgres import PostgresSearchBackend
+
+
+class UnaccentedPostgresSearchBackend(PostgresSearchBackend):
+    def __init__(self, params):
+        super().__init__(params)
+        self.autocomplete_config = params.get(
+            "AUTOCOMPLETE_SEARCH_CONFIG", "simple_unaccent"
+        )
+
+
+SearchBackend = UnaccentedPostgresSearchBackend

--- a/pages/models.py
+++ b/pages/models.py
@@ -87,6 +87,8 @@ class PostIndexPage(BasePage):
 
     PAGE_SIZE = 10
     RELATED_POSTS_LIMIT = 3
+    # One or two letters prefix too much of the feed to be worth answering.
+    MIN_PREFIX_SEARCH_LENGTH = 3
 
     def route(self, request, path_components):
         """Act as an umbrella handler for both Wagtail posts and legacy entries.
@@ -161,7 +163,7 @@ class PostIndexPage(BasePage):
         posts = self._filtered_queryset(filters)
         if not filters.q:
             return posts
-        return (
+        searchable = (
             PostPage.objects.filter(pk__in=posts.order_by().values("pk"))
             .select_related("owner")
             .prefetch_related(
@@ -169,8 +171,14 @@ class PostIndexPage(BasePage):
                 active_badges_prefetch("owner__badges"),
                 "owner__profile_routing_keys",
             )
-            .search(filters.q)
         )
+        results = searchable.search(filters.q)
+        if results.count() or len(filters.q) < self.MIN_PREFIX_SEARCH_LENGTH:
+            return results
+        # Full text matches whole stemmed words, so "Rob" misses an author called
+        # Robert. A fallback rather than the primary query, so a term with real
+        # matches keeps full text relevance ranking.
+        return searchable.autocomplete(filters.q)
 
     def _related_posts(self, filters):
         """Fallback shown with the empty state: same library, search dropped.
@@ -564,8 +572,12 @@ class PostPage(BasePage):
             "owner",
             [
                 index.SearchField("display_name"),
+                index.AutocompleteField("display_name"),
             ],
         ),
+        # Prefix matching reads its own vector. Title and author only: prefixes
+        # over body text match far more than a partially typed name should.
+        index.AutocompleteField("title"),
     ]
 
 

--- a/pages/tasks.py
+++ b/pages/tasks.py
@@ -26,9 +26,10 @@ def convert_news_entries_task():
 @shared_task
 def update_index_task():
     """
-    Run the 'update_index' management command as a one-off request.
+    Run the `wagtail_update_index` management command as a one-off request.
 
     Needs to be run after the convert_news_entry task is run in order to ensure wagtail indexing
-    is up to date for searching
+    is up to date for searching. Not `update_index`: haystack takes that name
+    and its command is a no-op that exits successfully.
     """
-    call_command("update_index")
+    call_command("wagtail_update_index")

--- a/pages/tests/test_commands.py
+++ b/pages/tests/test_commands.py
@@ -163,3 +163,20 @@ class TestConvertNewsEntriesCommand:
 
         page = PostPage.objects.get(title=entry.title)
         assert page.image is None
+
+
+class TestUpdateIndexTask:
+    def test_runs_the_wagtail_command(self, mocker):
+        from pages.tasks import update_index_task
+
+        call_command = mocker.patch("pages.tasks.call_command")
+
+        update_index_task()
+
+        call_command.assert_called_once_with("wagtail_update_index")
+
+    def test_update_index_is_haystacks_no_op(self):
+        """Wagtail ships `update_index` as an alias too, but haystack precedes
+        it in INSTALLED_APPS and wins the name, which is why the task above
+        cannot use it."""
+        assert management.get_commands()["update_index"] == "haystack"

--- a/pages/tests/test_posts_feed.py
+++ b/pages/tests/test_posts_feed.py
@@ -100,12 +100,60 @@ class TestSearch:
 
         assert titles(get_feed(tp, feed_url, q="Falco")) == {"Authored Post"}
 
+    @pytest.mark.parametrize("term", ["Rob", "Robe", "Fal", "vinn"])
+    def test_matches_a_partial_author_name(self, tp, feed_url, make_post_page, term):
+        """Full text matches whole stemmed words, so a prefix found nothing."""
+        author = baker.make("users.User", display_name="Robert Vinnie Falco")
+        make_post_page(title="Authored Post", owner=author)
+        make_post_page(title="Orphan Post")
+
+        assert titles(get_feed(tp, feed_url, q=term)) == {"Authored Post"}
+
+    def test_matches_a_partial_title(self, tp, feed_url, make_post_page):
+        make_post_page(title="Boost.SQLite proposal results")
+        make_post_page(title="Something else entirely")
+
+        assert titles(get_feed(tp, feed_url, q="propos")) == {
+            "Boost.SQLite proposal results"
+        }
+
+    def test_prefers_whole_word_matches_over_prefixes(
+        self, tp, feed_url, make_post_page
+    ):
+        """The prefix pass is a fallback, so whole-word matches are not widened."""
+        falco = baker.make("users.User", display_name="Vinnie Falco")
+        falconer = baker.make("users.User", display_name="Ada Falconer")
+        make_post_page(title="Falco Post", owner=falco)
+        make_post_page(title="Falconer Post", owner=falconer)
+
+        assert titles(get_feed(tp, feed_url, q="Falco")) == {"Falco Post"}
+
+    @pytest.mark.parametrize("term", ["p", "ab"])
+    def test_does_not_run_the_prefix_pass_for_very_short_terms(
+        self, tp, feed_url, make_post_page, term
+    ):
+        """One or two letters prefix most of the feed."""
+        make_post_page(title="Post About Absolutely Everything")
+
+        assert titles(get_feed(tp, feed_url, q=term)) == set()
+
     @pytest.mark.parametrize("term", ["Perez", "Pérez", "perez", "PEREZ"])
     def test_matches_an_accented_author_name_either_spelling(
         self, tp, feed_url, make_post_page, term
     ):
         """Stock `english` makes "perez" and "pérez" different lexemes."""
         author = baker.make("users.User", display_name="Rubén Pérez")
+        make_post_page(title="Authored Post", owner=author)
+        make_post_page(title="Orphan Post")
+
+        assert titles(get_feed(tp, feed_url, q=term)) == {"Authored Post"}
+
+    @pytest.mark.parametrize("term", ["Lope", "Lópe", "Muno", "Muñ"])
+    def test_matches_a_partial_accented_author_name_either_spelling(
+        self, tp, feed_url, make_post_page, term
+    ):
+        """The prefix vector unaccents too, so "Lope" reaches "López"."""
+        author = baker.make("users.User", display_name="Joaquín M López Muñoz")
         make_post_page(title="Authored Post", owner=author)
         make_post_page(title="Orphan Post")
 

--- a/pages/tests/test_posts_feed.py
+++ b/pages/tests/test_posts_feed.py
@@ -100,6 +100,31 @@ class TestSearch:
 
         assert titles(get_feed(tp, feed_url, q="Falco")) == {"Authored Post"}
 
+    @pytest.mark.parametrize("term", ["Perez", "Pérez", "perez", "PEREZ"])
+    def test_matches_an_accented_author_name_either_spelling(
+        self, tp, feed_url, make_post_page, term
+    ):
+        """Stock `english` makes "perez" and "pérez" different lexemes."""
+        author = baker.make("users.User", display_name="Rubén Pérez")
+        make_post_page(title="Authored Post", owner=author)
+        make_post_page(title="Orphan Post")
+
+        assert titles(get_feed(tp, feed_url, q=term)) == {"Authored Post"}
+
+    def test_leaves_non_latin_scripts_alone(self, tp, feed_url, make_post_page):
+        """`unaccent` passes through what it cannot fold."""
+        author = baker.make("users.User", display_name="Ольга Иванова")
+        make_post_page(title="Cyrillic Post", owner=author)
+
+        assert titles(get_feed(tp, feed_url, q="Ольга")) == {"Cyrillic Post"}
+
+    def test_returns_nothing_for_a_term_that_matches_neither_way(
+        self, tp, feed_url, make_post_page
+    ):
+        make_post_page(title="A Post", body="asio networking")
+
+        assert titles(get_feed(tp, feed_url, q="xylophone")) == set()
+
     @pytest.mark.parametrize("term", ["beast", "Beast"])
     def test_matches_library_tag(self, tp, feed_url, make_post_page, term):
         make_post_page(title="Tagged Post", tags=[("beast", "Beast")])

--- a/pages/tests/test_search_indexing.py
+++ b/pages/tests/test_search_indexing.py
@@ -5,6 +5,7 @@ from model_bakery import baker
 from wagtail.search.models import IndexEntry
 
 from pages.models import PostPage
+from users.models import User
 
 pytestmark = pytest.mark.django_db
 
@@ -104,3 +105,51 @@ class TestSearchConfig:
 
         assert backend.config == "english_unaccent"
         assert backend.autocomplete_config == "simple_unaccent"
+
+
+class TestReindexOnRename:
+    """Each page's index entry holds a copy of its author's name."""
+
+    def test_a_renamed_author_is_findable_by_the_new_name(
+        self, make_post_page, django_capture_on_commit_callbacks
+    ):
+        author = baker.make("users.User", display_name="Vinnie Falco")
+        page = make_post_page(title="Authored Post", owner=author)
+
+        with django_capture_on_commit_callbacks(execute=True):
+            author.display_name = "Vinnie Zulawski"
+            author.save()
+
+        body = index_entry_for(page).body
+
+        assert "zulawski" in body
+        assert "falco" not in body
+
+    def test_a_rename_on_a_reloaded_user_is_spotted_too(
+        self, make_post_page, django_capture_on_commit_callbacks
+    ):
+        """The usual path: a request loads the user, edits and saves it."""
+        author = baker.make("users.User", display_name="Vinnie Falco")
+        page = make_post_page(title="Authored Post", owner=author)
+
+        reloaded = User.objects.get(pk=author.pk)
+        with django_capture_on_commit_callbacks(execute=True):
+            reloaded.display_name = "Vinnie Zulawski"
+            reloaded.save()
+
+        assert "zulawski" in index_entry_for(page).body
+
+    def test_saving_without_a_rename_does_not_reindex(
+        self, make_post_page, django_capture_on_commit_callbacks, mocker
+    ):
+        """Otherwise every profile save rewrites all of that author's entries."""
+        author = baker.make("users.User", display_name="Vinnie Falco")
+        make_post_page(title="Authored Post", owner=author)
+        reindex = mocker.patch("users.tasks.reindex_user_pages.delay")
+
+        reloaded = User.objects.get(pk=author.pk)
+        with django_capture_on_commit_callbacks(execute=True):
+            reloaded.tagline = "Now with a tagline"
+            reloaded.save()
+
+        reindex.assert_not_called()

--- a/pages/tests/test_search_indexing.py
+++ b/pages/tests/test_search_indexing.py
@@ -70,3 +70,24 @@ class TestIndexEntry:
 
         assert "beast" in body
         assert "falco" in body
+
+
+class TestSearchConfig:
+    def test_folds_accents_into_the_indexed_lexemes(self, make_post_page):
+        """The config applies at index time, so the stored vector proves it."""
+        author = baker.make("users.User", display_name="Rubén Pérez")
+        page = make_post_page(owner=author)
+
+        body = index_entry_for(page).body
+
+        assert "perez" in body
+        assert "ruben" in body
+
+    def test_backend_is_configured_for_unaccented_search(self):
+        """Both vectors, not just the full text one."""
+        from modelsearch.backends import get_search_backend
+
+        backend = get_search_backend()
+
+        assert backend.config == "english_unaccent"
+        assert backend.autocomplete_config == "simple_unaccent"

--- a/pages/tests/test_search_indexing.py
+++ b/pages/tests/test_search_indexing.py
@@ -35,6 +35,19 @@ class TestSearchFields:
         assert ("RelatedFields", "tags") in declared
         assert ("RelatedFields", "owner") in declared
 
+    def test_indexes_an_autocomplete_surface(self):
+        """Prefix matching reads a separate vector from SearchField."""
+        declared = {(type(f).__name__, f.field_name) for f in PostPage.search_fields}
+        owner = next(
+            f
+            for f in PostPage.search_fields
+            if type(f).__name__ == "RelatedFields" and f.field_name == "owner"
+        )
+        owner_fields = {(type(f).__name__, f.field_name) for f in owner.fields}
+
+        assert ("AutocompleteField", "title") in declared
+        assert ("AutocompleteField", "display_name") in owner_fields
+
 
 class TestSearchBody:
     def test_strips_markup(self, make_post_page):

--- a/users/models.py
+++ b/users/models.py
@@ -351,6 +351,10 @@ class User(BaseUser):
     TAGLINE_MAX_LENGTH = 70
     BIOGRAPHY_MAX_LENGTH = 20000
 
+    # A row loaded without display_name (.only()/.defer()), which the rename
+    # receiver cannot compare against.
+    DISPLAY_NAME_UNKNOWN = object()
+
     # todo: consider making this unique=True after checking user data for duplicates
     github_username = models.CharField(_("github username"), max_length=100, blank=True)
     is_commit_author_name_overridden = models.BooleanField(
@@ -555,6 +559,18 @@ class User(BaseUser):
     def delete_cached_hq_render(self):
         """Delete the cached full-size render of the high-quality image."""
         self._delete_cached_spec("hq_image", "hq_image_render")
+
+    @classmethod
+    def from_db(cls, db, field_names, values):
+        instance = super().from_db(db, field_names, values)
+        # Lets users.signals.reindex_pages_on_display_name_change spot a rename
+        # without re-reading the row.
+        instance._loaded_display_name = (
+            instance.display_name
+            if "display_name" in field_names
+            else cls.DISPLAY_NAME_UNKNOWN
+        )
+        return instance
 
     def save_image_from_provider(self, avatar_url):
         from django.core.files.base import ContentFile

--- a/users/signals.py
+++ b/users/signals.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_delete, post_save
 from allauth.socialaccount.models import SocialAccount
 
 from users.constants import LOGIN_METHOD_SESSION_FIELD_NAME
-from users.models import UserProfileRoutingKey
+from users.models import User, UserProfileRoutingKey
 
 GITHUB = "github"
 GOOGLE = "google"
@@ -87,3 +87,26 @@ def user_logged_in_handler(request, user, **kwargs):
 
     if not user.data.get("ml_post_auth_seen"):
         request.session["show_ml_post_auth_modal"] = True
+
+
+@receiver(post_save, sender=User)
+def reindex_pages_on_display_name_change(sender, instance, created, **kwargs):
+    """Keep a renamed author findable by their new name.
+
+    Each page's index entry holds a copy of its author's name, so renaming the
+    user leaves every one of their posts matching only the old one.
+    """
+    if created:
+        # No pages yet, but this makes a later rename of the same instance
+        # comparable.
+        instance._loaded_display_name = instance.display_name
+        return
+    previous = getattr(instance, "_loaded_display_name", User.DISPLAY_NAME_UNKNOWN)
+    if previous is User.DISPLAY_NAME_UNKNOWN or previous == instance.display_name:
+        return
+    instance._loaded_display_name = instance.display_name
+
+    from . import tasks
+
+    user_pk = instance.pk
+    transaction.on_commit(lambda: tasks.reindex_user_pages.delay(user_pk))

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -326,3 +326,22 @@ def recompute_displayed_profile_roles():
         resolved=len(top),
         cleared_choices=cleared_choices,
     )
+
+
+@shared_task
+def reindex_user_pages(user_id):
+    """Refresh the index entries that embed a user's display name.
+
+    Related-field text is copied into each page's own entry at index time, and
+    nothing reindexes those pages when the user changes.
+    """
+    from modelsearch import index as search_index
+
+    from pages.models import PostPage
+
+    reindexed = 0
+    for page in PostPage.objects.filter(owner_id=user_id).iterator():
+        search_index.insert_or_update_object(page)
+        reindexed += 1
+
+    logger.info("reindex_user_pages finished", user_id=user_id, pages=reindexed)


### PR DESCRIPTION
# Issue: #2688

## Summary & Context

Searching the posts feed by an author's name returned nothing. Three separate causes, all presenting the same way.

The feed's search code was correct all along: `PostPage.search_fields` declares the owner as a related search field and `PostIndexPage._results` reaches `.search(q)` properly. What failed was the index behind it, and two gaps in how terms are matched.

Reproduced locally by rebuilding the index the way an index built before the owner field looks: titles keep matching, author matches drop to zero, which is the exact empty state in the issue.

## Changes

- The admin button executed `update_index`, now it calls `wagtail_update_index`. 
- Accented names only matched one spelling: Postgres' stock `english` config indexes "Perez" and "Pérez" as different lexemes. We added **english_unaccent** (migration 0011) and **simple_unaccent** (migration 0012)
- Partially typed names matched nothing (eg: Rob vs Robert): now we add `AutocompleteField` for the title and the author's display name and  `.autocomplete()` runs as a fallback (minimum of 3 characters).
- A renamed author kept matching their old name, now we have a post_save receiver to call the `reindex_user_pages`.

## Peer-Testing Guidelines

Run Update Index from the admin, wait a couple of minutes and try the search again:
<img width="1295" height="850" alt="SCR-20260902-mitf" src="https://github.com/user-attachments/assets/d9b40171-1ff7-41db-a9b4-c9804a341c01" />

## Cases
<img width="1298" height="720" alt="SCR-20260902-mipi" src="https://github.com/user-attachments/assets/a5bbf233-0b33-48a9-bc00-861dbef2912e" />
<img width="1290" height="651" alt="SCR-20260902-mhwd" src="https://github.com/user-attachments/assets/9e3c8241-75aa-4b1b-82da-90378add90bd" />
<img width="1282" height="658" alt="SCR-20260902-mjnc" src="https://github.com/user-attachments/assets/c6e9f62c-388b-4392-8abf-89ed469a087f" />


## Self-review Checklist
- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Backend
- [x] Full suite green (2502 passed; two failures pre-exist on develop in this environment and are unrelated)
- [x] `pre-commit run -a` clean
- [x] No new pending migrations introduced by this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search now supports accent-insensitive matching, including partial author and title searches.
  - Autocomplete provides improved results for longer queries and supports author names and post titles.
  - Updated author display names are reflected in post search results automatically.

- **Bug Fixes**
  - Search indexing now uses the correct Wagtail indexing command, ensuring content updates are processed reliably.

- **Tests**
  - Added coverage for accented text, partial matches, short queries, non-Latin names, and reindexing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->