### PR TITLE
Issue #2680 :: fix: remove placeholder illustration from library subpage hero

### DIFF
--- a/libraries/views.py
+++ b/libraries/views.py
@@ -671,18 +671,9 @@ class LibraryDetail(
         )
 
         context["is_flagship_lib"] = self.object.tier == Tier.FLAGSHIP
-        if context["is_flagship_lib"]:
-            context["library_hero_image_url_light"] = (
-                SharedResources.hero_legacy_image_url_light
-            )
-            context["library_hero_image_url_dark"] = (
-                SharedResources.hero_legacy_image_url_dark
-            )
-            context["hero_image_url"] = SharedResources.hero_legacy_image_url_dark
-        else:
-            context["library_hero_image_url_light"] = ""
-            context["library_hero_image_url_dark"] = ""
-            context["hero_image_url"] = ""
+        context["library_hero_image_url_light"] = ""
+        context["library_hero_image_url_dark"] = ""
+        context["hero_image_url"] = ""
 
         return context
 


### PR DESCRIPTION
# Issue: #2680

## Summary & Context

Flagship library subpages no longer receive the placeholder beaver art (`heros.png` / `heros_light.png`); the view now hands the hero empty image URLs for every tier, exactly as it already did for non-flagship libraries. Nothing else changed: templates and CSS are byte-identical to `develop`, so the hero partial's existing no-image handling is what renders the empty band.

- **Figma link**: n/a (ticket has none)
- **Link to components/page:**
  - [http://localhost:8000/library/latest/redis/](http://localhost:8000/library/latest/redis/)
  - [http://localhost:8000/library/latest/date_time/](http://localhost:8000/library/latest/date_time/)

## Changes

- **`libraries/views.py`** - drop the flagship branch that put `hero_legacy_image_url_*` into `library_hero_image_url_*` / `hero_image_url`; all tiers now get `""`, `is_flagship_lib` is unchanged

## ‼️ Risks & Considerations ‼️

- With no image passed, `_hero_library.html` adds `hero--no-image` on its own, so flagship heroes now take the existing no-image path (page surface, 368px floor, flush with the cards) rather than the yellow / navy band; no CSS was touched to make that happen.
- The `hero--library`, `fullbleed_fg=True` and `hero_image_url_*` args on the flagship include are now inert but were deliberately left in place for when real hero art ships.
- `hero_legacy_image_url_*` mock resources stay, since the V3 example gallery and `core/views.py` still use them.

## Screenshots
<img width="1725" height="961" alt="image" src="https://github.com/user-attachments/assets/6539d844-5c6a-4ba7-86fd-e9596592a713" />
## Peer-review testing steps

1. The stack is already up with the `v3` flag on for everyone.
2. Open a flagship library, e.g. [http://localhost:8000/library/latest/redis/](http://localhost:8000/library/latest/redis/).
3. Confirm the hero has no illustration and no `heros*.png` request appears in the network tab.
4. Open a non-flagship library, e.g. [http://localhost:8000/library/latest/date_time/](http://localhost:8000/library/latest/date_time/), and confirm both heroes are laid out the same.
5. Toggle dark mode and resize to tablet / mobile; behaviour should match a non-flagship subpage on `develop`.
