### PR TITLE
Issue #2729 :: Task: don't show release version mismatch when the selected version is the latest

### DIFF
--- a/libraries/mixins.py
+++ b/libraries/mixins.py
@@ -114,9 +114,9 @@ class VersionAlertMixin:
 
         if selected == current:
             return format_html(
-                "You've currently chosen the {name} version. If a newer "
-                "release comes out, you will continue to view the {name} "
-                'version, not the new <a href="{url}">latest release</a>.',
+                "You're viewing version {name}.\n If a newer release becomes "
+                "available, you'll remain on this version unless you switch "
+                'to the <a href="{url}">latest release</a>.',
                 name=current.display_name,
                 url=url,
             )

--- a/libraries/mixins.py
+++ b/libraries/mixins.py
@@ -92,11 +92,18 @@ class VersionAlertMixin:
                 url_name, kwargs=current_version_kwargs
             )
 
-        context["version_alert"] = alert_visible
         # V3-only: legacy templates build their own alert markup and never read
         # version_alert_message, so don't compute it off the v3 render path.
         if alert_visible and getattr(self, "_v3_active", False):
-            context["version_alert_message"] = self.get_version_alert_message(context)
+            # A numbered version that is also the current release is not a
+            # mismatch, so the banner stays hidden there as it does on /latest/.
+            if context.get("selected_version") == context.get("current_version"):
+                alert_visible = False
+            else:
+                context["version_alert_message"] = self.get_version_alert_message(
+                    context
+                )
+        context["version_alert"] = alert_visible
         return context
 
     def get_version_alert_message(self, context):

--- a/libraries/tests/test_mixins.py
+++ b/libraries/tests/test_mixins.py
@@ -67,8 +67,10 @@ def test_version_alert_message_sticky_latest():
 
     current = Version(name="boost-1.90.0", full_release=True)
     msg = _alert_message(current, current)
-    assert "you will continue to view" in msg
-    assert 'href="/releases/latest/"' in msg
+    assert "You're viewing version 1.90.0." in msg
+    assert "you'll remain on this version" in msg
+    assert 'switch to the <a href="/releases/latest/">latest release</a>' in msg
+    assert "not the new" not in msg
 
 
 def test_version_alert_message_beta():

--- a/libraries/tests/test_mixins.py
+++ b/libraries/tests/test_mixins.py
@@ -1,4 +1,6 @@
 import datetime
+from types import SimpleNamespace
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory
@@ -105,6 +107,56 @@ def test_version_alert_message_dev_branch():
     msg = _alert_message(selected, current)
     assert "under active development" in msg
     assert "develop" in msg
+
+
+class _ContextBase:
+    def get_context_data(self, **kwargs):
+        return dict(self.base_context, **kwargs)
+
+
+class _V3AlertView(VersionAlertMixin, _ContextBase):
+    """Minimal v3-active view exercising VersionAlertMixin.get_context_data."""
+
+    _v3_active = True
+
+    def __init__(self, version_slug, selected, current):
+        self.request = RequestFactory().get("/")
+        self.request.resolver_match = SimpleNamespace(url_name="libraries-list")
+        self.kwargs = {"version_slug": version_slug, "library_view_str": "grid"}
+        self.base_context = {"selected_version": selected, "current_version": current}
+
+
+def test_version_alert_hidden_on_latest_slug():
+    from versions.models import Version
+
+    current = Version(name="boost-1.92.0", full_release=True)
+    context = _V3AlertView("latest", current, current).get_context_data()
+    assert context["version_alert"] is False
+    assert "version_alert_message" not in context
+
+
+def test_version_alert_hidden_when_numbered_version_is_current():
+    from versions.models import Version
+
+    current = Version(name="boost-1.92.0", full_release=True)
+    context = _V3AlertView("boost-1-92-0", current, current).get_context_data()
+    assert context["version_alert"] is False
+    assert "version_alert_message" not in context
+
+
+def test_version_alert_visible_for_older_version():
+    from versions.models import Version
+
+    current = Version(name="boost-1.92.0", full_release=True)
+    selected = Version(
+        name="boost-1.85.0",
+        full_release=True,
+        release_date=datetime.date(2024, 6, 1),
+    )
+    context = _V3AlertView("boost-1-85-0", selected, current).get_context_data()
+    assert context["version_alert"] is True
+    assert "older version of Boost" in context["version_alert_message"]
+    assert context["version_alert_url"] == "/libraries/latest/grid/"
 
 
 # ── build_all_contributors ──────────────────────────────────────────────────


