### PR TITLE
Issue #2651 :: Order library contributions in users' bios alphabetically, flagships first

### DIFF
--- a/static/css/v3/user-profile-bio-card.css
+++ b/static/css/v3/user-profile-bio-card.css
@@ -1,3 +1,15 @@
+.bio-card__contributions {
+    margin: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    list-style: none;
+}
+
+.bio-card__contribution {
+    position: relative;
+    width: 100%;
+}
+
 .bio-card__contributor_role {
     color: var(--color-text-primary);
     font-family: var(--font-sans);
@@ -8,10 +20,67 @@
 }
 
 .bio-card__contributor_libraries {
+    margin: 0;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    line-clamp: 3;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
     color: var(--color-text-secondary);
     font-family: var(--font-sans);
     font-size: var(--font-size-small);
     font-weight: var(--font-weight-regular);
     line-height: var(--line-height-relaxed);
     letter-spacing: var(--letter-spacing-tight);
+}
+
+.bio-card__expand_input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.bio-card__expand_input:checked ~ .bio-card__contributor_libraries {
+    display: block;
+    overflow: visible;
+    line-clamp: none;
+    -webkit-line-clamp: none;
+}
+
+.bio-card__expand_label {
+    display: inline-block;
+    margin-top: var(--space-s);
+    color: var(--color-text-primary);
+    font-family: var(--font-sans);
+    font-size: var(--font-size-small);
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-relaxed);
+    letter-spacing: var(--letter-spacing-tight);
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.bio-card__expand_input:focus-visible ~ .bio-card__expand_label {
+    outline: 2px solid var(--color-stroke-link-accent);
+    outline-offset: 2px;
+    border-radius: var(--border-radius-xs);
+}
+
+.bio-card__expand_label_less,
+.bio-card__expand_input:checked
+    ~ .bio-card__expand_label
+    .bio-card__expand_label_more {
+    display: none;
+}
+
+.bio-card__expand_input:checked
+    ~ .bio-card__expand_label
+    .bio-card__expand_label_less {
+    display: inline;
 }

--- a/static/css/v3/user-profile-bio-card.css
+++ b/static/css/v3/user-profile-bio-card.css
@@ -46,7 +46,8 @@
     border: 0;
 }
 
