### PR TITLE
Story 2727: enable hide mailing list activity functionality

### DIFF
--- a/users/constants.py
+++ b/users/constants.py
@@ -6,6 +6,7 @@ LOGIN_METHOD_SESSION_FIELD_NAME = "boost_login_method"
 
 GITHUB_PROVIDER = "github"
 GITHUB_ACTIVITY_CARD_TITLE = "Latest Boost Github activity"
+MAILING_LIST_ACTIVITY_CARD_TITLE = "Latest mailing list activity"
 # Stored GitHub activity older than this is refreshed on the next profile load.
 GITHUB_ACTIVITY_STALE_AFTER = timedelta(hours=24)
 # Guards against re-queueing a refresh on every page load while one is running,

--- a/users/mixins.py
+++ b/users/mixins.py
@@ -3,7 +3,10 @@ from urllib.parse import urlparse
 from badges import display as badge_display
 from badges.summary import user_badge_summary
 from core.context_processors import edit_profile_url
-from users.profile_cards import github_activity_card_context
+from users.profile_cards import (
+    github_activity_card_context,
+    mailing_list_activity_card_context,
+)
 
 
 class V3UserProfileContextMixin:
@@ -171,4 +174,10 @@ class V3UserProfileContextMixin:
         activity = github_activity_card_context(user, include_hidden=is_owner)
         if activity and activity["data"]["linked"]:
             context["github_activity"] = activity
+        # Same gate for the mailing list card, which has no data source yet:
+        # the key is only set once there are items, so today the section stays
+        # out of every page and the hide switch is already honoured.
+        mailing_list = mailing_list_activity_card_context(user, include_hidden=is_owner)
+        if mailing_list and mailing_list["mailing_list_items"]:
+            context["mailing_list_activity_card_data"] = mailing_list
         return context

--- a/users/profile_cards.py
+++ b/users/profile_cards.py
@@ -14,6 +14,7 @@ from users.constants import (
     GITHUB_ACTIVITY_POLL_MAX_ATTEMPTS,
     GITHUB_ACTIVITY_REFRESH_LOCK_SECONDS,
     GITHUB_PROVIDER,
+    MAILING_LIST_ACTIVITY_CARD_TITLE,
 )
 
 GithubActivityState = namedtuple(
@@ -197,4 +198,23 @@ def github_activity_card_context(user, attempt=0, include_hidden=False):
         "poll_exhausted": attempt >= GITHUB_ACTIVITY_POLL_MAX_ATTEMPTS or not poll_url,
         "poll_url": poll_url,
         "poll_interval": GITHUB_ACTIVITY_POLL_INTERVAL_SECONDS,
+    }
+
+
+def mailing_list_activity_card_context(user, include_hidden=False):
+    """Context for ``_mailing_list_activity_card.html`` on the public profile.
+
+    Returns None when the user has hidden their mailing list activity, unless
+    ``include_hidden`` is set - the same shape ``github_activity_card_context``
+    uses, so callers omit the section rather than rendering it empty.
+
+    TODO: The card has no data source yet, so ``mailing_list_items`` is always empty
+    and the section never renders. This is the privacy gate only.
+    """
+    if user.hide_mailing_list_activity and not include_hidden:
+        return None
+
+    return {
+        "title": MAILING_LIST_ACTIVITY_CARD_TITLE,
+        "mailing_list_items": [],
     }

--- a/users/tests/test_profile_cards.py
+++ b/users/tests/test_profile_cards.py
@@ -15,6 +15,7 @@ from users.profile_cards import (
     github_activity_card_context,
     github_activity_card,
     github_activity_state,
+    mailing_list_activity_card_context,
 )
 
 
@@ -353,3 +354,27 @@ def test_pr_and_review_links_target_the_pull_requests_tab():
 
     assert markdown.count("type=pullrequests") == 2
     assert "type=commits" not in markdown