### PR DESCRIPTION
# Issue: #2729

## Summary & Context

On v3 pages the version banner no longer renders when the selected version is the current release, whether reached as `/latest/` or by its number (e.g. `/libraries/1.92.0/` while 1.92.0 is current); older, beta and dev versions still get the banner. The sticky-latest message in `get_version_alert_message` is also rewritten to the ticket copy with the "latest release" link kept, so the wording is right if that branch is ever rendered again.

- **Figma link**: n/a
- **Link to components/page:**
  - [http://localhost:8000/libraries/1.92.0/](http://localhost:8000/libraries/1.92.0/)
  - [http://localhost:8000/libraries/latest/](http://localhost:8000/libraries/latest/)
  - [http://localhost:8000/libraries/1.85.0/](http://localhost:8000/libraries/1.85.0/)

## Changes

- **`libraries/mixins.py`** - `VersionAlertMixin.get_context_data` sets `version_alert` to False on the v3 path when `selected_version == current_version` (the `/latest/` slug was already hidden); the legacy path is untouched
- **`libraries/mixins.py`** - sticky-latest branch of `get_version_alert_message` now reads "You're viewing version X. If a newer release becomes available, you'll remain on this version unless you switch to the latest release." with the link on "latest release"
- **`libraries/tests/test_mixins.py`** - new `_V3AlertView` harness with tests for the `latest` slug, the numbered-current case (both hidden) and an older version (visible, older-version copy, `/libraries/latest/grid/` link); sticky-latest message test updated to the new copy

## ‼️ Risks & Considerations ‼️

- The hide is gated on `_v3_active`, so legacy templates (and the `/doc/libs/` pages, which render the legacy alert) keep showing the old sticky banner at `/1.92.0/`; `VersionAlertMixin` is one code path for both, the gate is what keeps legacy verbatim
- With the hide in place the sticky-latest message branch is unreachable on v3; it is kept, tested and reworded rather than deleted so the copy is ready if it is reinstated
- Release pages share the mixin, so `/releases/1.92.0/` loses its banner too (verified)

## Screenshots
<img width="1467" height="719" alt="image" src="https://github.com/user-attachments/assets/43837a68-c977-4d68-9436-5d811d651d17" />
<img width="1565" height="836" alt="image" src="https://github.com/user-attachments/assets/d48bdef1-e971-4726-bc16-edd94fdc2c3f" />


## Peer-review testing steps

1. Make sure the `v3` waffle flag is on for your user
2. Open [http://localhost:8000/libraries/1.92.0/](http://localhost:8000/libraries/1.92.0/) (the current release by number) and confirm no amber banner
3. Open [http://localhost:8000/libraries/latest/](http://localhost:8000/libraries/latest/) and confirm no banner
4. Open [http://localhost:8000/libraries/1.85.0/](http://localhost:8000/libraries/1.85.0/) and confirm the "older version of Boost" banner with a working "current version" link
5. Repeat 2 to 4 on `/releases/<version>/`
6. Turn the `v3` flag off and confirm `/libraries/1.92.0/` still shows the legacy sticky banner (unchanged)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Version alerts now appear only for active V3 rendering.
  - Alerts are suppressed when viewing the currently selected numbered version.
  - Updated messaging clarifies when you are viewing the current version and will remain on it.

- **Tests**
  - Added coverage for latest, current numbered, and older version alert behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->