### PR TITLE
Issue #2666 :: fix: stack horizontal card group posts on tablet

### DIFF
--- a/static/css/v3/card-group.css
+++ b/static/css/v3/card-group.css
@@ -125,7 +125,7 @@
 
 /* ── Responsive ─────────────────────────────── */
 
-@media (max-width: 767px) {
+@media (max-width: 1279px) {
   .card-group--horizontal .card-group__list {
     flex-direction: column;
   }


### PR DESCRIPTION
# Issue: #2666

## Summary & Context

The "Latest <library> posts" card on the library subpage is a `card-group--horizontal`, whose row-to-column fallback only kicked in below 768px, so tablet widths still laid the three posts side by side. Figma stacks them on the 1024px tablet frame (Card/Posts content is `column` there, `row` only on the 1440px desktop frame), so the fallback now covers everything below the 1280px desktop threshold already used across the V3 CSS.

- **Figma link**: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=11872-15690
- **Link to components/page:** [http://localhost:8000/library/latest/algorithm/](http://localhost:8000/library/latest/algorithm/)

## Changes

- **`static/css/v3/card-group.css`** - the `.card-group--horizontal` column fallback moves from `max-width: 767px` to `max-width: 1279px`

## ‼️ Risks & Considerations ‼️

- `card-group--horizontal` is only used by the library subpage posts card (and the V3 examples page), so no other page changes layout.
- Figma also splits the tablet bottom row 1/2 + 1/2 (posts 488px, mailing list 488px) while the page keeps the desktop 2/3 + 1/3 grid; that is a separate mismatch and is left alone here.

## Screenshots
<img width="1029" height="1313" alt="image" src="https://github.com/user-attachments/assets/ad22ef8f-b362-4ccc-b961-6da29688b432" />
<img width="1949" height="1320" alt="image" src="https://github.com/user-attachments/assets/e6858505-1aae-4090-ab13-2291f8b74cb7" />


## Peer-review testing steps

1. Make sure the `v3` flag is on and pick a library with at least two related posts (tag a few live PostPages with a `ContentTag` whose slug matches the library, e.g. `algorithm`, if the seed has none).
2. Open the library subpage at a 1024px wide viewport and scroll to "Latest <library> posts".
3. The posts stack vertically, one below the other, with the mailing list card still beside them.
4. Widen to 1440px: the posts sit side by side again.
5. Narrow to 390px: the posts stay stacked and the mailing list card drops below.

