### PR TITLE
Issue #2629 :: Task: Hide Badge Assignment Dates

### DIFF
--- a/badges/tests/test_profile.py
+++ b/badges/tests/test_profile.py
@@ -135,12 +135,14 @@ def test_token_numbers_climb_with_the_rank_ladder():
     )
 
 
-def test_badge_card_renders_its_semantic_asset_and_award_date(plain_user):
-    """The card hands the component a token and a date the template formats.
+def test_badge_card_renders_its_semantic_asset_but_hides_the_award_date(plain_user):
+    """The card hands the component a token and a date the template leaves out.
 
     A ``date`` rather than a preformatted string: the project renders dates
     through Django's ``DATE_FORMAT`` everywhere else, so a string here would pin
-    this one card to a format nothing else uses.
+    this one card to a format nothing else uses. The template does not show it
+    for now: the historical backfill stamped every badge with the same day, so
+    the date is kept in the data for when real dates exist but hidden from view.
     """
     achievement = Achievement.objects.get(slug="library-review")
     badge = achievement.badges.get()
@@ -159,7 +161,8 @@ def test_badge_card_renders_its_semantic_asset_and_award_date(plain_user):
     assert card["earned_date"] == date(2025, 3, 7)
     assert "img/v3/badges/tier-5.png" in rendered
     assert "img/v3/badges/tier-4.png" not in rendered
-    assert date_format(date(2025, 3, 7)) in rendered
+    assert date_format(date(2025, 3, 7)) not in rendered
+    assert "2025" not in rendered
 
 
 @override_settings(TIME_ZONE="America/New_York")

--- a/static/css/v3/badges-card.css
+++ b/static/css/v3/badges-card.css
@@ -48,13 +48,6 @@
   line-height: var(--line-height-default);
 }
 
-.badges-card__date {
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-regular);
-  line-height: var(--line-height-default);
-}
-
 /* Empty state */
 .badges-card__empty {
   display: flex;

--- a/templates/v3/includes/_badges_card.html
+++ b/templates/v3/includes/_badges_card.html
@@ -2,9 +2,10 @@
   Badges Card component.
 
   Variables:
-    badges          (list, optional)    - List of badge objects. Each badge has: icon, name, earned_date.
+    badges          (list, optional)    - List of badge objects. Each badge has: icon, name.
                                           `icon` is a Badge component token (e.g. "badge-tier-3", "star-tier-2", "boost-day").
                                           Empty or undefined triggers the empty state.
+                                          `earned_date` may be present on each badge but is intentionally not rendered.
     cta_url         (string, optional)  - CTA target URL (empty state). Omit to hide the CTA button.
     cta_label       (string, optional)  - CTA button text (empty state)
 
@@ -31,13 +32,12 @@
     {# Filled state #}
     <ul class="badges-card__grid" role="list">
       {% for badge in badges %}
-        <li class="badges-card__entry" aria-label="{{ badge.name }}, earned {{ badge.earned_date }}">
+        <li class="badges-card__entry">
           <span class="badges-card__icon">
             {% if badge.icon %}{% include "v3/includes/_badge_v3.html" with token=badge.icon label=badge.name size="large" only %}{% endif %}
           </span>
           <div class="badges-card__text">
             <span class="badges-card__name">{{ badge.name }}</span>
-            <span class="badges-card__date">{{ badge.earned_date }}</span>
           </div>
         </li>
       {% endfor %}


### PR DESCRIPTION
# Issue: #2629

## Summary & Context

The badges card on user profiles no longer prints the award date under each badge name; the historical backfill stamped every badge with the same day, so the date was confusing rather than informative. The date is still computed in `badges/display.py` and still covered by tests, so it can be shown again once real award dates exist without touching the data layer.

- **Figma link**: https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=12403-25872
- **Link to components/page:**
  - [http://localhost:8000/users/me/](http://localhost:8000/users/me/)
  - [http://localhost:8000/users/serg-kryvonos-tgpu/](http://localhost:8000/users/serg-kryvonos-tgpu/)

## Changes

- **`templates/v3/includes/_badges_card.html`** - drop the `badges-card__date` span and the date from the entry `aria-label`; name renders alone beside the icon
- **`static/css/v3/badges-card.css`** - remove the now-unused `.badges-card__date` rule
- **`badges/tests/test_profile.py`** - the render test now asserts the date is kept in the card data but absent from the markup

## ‼️ Risks & Considerations ‼️

- `badges/display.py` still returns `earned_date` on purpose; removing it would break the timezone test and make re-enabling dates later a data change instead of a template change
- The Figma frame is newer than the shared design cache, so its layout was read straight from the API: icon 32px, gap 12px, name vertically centred, matching the existing `.badges-card__entry` rules
- The template's `btn-row` block was already djhtml-nonconformant on `develop` and was left as-is to keep the diff to the ticket

## Screenshots

### Before
<img width="1497" height="659" alt="image" src="https://github.com/user-attachments/assets/ca8eac66-8b6b-4e9b-87c7-c131a557afa8" />

### After
<img width="1526" height="710" alt="image" src="https://github.com/user-attachments/assets/2ce36498-ceeb-4fff-8a4d-22cdb4a51e3c" />


## Peer-review testing steps

1. Enable the `v3` waffle flag for everyone if it is not already on
2. Log in as a user who has at least one badge, or open the public profile of one (`/users/serg-kryvonos-tgpu/` in the `fresh_with_v3` seed)
3. Find the Badges card: each entry shows the badge icon and name only, with the name vertically centred against the icon
4. Inspect the entry markup: no `badges-card__date` span and no "earned" text in the `aria-label`
5. Open a profile with no badges: the empty state and its CTA are unchanged
6. Run `pytest badges/tests/test_profile.py`