### PR TITLE
Issue: #2730 :: feat: make the library list view the default libraries landing view

### DIFF
--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -295,7 +295,7 @@ def test_docs_libs_gateway_200_non_html(tp, mock_get_file_data):
 def test_doc_libs_version_redirect(tp):
     response = tp.get("redirect-to-library-page", requested_version="1.82.0")
     tp.response_302(response)
-    assert response["Location"] == "/libraries/1.82.0/grid/"
+    assert response["Location"] == "/libraries/1.82.0/list/"
 
     response = tp.get("redirect-to-library-page", requested_version="release")
     tp.response_302(response)

--- a/libraries/constants.py
+++ b/libraries/constants.py
@@ -395,7 +395,7 @@ LIBRARY_GITHUB_URL_OVERRIDES = {
     "outcome": "https://github.com/ned14/outcome/issues",
 }
 
-DEFAULT_LIBRARIES_LANDING_VIEW = "grid"
+DEFAULT_LIBRARIES_LANDING_VIEW = "list"
 SELECTED_BOOST_VERSION_COOKIE_NAME = "boost_version"
 SELECTED_LIBRARY_VIEW_COOKIE_NAME = "library_view"
 LATEST_RELEASE_URL_PATH_STR = "latest"

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -7,7 +7,7 @@ from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from model_bakery import baker
 
-from ..constants import README_MISSING
+from ..constants import README_MISSING, SELECTED_LIBRARY_VIEW_COOKIE_NAME
 from ..models import Library
 from ..utils import benchmark_sets, designed_for_html
 from ..views import LibraryListBase, _build_quick_start_links, _is_boost_url
@@ -132,8 +132,16 @@ def test_library_list(library_version, tp, url_name="libraries", request_kwargs=
     assert lib2 not in res.context["object_list"]
 
 
-def test_library_root_redirect_to_grid(tp):
+def test_library_root_redirect_to_list(tp):
     """GET /libraries/"""
+    res = tp.get("libraries")
+    tp.response_302(res)
+    assert res.url == "/libraries/latest/list/"
+
+
+def test_library_root_redirect_honors_view_cookie(tp):
+    """GET /libraries/ with a saved view preference keeps that view."""
+    tp.client.cookies[SELECTED_LIBRARY_VIEW_COOKIE_NAME] = "grid"
     res = tp.get("libraries")
     tp.response_302(res)
     assert res.url == "/libraries/latest/grid/"
@@ -638,7 +646,7 @@ def test_redirect_to_library_list_view(library_version, tp):
     tp.response_302(response)
 
     # Should redirect to the libraries-list view with the version slug
-    expected_redirect = "/libraries/1.79.0/grid/"
+    expected_redirect = "/libraries/1.79.0/list/"
     assert response.url == expected_redirect
 
 

--- a/libraries/utils.py
+++ b/libraries/utils.py
@@ -225,7 +225,7 @@ def get_prioritized_library_view(request):
     View Priorities:
     1. URL parameter
     2. Cookie
-    3. Default to grid view
+    3. Default to list view
     """
     url_view = get_view_from_url(request)
     cookie_view = get_view_from_cookie(request)


### PR DESCRIPTION
# Issue: #2730

**Branch:** `teo/2730-make-library-list-view-default` · **Base:** `origin/develop`

## Summary & Context

Flips `DEFAULT_LIBRARIES_LANDING_VIEW` from `grid` to `list`, so `/libraries/` and
the `/libraries/<version>/` version redirect land on the list view. The default is
only the third priority behind the URL segment and the saved `library_view` cookie,
so anyone who has already picked a view keeps it.

- **Figma link**: n/a
- **Link to components/page:**
  - [http://localhost:8000/libraries/](http://localhost:8000/libraries/)
  - [http://localhost:8000/libraries/latest/list/](http://localhost:8000/libraries/latest/list/)

## Changes

- **`libraries/constants.py`** - `DEFAULT_LIBRARIES_LANDING_VIEW` is now `"list"`.
- **`libraries/utils.py`** - `get_prioritized_library_view` docstring updated to match.
- **`libraries/tests/test_views.py`** - root redirect test now expects `/latest/list/`; added a test proving a `library_view=grid` cookie still wins over the default.
- **`core/tests/test_views.py`** - version redirect test expects `/libraries/1.82.0/list/`.

## ‼️ Risks & Considerations ‼️

- The constant is shared by the legacy and V3 pages, so the legacy libraries landing view changes too. The ticket asks for the default view, not a V3-only default, and gating it behind the waffle flag would leave the two systems disagreeing on the same cookie.
- Returning users with an existing `library_view` cookie will not see any change; only first-time and cookie-cleared visitors land on the list.
- Nothing else was touched: the view switcher, the `?view=` query redirect and the explicit `/grid/` URLs all still work.

## Peer-review testing steps

1. Clear the `library_view` cookie for the site (or use a fresh private window).
2. Open `/libraries/` and confirm it redirects to `/libraries/latest/list/` and renders the list view.
3. Switch the View dropdown to Card, then open `/libraries/` again and confirm the cookie sends you to `/libraries/latest/grid/`.
4. Open `/libraries/1.88.0/` and confirm it redirects to that version's list view with the cookie cleared.
5. Turn the `v3` waffle flag off and repeat step 2 to confirm the legacy page also lands on the list view.
6. Confirm `/libraries/latest/grid/`, `/categorized/` and `/grading/` still load directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Libraries now open in the list view by default, including versioned library redirects.
  - Saved view preferences continue to preserve the selected grid view.
- **Bug Fixes**
  - Corrected redirect behavior and related view expectations to consistently use the default list layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->