### PR TITLE
Issue #2681 :: Task: Fix Library Table Column Ordering

### DIFF
--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -495,6 +495,28 @@ def test_library_detail_v3_latest_posts_are_scoped_to_the_library(
 
 
 @waffle.testutils.override_flag("v3", active=True)
+def test_library_detail_v3_about_card_falls_back_to_the_docs_link(
+    tp, library_version, wagtail_site
+):
+    """Without adoc About content the card stays, pointing at the docs."""
+    library_version.website_adoc = {}
+    library_version.documentation_url = "/doc/libs/release/libs/example/"
+    library_version.save()
+    library = library_version.library
+
+    url = tp.reverse("library-detail", "latest", library.slug)
+    response = tp.get(url)
+    tp.response_200(response)
+
+    documentation_url = tp.get_context("documentation_url")
+    assert documentation_url
+    content = response.content.decode()
+    assert f"About {library.display_name}" in content
+    assert "Please check out the library" in content
+    assert f'href="{documentation_url}"' in content
+
+
+@waffle.testutils.override_flag("v3", active=True)
 def test_library_detail_v3_latest_posts_cta_points_at_the_news_index(
     tp, library_version, make_post_page, post_index_page, wagtail_site
 ):

--- a/templates/v3/libraries/library-subpage.html
+++ b/templates/v3/libraries/library-subpage.html
@@ -27,9 +27,9 @@
         {% if website_adoc.about %}
           {% include "v3/includes/_code_block_card.html" with heading="About "|add:object.display_name description=website_adoc.about.blurb code=website_adoc.about.code.code language=website_adoc.about.code.language|default:"cpp" %}
         {% elif documentation_url %}
-          {% include "v3/includes/_code_block_card.html" with heading="About "|add:object.display_name description="Please check out the library's documentation to learn more about it." button_text="View documentation" button_url=documentation_url %}
+          {% include "v3/includes/_code_block_card.html" with heading="About "|add:object.display_name description="Please check out the library's documentation to learn more." button_text="View documentation" button_url=documentation_url %}
         {% else %}
-          {% include "v3/includes/_code_block_card.html" with heading="About "|add:object.display_name description="Please check out the library's documentation to learn more about it." %}
+          {% include "v3/includes/_code_block_card.html" with heading="About "|add:object.display_name description="Please check out the library's documentation to learn more." %}
         {% endif %}
       </div>
 

--- a/templates/v3/libraries/library-subpage.html
+++ b/templates/v3/libraries/library-subpage.html
@@ -23,11 +23,15 @@
 
   <div class="library-subpage-container">
     <div class="card-masonry-top">
-      {% if website_adoc.about %}
       <div class="item-a">
-        {% include "v3/includes/_code_block_card.html" with heading="About "|add:object.display_name description=website_adoc.about.blurb code=website_adoc.about.code.code language=website_adoc.about.code.language|default:"cpp" %}
+        {% if website_adoc.about %}
+          {% include "v3/includes/_code_block_card.html" with heading="About "|add:object.display_name description=website_adoc.about.blurb code=website_adoc.about.code.code language=website_adoc.about.code.language|default:"cpp" %}
+        {% elif documentation_url %}
+          {% include "v3/includes/_code_block_card.html" with heading="About "|add:object.display_name description="Please check out the library's documentation to learn more about it." button_text="View documentation" button_url=documentation_url %}
+        {% else %}
+          {% include "v3/includes/_code_block_card.html" with heading="About "|add:object.display_name description="Please check out the library's documentation to learn more about it." %}
+        {% endif %}
       </div>
-      {% endif %}
 
       {% if benchmark_sets %}
       <div class="item-g">


### PR DESCRIPTION
# Issue: #2681

## Summary & Context

The "About" card on the v3 library subpage now always renders: when the library version has adoc About content it shows the blurb and code block as before, and when it has none it falls back to a "Please check out the library's documentation to learn more about it." blurb with a "View documentation" button pointing at `documentation_url`. Previously the whole `item-a` cell was skipped, which left the masonry grid without its lead card on every library that has no `website_adoc.about` (currently all of them in the seed data).

- **Figma link**: n/a
- **Link to components/page:**
  - [http://localhost:8000/library/latest/integer/](http://localhost:8000/library/latest/integer/)
  - [http://localhost:8000/library/latest/wave/](http://localhost:8000/library/latest/wave/)

## Changes

- **`templates/v3/libraries/library-subpage.html`** - the `{% if website_adoc.about %}` guard moved inside `item-a`; adds `elif documentation_url` and `else` branches that reuse `_code_block_card.html` with the fallback blurb (button only when a docs URL exists)
- **`libraries/tests/test_views.py`** - new `test_library_detail_v3_about_card_falls_back_to_the_docs_link` covering the fallback heading, blurb and docs href

## ‼️ Risks & Considerations ‼️

- This does not address the ticket title's table column ordering (Dependencies / Contributors); it is only the About-card fallback, so the ticket may need retitling or relinking.
- The template was already non-conformant to `djhtml` on `develop` (the whole `{% block %}` body is under-indented); the touched lines follow the surrounding indentation and were not reformatted.
- Libraries with no adoc About and no `documentation_url` get the blurb with no button.

## Screenshots

### Before
<img width="1658" height="1253" alt="image" src="https://github.com/user-attachments/assets/20061442-9612-4cfc-b852-4694981b96e2" />
<img width="1639" height="1306" alt="image" src="https://github.com/user-attachments/assets/acadac98-f73a-4789-a0a5-5acff7eb0d20" />


### After
<img width="1671" height="958" alt="image" src="https://github.com/user-attachments/assets/1454d91e-013e-464d-968a-e94e1649452a" />
<img width="1683" height="960" alt="image" src="https://github.com/user-attachments/assets/1139c55e-d091-4199-95cd-7306eb667eed" />


## Peer-review testing steps

1. Enable the `v3` waffle flag for everyone.
2. Open a library with no `website_adoc.about` (e.g. `/library/latest/integer/`) and confirm the "About Boost.Integer" card renders with the docs blurb and a "View documentation" button linking to `/doc/libs/latest/libs/integer/index.html`.
3. In a shell, set `website_adoc = {"about": {"blurb": "...", "code": {"code": "int x = 1;", "language": "cpp"}}}` on a `LibraryVersion` and reload its page; the card shows the blurb and code block with no docs button.
