### PR TITLE
Issue #2721 :: fix: offer only tagged libraries in the posts feed filter

### DIFF
--- a/libraries/utils.py
+++ b/libraries/utils.py
@@ -788,15 +788,29 @@ def group_libraries_by_tier(
 def library_filter_options() -> list[tuple[str, str]]:
     """(slug, label) pairs for the library filter dropdowns.
 
+    Only libraries carried by a live post are offered. The dropdown exists to
+    narrow the feed, and a library no post is tagged with can only narrow it to
+    nothing, so listing every library buries the handful that lead somewhere.
+
+    Posts reach a library through a `ContentTag` whose slug mirrors the library
+    slug rather than through a relation, so the tagged slugs come back as a
+    subquery instead of a join.
+
     Labelled with display_name so the dropdown matches the wording used in
     feed headers ("Boost.Beast" rather than "Beast").
     """
 
     from libraries.models import Library
+    from pages.mixins import TaggedContent
+
+    tagged_slugs = TaggedContent.objects.filter(content_object__live=True).values(
+        "tag__slug"
+    )
 
     return [
         (library.slug, library.display_name)
         for library in Library.objects.exclude(slug="")
         .exclude(slug__isnull=True)
+        .filter(slug__in=tagged_slugs)
         .order_by("name")
     ]

--- a/pages/tests/test_posts_feed.py
+++ b/pages/tests/test_posts_feed.py
@@ -252,6 +252,66 @@ class TestFilters:
         assert response.context["header_text"] == "Latest Posts"
 
 
+class TestLibraryFilterOptions:
+    """The dropdown offers only libraries a live post is tagged with.
+
+    Every other library narrows the feed to nothing and nothing else, so
+    listing them all buries the handful that lead somewhere.
+    """
+
+    @staticmethod
+    def options(response):
+        return response.context["library_options"]
+
+    def test_offers_a_tagged_library(self, tp, feed_url, make_post_page, beast):
+        make_post_page(title="Tagged Post", tags=[("beast", "Beast")])
+
+        assert self.options(get_feed(tp, feed_url)) == [("beast", "Boost.Beast")]
+
+    def test_omits_an_untagged_library(self, tp, feed_url, make_post_page, beast):
+        make_post_page(title="Untagged Post")
+
+        assert self.options(get_feed(tp, feed_url)) == []
+
+    def test_omits_a_library_tagged_only_on_a_draft(
+        self, tp, feed_url, make_post_page, beast
+    ):
+        """A draft is not in the feed, so filtering by its library would come
+        back empty."""
+        make_post_page(title="Draft Post", tags=[("beast", "Beast")], live=False)
+
+        assert self.options(get_feed(tp, feed_url)) == []
+
+    def test_lists_a_library_once_however_many_posts_carry_it(
+        self, tp, feed_url, make_post_page, beast
+    ):
+        """The tagged slugs arrive as a subquery over one row per post/tag
+        pair, which duplicates the library without the IN."""
+        make_post_page(title="First Post", tags=[("beast", "Beast")])
+        make_post_page(title="Second Post", tags=[("beast", "Beast")])
+
+        assert self.options(get_feed(tp, feed_url)) == [("beast", "Boost.Beast")]
+
+    def test_orders_by_name(self, tp, feed_url, make_post_page):
+        baker.make("libraries.Library", name="Beast", slug="beast")
+        baker.make("libraries.Library", name="Asio", slug="asio")
+        make_post_page(
+            title="Tagged Twice", tags=[("beast", "Beast"), ("asio", "Asio")]
+        )
+
+        assert [slug for slug, _ in self.options(get_feed(tp, feed_url))] == [
+            "asio",
+            "beast",
+        ]
+
+    def test_omits_a_tag_no_library_answers_to(self, tp, feed_url, make_post_page):
+        """Posts reach a library by matching slugs rather than by a relation,
+        so a tag with no library behind it must not reach the dropdown."""
+        make_post_page(title="Oddly Tagged", tags=[("not-a-library", "Not A Library")])
+
+        assert self.options(get_feed(tp, feed_url)) == []
+
+
 class TestFilterCombinations:
     """The search backend rejects StreamField lookups with an AttributeError
     and tag lookups with a FilterFieldError, so each combination of a search
@@ -438,10 +498,16 @@ class TestUrlDrivenState:
         assert "checked" in radio_tag(content, "news")
         assert "checked" not in radio_tag(content, "video")
 
-    def test_library_option_is_selected(self, tp, feed_url, beast):
-        """Every library gets an <option>, and the word "selected" appears in
-        the dropdown's Alpine bindings either way, so both halves of the
-        control have to be checked against the value itself."""
+    def test_library_option_is_selected(self, tp, feed_url, make_post_page, beast):
+        """The word "selected" appears in the dropdown's Alpine bindings
+        whether or not anything is chosen, so both halves of the control have
+        to be checked against the value itself.
+
+        The post is what puts Boost.Beast in the dropdown at all: only
+        libraries a live post carries are offered.
+        """
+        make_post_page(title="Tagged Post", tags=[("beast", "Beast")])
+
         content = get_feed(tp, feed_url, library="beast").content.decode()
 
         assert 'value="beast" selected' in content


### PR DESCRIPTION
# Issue: #2721

## Summary & Context

The posts feed's Library dropdown listed all 185 Boost libraries, so nearly every option narrowed the feed to nothing. It now offers only libraries a live post is tagged with (43 on a production mirror).

- **Link to components/page:** [http://localhost:8000/news/](http://localhost:8000/news/)

## Changes

- `library_filter_options()` returns only libraries carried by a live `PostPage`. Posts reach a library by matching slugs rather than a relation, so the tagged slugs come back as a subquery.
- Added `TestLibraryFilterOptions`; updated `test_library_option_is_selected`, which selected a library no post carried.

## ‼️ Risks & Considerations ‼️

- Where no post carries a library the dropdown is empty. Correct, but a visible change from the always-full list.
- Unresolvable filter values still fall back to the unfiltered feed, unchanged and still tested.

## Screenshots
Before: 
<img width="1718" height="994" alt="image" src="https://github.com/user-attachments/assets/fa3e4b92-bd2d-490d-981d-40018eb10603" />

After:
<img width="1524" height="1130" alt="image" src="https://github.com/user-attachments/assets/18624be0-606d-4e03-a5e8-2f0bc3c3ea3b" />

## Peer-review testing steps

0. Create some new posts and tag them with related libraries;
1. With posts tagged with libraries and the `v3` flag on, open `/news/` and the Library dropdown: only libraries some post carries are listed.
2. Every option returns at least one post; none lands on the empty state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Library filter dropdowns now show only libraries associated with live content.
  * Options are alphabetized and exclude empty, duplicate, draft-only, untagged, or unresolved libraries.

* **Tests**
  * Added coverage for library filtering, ordering, deduplication, and content visibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->