+
+
+def test_mailing_list_card_is_withheld_when_hidden(user, db):
+    user.hide_mailing_list_activity = True
+    user.save(update_fields=["hide_mailing_list_activity"])
+
+    assert mailing_list_activity_card_context(user) is None
+
+
+def test_mailing_list_card_is_offered_when_not_hidden(user, db):
+    context = mailing_list_activity_card_context(user)
+
+    assert context is not None
+    # TODO: Make sure to retrieve mailing_list_items once data is
+    # available.
+    assert context["mailing_list_items"] == []
+
+
+def test_mailing_list_card_reaches_its_owner_while_hidden(user, db):
+    """Hiding is about the public profile, not about hiding it from yourself."""
+    user.hide_mailing_list_activity = True
+    user.save(update_fields=["hide_mailing_list_activity"])
+
+    assert mailing_list_activity_card_context(user, include_hidden=True) is not None

--- a/users/tests/test_v3_profile_public.py
+++ b/users/tests/test_v3_profile_public.py
@@ -1,9 +1,12 @@
+from unittest.mock import patch
+
 import pytest
 import waffle.testutils
 from django.urls import resolve
 from model_bakery import baker
 
 from users.models import GithubActivity, UserProfileRoutingKey
+from users.profile_cards import mailing_list_activity_card_context
 
 pytestmark = pytest.mark.django_db
 
@@ -370,3 +373,62 @@ def test_hidden_github_activity_still_shows_to_its_owner(user, tp):
     content = response.content.decode()
     assert "user-profile__github" in content
     assert "Created 9 Commits" in content
+
+
+def _with_one_item(user, include_hidden=False):
+    """Stand in for a populated mailing list card.
+
+    TODO: The real card has no data source yet, so the gate always returns an empty
+    item list and the section never renders. Wrapping the real gate - rather
+    than replacing it - keeps the hide switch under test while giving the
+    template something to draw.
+    """
+    context = mailing_list_activity_card_context(user, include_hidden=include_hidden)
+    if context is None:
+        return None
+    context["mailing_list_items"] = [
+        {"date": None, "headline": "Re: [boost] a thread", "url": "https://x.test/1"}
+    ]
+    return context
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_mailing_list_activity_is_withheld_from_visitors_when_hidden(other_user, tp):
+    other_user.hide_mailing_list_activity = True
+    other_user.save(update_fields=["hide_mailing_list_activity"])
+
+    with patch("users.mixins.mailing_list_activity_card_context", _with_one_item):
+        response = tp.get(
+            "profile-user", routing_key=other_user.profile_routing_key.routing_key
+        )
+
+    content = response.content.decode()
+    assert "user-profile__mailing-list" not in content
+    assert "Re: [boost] a thread" not in content
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_mailing_list_activity_shows_to_visitors_when_not_hidden(other_user, tp):
+    with patch("users.mixins.mailing_list_activity_card_context", _with_one_item):
+        response = tp.get(
+            "profile-user", routing_key=other_user.profile_routing_key.routing_key
+        )
+
+    content = response.content.decode()
+    assert "user-profile__mailing-list" in content
+    assert "Re: [boost] a thread" in content
+
+
+@waffle.testutils.override_flag("v3", active=True)
+def test_hidden_mailing_list_activity_still_shows_to_its_owner(user, tp):
+    """Hiding is about the public profile, not about hiding it from yourself."""
+    user.hide_mailing_list_activity = True
+    user.save(update_fields=["hide_mailing_list_activity"])
+
+    with patch("users.mixins.mailing_list_activity_card_context", _with_one_item):
+        with tp.login(user):
+            response = tp.get("profile-account")
+
+    content = response.content.decode()
+    assert "user-profile__mailing-list" in content
+    assert "Re: [boost] a thread" in content


### PR DESCRIPTION
# Issue: #2727

## Summary & Context

The "Hide your mailing list activity from your profile" checkbox already saved its value, but nothing on the public profile ever read it back. This adds the missing read side, so the setting now actually controls whether the mailing list activity card is served.

