### PR TITLE
Story 2722: fix display for achievement counts with more than three digis

### DIFF
--- a/core/templatetags/number_filters.py
+++ b/core/templatetags/number_filters.py
@@ -6,12 +6,28 @@ from django import template
 
 register = template.Library()
 
+# Below this, a count carries one decimal; at or above it the decimal is dropped.
+# Five digits is where "29.2k" stops fitting the counter badge, and a decimal buys
+# nothing at that magnitude.
+DECIMAL_LIMIT = 10_000
+
+
+def _thousands(n):
+    """``n`` in thousands: one decimal below ``DECIMAL_LIMIT``, whole above it."""
+    if n >= DECIMAL_LIMIT:
+        # Half up. round() and format() round half to even, which would make
+        # 28500 -> "28" while 29500 -> "30".
+        return str((n + 500) // 1000)
+    return f"{n / 1000:.1f}".rstrip("0").rstrip(".")
+
 
 @register.filter
 def compact_number(value):
     """
     Format integers in compact form: 2300 → 2.3k, 33000 → 33k, 1500000 → 1.5M.
-    Values under 1000 are shown as-is. Non-numeric values are returned unchanged.
+    Counts of 10000 and up round to whole thousands — 29200 → 29k, 29500 → 30k,
+    101400 → 101k. Values under 1000 are shown as-is. Non-numeric values are
+    returned unchanged.
     """
     if value is None:
         return ""
@@ -22,9 +38,7 @@ def compact_number(value):
     if n < 1000:
         return str(n)
     if n < 1_000_000:
-        k = n / 1000
-        formatted = f"{k:.1f}".rstrip("0").rstrip(".")
-        return f"{formatted}k"
+        return f"{_thousands(n)}k"
     m = n / 1_000_000
     formatted = f"{m:.1f}".rstrip("0").rstrip(".")
     return f"{formatted}M"
@@ -35,8 +49,9 @@ def k_count(value):
     """
     Achievement-counter format per Figma spec: a single digit is padded to two
     so the counter keeps one width — e.g. 1 → "01", 9 → "09" — 10..999 are shown
-    as-is, and 1000+ uses the "K" dimension: 1000 → "1K", 5500 → "5.5K".
-    Non-numeric values are returned unchanged.
+    as-is, and 1000+ uses the "K" dimension: 1000 → "1K", 5500 → "5.5K". Counts
+    of 10000 and up round to whole thousands: 29200 → "29K", 29500 → "30K",
+    101400 → "101K". Non-numeric values are returned unchanged.
     """
     if value is None:
         return ""
@@ -46,6 +61,4 @@ def k_count(value):
         return value
     if n < 1000:
         return f"{n:02d}" if 0 <= n < 10 else str(n)
-    k = n / 1000
-    formatted = f"{k:.1f}".rstrip("0").rstrip(".")
-    return f"{formatted}K"
+    return f"{_thousands(n)}K"

--- a/core/tests/test_templatetags.py
+++ b/core/tests/test_templatetags.py
@@ -2,7 +2,7 @@ import json
 from datetime import date, timedelta
 
 from ..templatetags.date_filters import years_since
-from ..templatetags.number_filters import k_count
+from ..templatetags.number_filters import compact_number, k_count
 from ..templatetags.text_helpers import to_json
 
 
@@ -62,3 +62,38 @@ def test_k_count_leaves_wider_numbers_alone():
 
 def test_k_count_still_uses_the_k_dimension():
     assert [k_count(n) for n in (1000, 5500, 10000)] == ["1K", "5.5K", "10K"]
+
+
+def test_k_count_rounds_five_digit_counts_to_whole_thousands():
+    """A decimal makes five digits too wide for the counter, so it is dropped."""
+    assert [k_count(n) for n in (29200, 29500, 29999)] == ["29K", "30K", "30K"]
+
+
+def test_k_count_rounds_half_up():
+    """Not half to even, which would make 28500 round down while 29500 rounds up."""
+    assert [k_count(n) for n in (28500, 29500)] == ["29K", "30K"]
+
+
+def test_k_count_keeps_the_decimal_below_five_digits():
+    assert [k_count(n) for n in (1000, 5500, 9999)] == ["1K", "5.5K", "10K"]
+
+
+def test_compact_number_rounds_five_digit_counts_to_whole_thousands():
+    assert [compact_number(n) for n in (29200, 29500, 28500)] == ["29k", "30k", "29k"]
+
+
+def test_compact_number_leaves_the_other_dimensions_alone():
+    values = (999, 2300, 9999, 100000, 1500000)
+    assert [compact_number(n) for n in values] == [
+        "999",
+        "2.3k",
+        "10k",
+        "100k",
+        "1.5M",
+    ]
+
+
+def test_compact_number_rounds_six_digit_counts_too():
+    """The decimal is dropped from five digits up, not only at five."""
+    values = (101999, 191029, 101400, 101500)
+    assert [compact_number(n) for n in values] == ["102k", "191k", "101k", "102k"]


### PR DESCRIPTION
# Issue: #2722

## Summary & Context

Achievement counters showed a decimal (`29.2k`), which made the text wider than the 24px badge and spilled it over the coloured square. Counts of 10,000 and up now round to whole thousands (`29k`), so they fit.

- **Figma link**: N/A
- **Link to components/page:** `localhost:8000/users/<routing-key>/`
 
Take a look at the Achievements card, and the counters inside the "Achievements" dialog on that page. 

## Changes

1. Counts of 10,000 and up lose the decimal and round to the nearest thousand: `29,200 → 29k`, `29,500 → 30k`, `101,400 → 101k`.
2. Rounding is half up, so `28,500 → 29k`. 
3. Counts below 10,000 are untouched: `3,836` still shows as `3.8k`, `999` as `999`, `1,000` as `1k`.
4. The two places that format a count (the Achievements card and the Achievements dialog) now share one helper, so the same number can't render as `29k` in one and `29.2K` in the other.

## ‼️ Risks & Considerations ‼️

1. **No real profile can show this yet.** The largest achievement count in the database is 9,976 (John Maddock, Code Commits), so nothing currently reaches five digits. Reviewing this visually needs a made-up count — see the testing steps below.
2. **Counts of 200,000 and over still overflow.** `200k` is 31px in a 24px badge. Rounding can't fix it: there is no decimal left to drop, and four characters don't fit. Unreachable from any current data source, but it is still a real limit of this approach. The 100,000–199,999 range is fine because `1` is a narrow character.
3. **`999,999` renders as `1000k`.** A pre-existing quirk of the boundary before the "M" scale takes over. Left alone, since it's also unreachable.
4. **The badge no longer shows an exact figure.** `29,200` and `29,499` both read `29k`. The Achievements dialog counter carries the exact number in its hover label and for screen readers; the counter on the Achievements card does not, so on that card the precise count is no longer visible anywhere. Flagging in case that matters to the PM.
5. **The formatting helper is shared with the carousel step badge** (`_cards_carousel_v3.html`), which only ever shows single digits, so nothing changes there.

## Peer Testing

**Seeing it in the browser** is the most straightforward option because no account has a five-digit or larger count, though I haven't pulled the latest production data in a while. 

In any case, you can follow these steps:

1. In `templates/v3/includes/_achievement_card.html`, change `value=ach.points` to `value=ach.points|add:**_29488_**`. :warning: In my case, I have just a few counters for my achievements, so please modify according to your testing needs. :warning:
2. Open your own profile at `localhost:8000/users/me/`.
3. The Achievements card shows `30k` next to Code Commits (29,500 rounds up) and `29k` for the rest (29,490–29,493 round down). Both cases in one screenshot. See _Thousands of Counts_ in the Screenshots section.
4. You can modify `value=ach.points|add:**_109458_**` so that the value you choose now hits the hundreds of thousands. See _Hundreds of Thousands of Counts_ in the Screenshots section.

### Screenshots
#### Thousands of Counts
<img width="718" height="248" alt="Achievements" src="https://github.com/user-attachments/assets/82d73eb6-19d3-451e-a2ed-a6288fb5da76" />

#### Hundreds of Thousands of Counts
<img width="712" height="230" alt="AchievementsHundredsOfThousands" src="https://github.com/user-attachments/assets/bd27b015-4e4d-4c2c-833c-ea3f7feb72d6" />


## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compact number formatting for thousands.
  * Values of 10,000 and above now round to whole thousands using standard half-up rounding.
  * Smaller thousands values retain one decimal place.
  * Formatting for hundreds and millions remains unchanged.

* **Tests**
  * Added coverage for rounding behavior across supported number ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->