-.bio-card__expand_input:checked ~ .bio-card__contributor_libraries {
+.bio-card__expand_input:checked ~ .bio-card__contributor_libraries,
+.bio-card__contributor_libraries--unclamped {
     display: block;
     overflow: visible;
     line-clamp: none;

--- a/templates/v3/includes/_user_profile_bio_card.html
+++ b/templates/v3/includes/_user_profile_bio_card.html
@@ -5,8 +5,9 @@
         title:              str, required   - text that appears bolded at the top of the card
         contributor_data:   dict, required  - a dict of contributions and libraries (i.e. {"author": "beast", "asyncio"})
                                               Each role's library list clamps to 3 lines behind a "See more" toggle.
-                                              The toggle is a hidden checkbox, so expanding works with JavaScript off;
-                                              Alpine only hides the toggle for a list that already fits.
+                                              The toggle is a hidden checkbox, so expanding works with JavaScript off.
+                                              It starts hidden and Alpine reveals it only for a list that overflows,
+                                              so a list that already fits never shows one (issue #2651).
         markdown:           str, optional   - markdown formatted text that appears in the body of the card. The card handles transforming the text. When empty, an empty state is shown instead.
         button_url:         str, optional   - url that the button should link to. If not provided, button is not shown
         button_label:       str, optional   - label for the optional cta button. If not provided, button is not shown.
@@ -20,7 +21,7 @@
     <ul class="card__column bio-card__contributions px-large">
       {% for role, libraries in contributor_data.items %}
         <li class="bio-card__contribution"
-            x-data="{ overflowing: true, measure() { const l = this.$refs.libraries; if (!this.$refs.expand.checked) this.overflowing = l.scrollHeight > l.clientHeight + 1 } }"
+            x-data="{ overflowing: false, measure() { const l = this.$refs.libraries; if (!this.$refs.expand.checked) this.overflowing = l.scrollHeight > l.clientHeight + 1 } }"
             x-init="$nextTick(() => measure())"
             @resize.window.debounce="measure()">
           <input type="checkbox"
@@ -32,13 +33,23 @@
           <p class="bio-card__contributor_libraries" x-ref="libraries">{{ libraries|join:', ' }}</p>
           <label class="bio-card__expand_label"
                  for="bio-card-contribution-{{ forloop.counter }}"
-                 x-show="overflowing">
+                 x-show="overflowing"
+                 x-cloak>
             <span class="bio-card__expand_label_more">See more</span>
             <span class="bio-card__expand_label_less">See less</span>
           </label>
         </li>
       {% endfor %}
     </ul>
+    {% comment %} No-JS fallback: the toggle is hidden until Alpine measures the
+    list, so without JS nothing would ever reveal it and a clamped list would be
+    unreachable. Show every toggle instead: expanding a list that already fits is
+    a no-op, and a clamped one stays openable. {% endcomment %}
+    <noscript>
+      <style>
+        .bio-card__expand_label[x-cloak] { display: inline-block !important; }
+      </style>
+    </noscript>
     <hr class="card__hr" />
   {% endif %}
   {% if markdown %}

--- a/templates/v3/includes/_user_profile_bio_card.html
+++ b/templates/v3/includes/_user_profile_bio_card.html
@@ -20,7 +20,7 @@
     <ul class="card__column bio-card__contributions px-large">
       {% for role, libraries in contributor_data.items %}
         <li class="bio-card__contribution"
-            x-data="{ overflowing: true, measure() { const l = $refs.libraries; if (!$refs.expand.checked) this.overflowing = l.scrollHeight > l.clientHeight + 1 } }"
+            x-data="{ overflowing: true, measure() { const l = this.$refs.libraries; if (!this.$refs.expand.checked) this.overflowing = l.scrollHeight > l.clientHeight + 1 } }"
             x-init="$nextTick(() => measure())"
             @resize.window.debounce="measure()">
           <input type="checkbox"

--- a/templates/v3/includes/_user_profile_bio_card.html
+++ b/templates/v3/includes/_user_profile_bio_card.html
@@ -4,6 +4,9 @@
     Inputs:
         title:              str, required   - text that appears bolded at the top of the card
         contributor_data:   dict, required  - a dict of contributions and libraries (i.e. {"author": "beast", "asyncio"})
+                                              Each role's library list clamps to 3 lines behind a "See more" toggle.
+                                              The toggle is a hidden checkbox, so expanding works with JavaScript off;
+                                              Alpine only hides the toggle for a list that already fits.
         markdown:           str, optional   - markdown formatted text that appears in the body of the card. The card handles transforming the text. When empty, an empty state is shown instead.
         button_url:         str, optional   - url that the button should link to. If not provided, button is not shown
         button_label:       str, optional   - label for the optional cta button. If not provided, button is not shown.
@@ -14,14 +17,28 @@
   </div>
   <hr class="card__hr" />
   {% if contributor_data %}
-    <div class="card__column px-large">
-    {% for role, libraries in contributor_data.items %}
-        <div>
-            <div class="bio-card__contributor_role">{{ role }}</div>
-            <div class="bio-card__contributor_libraries">{{ libraries|join:', ' }}</div>
-        </div>
-    {% endfor %}
-    </div>
+    <ul class="card__column bio-card__contributions px-large">
+      {% for role, libraries in contributor_data.items %}
+        <li class="bio-card__contribution"
+            x-data="{ overflowing: true, measure() { const l = $refs.libraries; if (!$refs.expand.checked) this.overflowing = l.scrollHeight > l.clientHeight + 1 } }"
+            x-init="$nextTick(() => measure())"
+            @resize.window.debounce="measure()">
+          <input type="checkbox"
+                 id="bio-card-contribution-{{ forloop.counter }}"
+                 class="bio-card__expand_input"
+                 x-ref="expand"
+                 aria-label="Show every {{ role }} library">
+          <span class="bio-card__contributor_role">{{ role }}</span>
+          <p class="bio-card__contributor_libraries" x-ref="libraries">{{ libraries|join:', ' }}</p>
+          <label class="bio-card__expand_label"
+                 for="bio-card-contribution-{{ forloop.counter }}"
+                 x-show="overflowing">
+            <span class="bio-card__expand_label_more">See more</span>
+            <span class="bio-card__expand_label_less">See less</span>
+          </label>
+        </li>
+      {% endfor %}
+    </ul>
     <hr class="card__hr" />
   {% endif %}
   {% if markdown %}

--- a/templates/v3/includes/_user_profile_bio_card.html
+++ b/templates/v3/includes/_user_profile_bio_card.html
@@ -7,7 +7,9 @@
                                               Each role's library list clamps to 3 lines behind a "See more" toggle.
                                               The toggle is a hidden checkbox, so expanding works with JavaScript off.
                                               It starts hidden and Alpine reveals it only for a list that overflows,
-                                              so a list that already fits never shows one (issue #2651).
+                                              so a list that already fits never shows one (issue #2651). Overflow is
+                                              measured by unclamping the list for one synchronous read: a clamped box
+                                              drops the hidden lines from layout, so its scrollHeight does not report them.
         markdown:           str, optional   - markdown formatted text that appears in the body of the card. The card handles transforming the text. When empty, an empty state is shown instead.
         button_url:         str, optional   - url that the button should link to. If not provided, button is not shown
         button_label:       str, optional   - label for the optional cta button. If not provided, button is not shown.
@@ -21,8 +23,8 @@
     <ul class="card__column bio-card__contributions px-large">
       {% for role, libraries in contributor_data.items %}
         <li class="bio-card__contribution"
-            x-data="{ overflowing: false, measure() { const l = this.$refs.libraries; if (!this.$refs.expand.checked) this.overflowing = l.scrollHeight > l.clientHeight + 1 } }"
-            x-init="$nextTick(() => measure())"
+            x-data="{ overflowing: false, measure() { const l = this.$refs.libraries; if (this.$refs.expand.checked) return; const clamped = l.clientHeight; l.classList.add('bio-card__contributor_libraries--unclamped'); const full = l.clientHeight; l.classList.remove('bio-card__contributor_libraries--unclamped'); this.overflowing = full > clamped } }"
+            x-init="$nextTick(() => measure()); document.fonts.ready.then(() => measure())"
             @resize.window.debounce="measure()">
           <input type="checkbox"
                  id="bio-card-contribution-{{ forloop.counter }}"

--- a/users/models.py
+++ b/users/models.py
@@ -877,19 +877,41 @@ class User(BaseUser):
         empty dict means no contributions at all. Backed by the same source of
         truth as the edit-page role dropdown (`get_role_library_options`).
 
+        Within a role the libraries read flagship-first, then alphabetically.
+        That is deliberately not the dropdown's order, which ranks by commit
+        count to put the user's likeliest self-description at the top: this list
+        is read as a catalogue, so a stable name order matters more than
+        prominence. Untiered libraries sort with the non-flagships.
+
         Cached per user. The underlying roles only change on library imports,
         which drop the entry via `recompute_displayed_profile_roles`; the TTL is
         a safety net. An empty dict is a real cached value (distinct from a
         cache miss, which returns None).
         """
+        from libraries.models import Tier
+
         cache_key = contributor_data_cache_key(self.pk)
         cached = cache.get(cache_key)
         if cached is not None:
             return cached
-        data = {}
+        grouped = {}
         for option in self.get_role_library_options():
             label = ProfileRole(option["role"]).label
-            data.setdefault(label, []).append(option["library"].display_name_short)
+            grouped.setdefault(label, []).append(option["library"])
+
+        def sort_key(library):
+            return (
+                library.tier != Tier.FLAGSHIP,
+                library.display_name_short.casefold(),
+            )
+
+        data = {
+            label: [
+                library.display_name_short
+                for library in sorted(libraries, key=sort_key)
+            ]
+            for label, libraries in grouped.items()
+        }
         cache.set(cache_key, data, settings.CONTRIBUTOR_DATA_CACHE_TIMEOUT)
         return data
 

--- a/users/models.py
+++ b/users/models.py
@@ -287,7 +287,11 @@ NO_PUBLIC_ROLE_LABEL = (
     "No Public Role - Your role won't be linked to your name elsewhere on the site."
 )
 
-CONTRIBUTOR_DATA_CACHE_PREFIX = "contributor_data_"
+# Bump this suffix whenever get_contributor_data's output shape or ordering
+# changes. The cache is only invalidated by a library import, so an
+# old-shaped entry would otherwise keep serving a stale order for the full
+# TTL after every deploy.
+CONTRIBUTOR_DATA_CACHE_PREFIX = "contributor_data_v2_"
 
 
 def contributor_data_cache_key(user_id):

--- a/users/tests/test_profile_role.py
+++ b/users/tests/test_profile_role.py
@@ -169,13 +169,26 @@ def test_contributor_data_groups_by_role_and_omits_empty(user, library, other_li
     assert data["Maintainer"] == ["Math"]
 
 
-def test_contributor_data_lists_libraries_by_commit_count(user, library, other_library):
+def test_contributor_data_lists_libraries_alphabetically(user, library, other_library):
     library.authors.add(user)
     other_library.authors.add(user)
+    # Commit counts order the edit-page dropdown, not the bio card: the busier
+    # library still sorts by name here.
     _add_commits(user, other_library, 5)
     _add_commits(user, library, 1)
-    # Busier library ranks first within the role group.
-    assert user.get_contributor_data()["Author"] == ["Math", "Beast"]
+    assert user.get_contributor_data()["Author"] == ["Beast", "Math"]
+
+
+def test_contributor_data_lists_flagship_libraries_first(user, library, other_library):
+    from libraries.models import Tier
+
+    # Math is a flagship, so it precedes Beast despite sorting after it.
+    other_library.tier = Tier.FLAGSHIP
+    other_library.save()
+    untiered = baker.make("libraries.Library", name="Asio", tier=None)
+    for lib in (library, other_library, untiered):
+        lib.authors.add(user)
+    assert user.get_contributor_data()["Author"] == ["Math", "Asio", "Beast"]
 
 
 def test_contributor_data_served_from_cache(user, library, other_library):

--- a/users/tests/test_profile_role.py
+++ b/users/tests/test_profile_role.py
@@ -191,6 +191,36 @@ def test_contributor_data_lists_flagship_libraries_first(user, library, other_li
     assert user.get_contributor_data()["Author"] == ["Math", "Asio", "Beast"]
 
 
+def test_contributor_data_lists_contributor_libraries_alphabetically(
+    user, library, other_library
+):
+    """The Contributor group is sorted the same way as Author (issue #2651).
+
+    Contributor is derived from commit counts rather than an explicit role
+    link, so it exercises a different code path in _role_library_pairs than
+    the alphabetical-order tests above.
+    """
+    from libraries.models import Tier
+
+    zlib = baker.make("libraries.Library", name="Zlib")
+    asio = baker.make("libraries.Library", name="Asio")
+    math = baker.make("libraries.Library", name="Math", tier=Tier.FLAGSHIP)
+    _add_commits(user, zlib, 3)
+    _add_commits(user, asio, 5)  # most active library must not lead the list
+    _add_commits(user, math, 1)
+    assert user.get_contributor_data()["Contributor"] == ["Math", "Asio", "Zlib"]
+
+
+def test_contributor_data_cache_key_is_versioned():
+    """The cache key must change whenever get_contributor_data's shape or
+    ordering does, or a still-warm entry from before the change keeps
+    serving its old order until the next library import (issue #2651).
+    """
+    from users.models import CONTRIBUTOR_DATA_CACHE_PREFIX
+
+    assert CONTRIBUTOR_DATA_CACHE_PREFIX != "contributor_data_"
+
+
 def test_contributor_data_served_from_cache(user, library, other_library):
     library.authors.add(user)
     assert user.get_contributor_data() == {"Author": ["Beast"]}  # now cached


### PR DESCRIPTION
# Issue: #2651

**Branch:** `teo/2651-order-library-contributions-alphabetically` · **Base:** `origin/develop`

## Summary & Context

The profile bio card now lists each contribution type's libraries flagship-first, then alphabetically, and clamps a list longer than 3 rendered lines behind a "See more" toggle. The dropdown on the edit page keeps its commit-count ordering on purpose: it ranks the role a user is most likely to pick, while the bio card is read as a catalogue, so only `get_contributor_data` changed.

- **Figma link**: n/a - the ticket states there is no design for the truncation
- **Link to components/page:** [http://localhost:8000/users/peter-dimov-nr59/](http://localhost:8000/users/peter-dimov-nr59/)

## Changes

- **`users/models.py`** - `get_contributor_data` groups by role, then sorts each list flagship-first and alphabetically (case-insensitive); untiered libraries sort with the non-flagships
- **`templates/v3/includes/_user_profile_bio_card.html`** - contributions become a `ul`/`li` list; each role gets a hidden checkbox plus a "See more"/"See less" label
- **`static/css/v3/user-profile-bio-card.css`** - 3-line clamp on the library list, `:checked` sibling rules to expand it, focus ring driven off the hidden input
- **`users/tests/test_profile_role.py`** - replaced the commit-count ordering test with alphabetical and flagship-first cases

## ‼️ Risks & Considerations ‼️

- The truncation has no Figma spec, so the toggle borrows bio-card typography and an underline; Henry may want a different affordance
- The AC names "Reviews" and "Version Author" contribution types; `ProfileRole` only has Author, Maintainer and Contributor, so nothing was added for them
- `contributor_data` is cached per user and only invalidated on a library import, so an existing cache entry keeps the old order until the next import or TTL expiry

## Screenshots

Before:
<img width="1578" height="1137" alt="image" src="https://github.com/user-attachments/assets/40dd9456-5275-4fc0-8642-28be151a65bf" />

After:
<img width="1574" height="1052" alt="image" src="https://github.com/user-attachments/assets/d4b2276c-042f-4b8d-bc3f-896ddec3d595" />
<img width="1589" height="1231" alt="image" src="https://github.com/user-attachments/assets/d515030f-d1d7-4c8b-921b-400666b0290f" />


## Peer-review testing steps

1. Open a profile with many contributions, e.g. `/users/peter-dimov-nr59/` or `/users/rene-ferdinand-rivera-morell-ugjs/`, with the `v3` flag on.
2. Check each contribution type: flagship libraries lead, the rest are alphabetical.
3. Confirm a list longer than 3 lines is cut at the 3rd line with "See more" below it.
4. Click "See more" - the list expands inline and the control reads "See less".
5. Confirm a role whose list fits in 3 lines shows no toggle at all.
6. Disable JavaScript and reload: the toggle is always shown and still expands and collapses.