- **Figma link**: n/a 
- **Link to components/page:** `localhost:8000/users/me/?edit=true` (the checkbox) and `localhost:8000/users/<routing-key>/` (the profile the setting governs)

> [!NOTE]
> The links to the components are there just for reference, as this PR DOES NOT cover FE implementation.

## Changes

1. **Added `mailing_list_activity_card_context(user, include_hidden=False)` in `users/profile_cards.py`.** Returns `None` when the user has hidden their mailing list activity, otherwise the card's context. Same signature and return shape as the existing `github_activity_card_context`.
2. Wired it into `get_v3_public_context` in `users/mixins.py`, passing `include_hidden=is_owner` so a user who hides their activity still sees it on their own page while visitors do not. The same convention is already used for GitHub activity, badges and the public role.
3. Added `MAILING_LIST_ACTIVITY_CARD_TITLE` to `users/constants.py`, next to the GitHub equivalent.

## ‼️ Risks & Considerations ‼️

1. **Nothing changes visibly.** The mailing list activity card has no data source yet (see the PM note on #2727), so it renders on no profile today, hidden or not. This PR only guarantees the setting will be honoured the moment the card gets its data. 
2. **The write path was already correct.** The checkbox was persisting to `User.hide_mailing_list_activity` before this PR. 
3. **How the page tests fake the card.** Because there is no data source, the three page-level tests patch `users.mixins.mailing_list_activity_card_context` with a wrapper that calls the *real* gate and then injects one item. The hide logic and the template wiring are both properly implemented and only the item list is fabricated. 
4. **The card is context-key-gated, not template-gated.** `templates/v3/user_profile_page.html:42` already guarded on `mailing_list_activity_card_data`, a key no Python set. This PR sets that key, and only when there are items to show. Whoever implements the card must keep populating it through this function.
5. No migrations, no dependency changes, no template changes.

## Screenshots
### N/A

## Testing steps

### Automated

```
just test_pytest users/ badges/
```

868 passed, 2 skipped. `black --check .` is clean.

The 6 new tests specifically:

```
just test_pytest users/tests/test_profile_cards.py users/tests/test_v3_profile_public.py -k mailing_list
```

### Manual for QA

The card does not render, so the visible half of this feature cannot be observed yet. What can be verified:

1. **The checkbox persists.**
   - Go to `/users/me/?edit=true`.
   - In the visibility section, tick **"Hide your mailing list activity from your profile"** and click **Save changes**.
   - Reload the page. The box is still ticked.
   - Untick it, save, reload. It stays unticked.

2. **The value reaches the database.**
   - In `/admin/`, open the same user under **Users**.
   - `hide_mailing_list_activity` matches the checkbox state from step 1.

3. **The other two toggles are unaffected.**
   - The same section holds "Hide your GitHub activity" and "Hide badges and achievements". Toggle each one on its own, save, reload and you'll notice each persists independently, and toggling the mailing list box does not disturb them.
   - With a GitHub account linked and synced activity, ticking "Hide your GitHub activity" still removes the GitHub card from another user's view of your profile. This confirms the shared save handler wasn't broken.

4. **The gate itself, if you want to see it work.** In a Django shell:
   ```python
   from django.contrib.auth import get_user_model
   from users.profile_cards import mailing_list_activity_card_context

   u = get_user_model().objects.get(email="<your-email>")

   u.hide_mailing_list_activity = True
   mailing_list_activity_card_context(u)                       # None  -> visitor sees nothing
   mailing_list_activity_card_context(u, include_hidden=True)  # dict  -> owner still sees it

   u.hide_mailing_list_activity = False
   mailing_list_activity_card_context(u)                       # dict
   ```

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mailing list activity card to user profiles.
  * The card can display recent mailing list activity when available.
  * Users can control whether their mailing list activity is visible to visitors, while profile owners can still view it.

* **Tests**
  * Added coverage for visibility settings and owner access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->