### PR TITLE
Issue #2736 :: Sublibrary Page Displays a Specific Version Instead of “Latest”

### DIFF
--- a/libraries/models.py
+++ b/libraries/models.py
@@ -833,16 +833,6 @@ class LibraryVersion(models.Model):
         return f"{self.library.github_url}/tree/{self.version.name}"
 
     @cached_property
-    def library_detail_url_for_version(self):
-        return reverse(
-            "library-detail",
-            kwargs={
-                "version_slug": self.version.slug,
-                "library_slug": self.library.slug,
-            },
-        )
-
-    @cached_property
     def author_details(self):
         author = self.authors.first()
         return {

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -859,3 +859,64 @@ def test_library_grid_patches_authors_in_one_query(version, tp):
         if "libraries_commitauthoremail" in q["sql"]
     ]
     assert len(email_queries) == 1, email_queries
+
+
+@pytest.mark.django_db
+@waffle.testutils.override_flag("v3", active=True)
+def test_library_list_v3_cards_link_to_latest_when_browsing_latest(library_version, tp):
+    """A list browsed under "latest" must not pin cards to the resolved release,
+    or the header selector flips to that release on the library page."""
+    library = library_version.library
+    response = tp.get("libraries-list", version_slug="latest", library_view_str="list")
+    tp.response_200(response)
+
+    expected = tp.reverse("library-detail", "latest", library.slug)
+    pinned = tp.reverse("library-detail", library_version.version.slug, library.slug)
+    cards = [
+        lv for lv in response.context["object_list"] if lv.pk == library_version.pk
+    ]
+    assert cards[0].library_detail_url == expected
+    assert expected in response.content.decode()
+    assert pinned not in response.content.decode()
+
+
+@pytest.mark.django_db
+@waffle.testutils.override_flag("v3", active=True)
+def test_library_list_v3_cards_keep_an_explicit_version(library_version, tp):
+    library = library_version.library
+    version = library_version.version
+    response = tp.get(
+        "libraries-list", version_slug=version.slug, library_view_str="grid"
+    )
+    tp.response_200(response)
+
+    cards = [
+        lv for lv in response.context["object_list"] if lv.pk == library_version.pk
+    ]
+    assert cards[0].library_detail_url == tp.reverse(
+        "library-detail", version.slug, library.slug
+    )
+
+
+@pytest.mark.django_db
+@waffle.testutils.override_flag("v3", active=True)
+def test_library_list_v3_grouped_cards_link_to_latest(library_version, category, tp):
+    """Categorized and grading views rebuild their groups after the v3 context
+    hook, so their cards need the same URL treatment."""
+    library = library_version.library
+    library.categories.add(category)
+    expected = tp.reverse("library-detail", "latest", library.slug)
+
+    for view_str in ("categorized", "grading"):
+        response = tp.get(
+            "libraries-list", version_slug="latest", library_view_str=view_str
+        )
+        tp.response_200(response)
+        grouped = [
+            lv
+            for group in response.context["library_versions_by_category"]
+            for lv in group["library_version_list"]
+            if lv.pk == library_version.pk
+        ]
+        assert grouped, view_str
+        assert grouped[0].library_detail_url == expected, view_str

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -408,6 +408,32 @@ class LibraryListBase(BoostVersionMixin, V3Mixin, VersionAlertMixin, ListView):
             .order_by("name")
         )
 
+    def render_to_response(self, context, **response_kwargs):
+        if getattr(self, "_v3_active", False):
+            self._set_library_detail_urls(context)
+        return super().render_to_response(context, **response_kwargs)
+
+    def _set_library_detail_urls(self, context):
+        """Point every card at the detail page for the version segment of the
+        current URL, so a list browsed under "latest" links to
+        `/library/latest/<slug>/` rather than pinning the resolved release.
+
+        Runs on the final context because the categorized and grading views
+        rebuild their groups after `get_v3_context_data` has returned.
+        """
+        version_slug = self.kwargs.get("version_slug") or LATEST_RELEASE_URL_PATH_STR
+        library_versions = list(context.get("object_list") or [])
+        for group in context.get("library_versions_by_category") or []:
+            library_versions.extend(group["library_version_list"])
+        for library_version in library_versions:
+            library_version.library_detail_url = reverse(
+                "library-detail",
+                kwargs={
+                    "version_slug": version_slug,
+                    "library_slug": library_version.library.slug,
+                },
+            )
+
     def dispatch(self, request, *args, **kwargs):
         # Resolve selected_version once so get_v3_context_data can reuse it.
         self._selected_version = self._resolve_selected_version()

--- a/templates/v3/library_page.html
+++ b/templates/v3/library_page.html
@@ -426,7 +426,7 @@ Inputs:
           <div></div>
         </li>
         {% for item in object_list %}
