### PR TITLE
Issue #2745 :: Lower the whitespace margins in Boostlook pages

### DIFF
--- a/static/css/v3/boostlook-v3.css
+++ b/static/css/v3/boostlook-v3.css
@@ -480,8 +480,9 @@
     --leftbar-paddings-leftbar-padding-2xs: var(--spacing-size-2xs);
     --leftbar-paddings-leftbar-padding-3xs: var(--spacing-size-3xs);
     --padding-padding-md: var(--spacing-size-md);
-    --main-margin: 0rem;
+    --main-margin: var(--spacing-size-xl);
     --main-max-width-leftbar: 18.25rem;
+    --main-content-width: 100%;
     --icons-24: 1.5rem;
     --icons-20: 1.25rem;
     --icons-16: 1rem;
@@ -3877,7 +3878,7 @@ div.source-docs-antora.boostlook:not(:has(article.doc)):not(:has(> .boostlook)) 
 /* Responsive Design */
 @media screen and (min-width: 768px) {
   .article.toc2.toc-left:has(.boostlook) {
-    padding: 0 var(--spacing-size-lg, 1.5rem);
+    padding: 0 !important;
   }
 
   .boostlook #toggle-toc {


### PR DESCRIPTION
# Issue: #2745

**Branch:** `teo/2745-lower-whitespace-margins-boostlook` · **Base:** `origin/develop`

## Summary & Context

The Boostlook v3 docs body no longer sits as a 44rem column centered in the space beside the sidebar; from 768px up it fills that space with a 32px gutter on each side. The gutter is carried by the existing `--main-margin` token on `#header`, `#content` and `#footer`, so breadcrumb, page arrows, body and footer all share the same edge.

- **Figma link**: n/a
- **Link to components/page:**
  - [http://localhost:8000/doc/user-guide/faq.html](http://localhost:8000/doc/user-guide/faq.html)
  - [http://localhost:8000/doc/libs/latest/libs/charconv/doc/html/charconv.html](http://localhost:8000/doc/libs/latest/libs/charconv/doc/html/charconv.html)

## Changes

- **`static/css/v3/boostlook-v3.css`** - at 768px+, `--main-margin` goes from `0rem` to `var(--spacing-size-xl)` (2rem) so header, content and footer get a 32px gutter
- **`static/css/v3/boostlook-v3.css`** - at 768px+, `--main-content-width` goes from `44rem` to `100%` so the body stops centering and fills the article
- **`static/css/v3/boostlook-v3.css`** - the `.article.toc2.toc-left` side padding is now `0 !important`; the upstream docs bundle sets `body.article` padding with `!important`, which was adding 12px on user-guide pages

## ‼️ Risks & Considerations ‼️

- Line length is no longer capped: on a 1728px screen paragraphs run about 1084px wide, which is well past the usual readability measure the 44rem column enforced.
- `.copyright-footer:empty` uses `--main-margin` as a bottom spacer, so empty footers now get 32px instead of 0 at 768px+.
- Mobile (below 768px) is untouched: 16px gutters and the 44rem cap stay as they were.

## Screenshots

Before:
<img width="1539" height="1312" alt="image" src="https://github.com/user-attachments/assets/c77ad981-e1ce-492a-964f-6d44e2d240a3" />


After:
<img width="1501" height="1277" alt="image" src="https://github.com/user-attachments/assets/d3ffeb03-ccd5-4de5-a170-2cd8a11a3914" />


## Peer-review testing steps

1. Open the user guide FAQ page above at a desktop width; the text should start 32px right of the sidebar and end 32px before the right edge.
2. In devtools, confirm `#content` has `padding-left: 32px` and `.doc` has `max-width: 100%`.
3. Open the Charconv docs page above; the same 32px gutters apply to the legacy-wrapper flavour.
4. Narrow the window to about 900px; gutters stay at 32px with the sidebar still present.
5. Narrow below 768px; the body keeps its previous 16px gutters.