-          {% include 'v3/includes/_library_item.html' with variant=library_view_str library_name=item.library.name library_slug=item.library.slug library_url=item.library_detail_url_for_version description=item.description categories=item.library.category_tags cpp_version=item.cpp_standard_minimum author=item.author_details doc_url=item.documentation_url version_str=version_str only %}
+          {% include 'v3/includes/_library_item.html' with variant=library_view_str library_name=item.library.name library_slug=item.library.slug library_url=item.library_detail_url description=item.description categories=item.library.category_tags cpp_version=item.cpp_standard_minimum author=item.author_details doc_url=item.documentation_url version_str=version_str only %}
         {% endfor %}
         <li id="library-empty-state"
             class="library-page__empty-state library-page__empty-state--in-list"
@@ -440,7 +440,7 @@ Inputs:
       </div>
       <div class="library-item-card-grid" x-cloak>
         {% for item in object_list %}
-          {% include 'v3/includes/_library_item.html' with variant=library_view_str library_name=item.library.name library_slug=item.library.slug library_url=item.library_detail_url_for_version description=item.description categories=item.library.category_tags cpp_version=item.cpp_standard_minimum author=item.author_details doc_url=item.documentation_url version_str=version_str only %}
+          {% include 'v3/includes/_library_item.html' with variant=library_view_str library_name=item.library.name library_slug=item.library.slug library_url=item.library_detail_url description=item.description categories=item.library.category_tags cpp_version=item.cpp_standard_minimum author=item.author_details doc_url=item.documentation_url version_str=version_str only %}
         {% endfor %}
       </div>
     {% elif library_view_str == 'categorized' or library_view_str == 'grading' %}
@@ -449,7 +449,7 @@ Inputs:
         <h2 class="library-page__category-header">{{ result.category }} {% if result.icon %}{% include "includes/icon.html" with icon_name=result.icon only %}{% endif %}</h2>
         <ul class="library-item-list grouped">
           {% for item in result.library_version_list %}
-            {% include 'v3/includes/_library_item.html' with variant='list' library_name=item.library.name library_slug=item.library.slug library_url=item.library_detail_url_for_version description=item.description categories=item.library.category_tags cpp_version=item.cpp_standard_minimum author=item.author_details doc_url=item.documentation_url version_str=version_str only %}
+            {% include 'v3/includes/_library_item.html' with variant='list' library_name=item.library.name library_slug=item.library.slug library_url=item.library_detail_url description=item.description categories=item.library.category_tags cpp_version=item.cpp_standard_minimum author=item.author_details doc_url=item.documentation_url version_str=version_str only %}
           {% endfor %}
         </ul>
       </section>


### PR DESCRIPTION
# Issue: #2736

## Summary & Context

V3 library cards linked to `/library/<resolved release>/<slug>/` even when the list was browsed under `latest`, so opening a library page flipped the header selector (and the version cookie) to 1.91.0. The card URL is now built in the list view from the version segment of the current URL, so `latest` stays `latest` and an explicitly chosen release still pins.

- **Figma link**: n/a
- **Link to components/page:**
  - [http://localhost:8000/libraries/latest/list/](http://localhost:8000/libraries/latest/list/)
  - [http://localhost:8000/libraries/latest/categorized/](http://localhost:8000/libraries/latest/categorized/)
  - [http://localhost:8000/library/latest/accumulators/](http://localhost:8000/library/latest/accumulators/)

## Changes

- **`libraries/views.py`** - `LibraryListBase.render_to_response` sets `library_detail_url` on every rendered `LibraryVersion` from the URL's `version_slug`, covering list, grid, categorized and grading groups
- **`libraries/models.py`** - drop `LibraryVersion.library_detail_url_for_version`, which always emitted the concrete release slug and had no other callers
- **`templates/v3/library_page.html`** - cards read `item.library_detail_url` instead of the removed model property
- **`libraries/tests/test_views.py`** - cover latest, explicit-version and grouped-view links

## ‼️ Risks & Considerations ‼️

- The hook runs on the final context because `LibraryCategorized` and `LibraryByTier` rebuild their groups after `get_v3_context_data` returns; annotating earlier is silently lost
- Legacy templates were already using `version_str` for these links and are untouched; the fix is v3-only

## Screenshots
Before it switched to a numeric version slug, now the selected version is fully preserved.
<img width="1666" height="1267" alt="image" src="https://github.com/user-attachments/assets/19695129-19d8-49a9-82e1-d9672b107f55" />

## Peer-review testing steps

1. Enable the `v3` waffle flag and pick "Latest" in the header version selector
2. Open `/libraries/latest/list/` and hover any library name: the href is `/library/latest/<slug>/`
3. Click through: the header still reads "Latest" and the cookie is not rewritten to a release
4. Repeat from `/libraries/latest/categorized/` and `/libraries/latest/grading/`
5. Open `/libraries/1.91.0/list/` and confirm cards still link to `/library/1.91.0/<slug>/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Library cards now link to the appropriate detail page for the selected release version.
  - When browsing the “latest” release, cards consistently link to the latest-version detail page.
  - Explicit version selections continue to use their pinned version URLs.
  - Categorized and grading views now apply the same release-specific linking behavior as standard library lists.
  - Updated list, grid, and grouped library displays to use the corrected detail links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->