### PR TITLE
Issue #2734 :: Exact Author Name Match Excludes Partial Author Matches

### DIFF
--- a/pages/models.py
+++ b/pages/models.py
@@ -109,8 +109,9 @@ class PostIndexPage(BasePage):
 
     PAGE_SIZE = 10
     RELATED_POSTS_LIMIT = 3
-    # One or two letters prefix too much of the feed to be worth answering.
-    MIN_PREFIX_SEARCH_LENGTH = 3
+    # A single letter prefixes most of the feed; two already narrow an author
+    # name ("Ma" for Matt and Mark) to something worth listing.
+    MIN_PREFIX_SEARCH_LENGTH = 2
 
     def route(self, request, path_components):
         """Act as an umbrella handler for both Wagtail posts and legacy entries.

--- a/pages/models.py
+++ b/pages/models.py
@@ -16,6 +16,9 @@ from django.db.models import (
     FloatField,
     F,
     Func,
+    OuterRef,
+    Q,
+    Subquery,
     Value,
     prefetch_related_objects,
 )
@@ -192,12 +195,43 @@ class PostIndexPage(BasePage):
             )
         )
         results = searchable.search(filters.q)
-        if results.count() or len(filters.q) < self.MIN_PREFIX_SEARCH_LENGTH:
+        if len(filters.q) < self.MIN_PREFIX_SEARCH_LENGTH:
             return results
-        # Full text matches whole stemmed words, so "Rob" misses an author called
-        # Robert. A fallback rather than the primary query, so a term with real
-        # matches keeps full text relevance ranking.
-        return searchable.autocomplete(filters.q)
+        # Full text matches whole stemmed words, so "Cris" finds an author
+        # called Cris but not Cristian. The prefix pass is added rather than
+        # substituted for it, so an exact hit no longer hides the wider matches.
+        return self._with_prefix_matches(
+            searchable, results, searchable.autocomplete(filters.q)
+        )
+
+    @staticmethod
+    def _with_prefix_matches(queryset, whole_words, prefixes):
+        """One queryset over both search passes.
+
+        Whole word hits come first in their full text relevance order, then
+        the prefix hits in theirs. SearchResults cannot be combined, but the
+        Postgres results expose the ranked queryset behind them, and a score
+        annotation makes that rank readable through a correlated subquery.
+        """
+
+        def score(results):
+            ranked = results.annotate_score("score").get_queryset()
+            return Subquery(
+                ranked.filter(pk=OuterRef("pk")).values("score")[:1],
+                output_field=FloatField(),
+            )
+
+        return (
+            queryset.annotate(
+                whole_word_score=score(whole_words), prefix_score=score(prefixes)
+            )
+            .filter(Q(whole_word_score__isnull=False) | Q(prefix_score__isnull=False))
+            .order_by(
+                F("whole_word_score").desc(nulls_last=True),
+                F("prefix_score").desc(nulls_last=True),
+                "-pk",
+            )
+        )
 
     def _related_posts(self, filters):
         """Fallback shown with the empty state: same library, search dropped.

--- a/pages/tests/test_posts_feed.py
+++ b/pages/tests/test_posts_feed.py
@@ -176,14 +176,27 @@ class TestSearch:
 
         assert titles(get_feed(tp, feed_url, q="asio")) == {"A Post", "Asiomatic"}
 
-    @pytest.mark.parametrize("term", ["p", "ab"])
-    def test_does_not_run_the_prefix_pass_for_very_short_terms(
-        self, tp, feed_url, make_post_page, term
+    def test_does_not_run_the_prefix_pass_for_a_single_letter(
+        self, tp, feed_url, make_post_page
     ):
-        """One or two letters prefix most of the feed."""
+        """One letter prefixes most of the feed."""
         make_post_page(title="Post About Absolutely Everything")
 
-        assert titles(get_feed(tp, feed_url, q=term)) == set()
+        assert titles(get_feed(tp, feed_url, q="p")) == set()
+
+    def test_two_letters_reach_every_author_with_that_prefix(
+        self, tp, feed_url, make_post_page
+    ):
+        matt = baker.make("users.User", display_name="Matt Borland")
+        mark = baker.make("users.User", display_name="Mark Cooper")
+        make_post_page(title="Decimal Goes Back to Review", owner=matt)
+        make_post_page(title="Powering Cognitive Communications", owner=mark)
+        make_post_page(title="Orphan Post")
+
+        assert titles(get_feed(tp, feed_url, q="ma")) == {
+            "Decimal Goes Back to Review",
+            "Powering Cognitive Communications",
+        }
 
     @pytest.mark.parametrize("term", ["Perez", "Pérez", "perez", "PEREZ"])
     def test_matches_an_accented_author_name_either_spelling(

--- a/pages/tests/test_posts_feed.py
+++ b/pages/tests/test_posts_feed.py
@@ -133,16 +133,48 @@ class TestSearch:
             "Boost.SQLite proposal results"
         }
 
-    def test_prefers_whole_word_matches_over_prefixes(
+    def test_an_exact_author_match_keeps_the_partial_ones(
         self, tp, feed_url, make_post_page
     ):
-        """The prefix pass is a fallback, so whole-word matches are not widened."""
+        """A whole-word hit used to skip the prefix pass, so "Cris" found Cris
+        and hid Cristian."""
+        cris = baker.make("users.User", display_name="Cris")
+        cristian = baker.make("users.User", display_name="Cristian")
+        make_post_page(title="Cris Post", owner=cris)
+        make_post_page(title="Cristian Post", owner=cristian)
+        make_post_page(title="Orphan Post")
+
+        assert titles(get_feed(tp, feed_url, q="Cris")) == {
+            "Cris Post",
+            "Cristian Post",
+        }
+
+    def test_ranks_whole_word_matches_before_prefixes(
+        self, tp, feed_url, make_post_page
+    ):
+        """Both passes are listed, whole words first, so an exact hit is not
+        pushed down by the wider matches."""
         falco = baker.make("users.User", display_name="Vinnie Falco")
         falconer = baker.make("users.User", display_name="Ada Falconer")
-        make_post_page(title="Falco Post", owner=falco)
         make_post_page(title="Falconer Post", owner=falconer)
+        make_post_page(title="Falco Post", owner=falco)
+        make_post_page(title="Falconer Follow-up", owner=falconer)
 
-        assert titles(get_feed(tp, feed_url, q="Falco")) == {"Falco Post"}
+        listed = [
+            post.title
+            for post in get_feed(tp, feed_url, q="Falco").context["entry_list"]
+        ]
+
+        assert listed[0] == "Falco Post"
+        assert set(listed[1:]) == {"Falconer Post", "Falconer Follow-up"}
+
+    def test_body_matches_survive_the_prefix_pass(self, tp, feed_url, make_post_page):
+        """The prefix vector covers title and author only, so a body hit is
+        reachable through the whole-word pass alone."""
+        make_post_page(title="A Post", body="asio networking")
+        make_post_page(title="Asiomatic", body="unrelated")
+
+        assert titles(get_feed(tp, feed_url, q="asio")) == {"A Post", "Asiomatic"}
 
     @pytest.mark.parametrize("term", ["p", "ab"])
     def test_does_not_run_the_prefix_pass_for_very_short_terms(


### PR DESCRIPTION
# Issue: #2734

**Branch:** `teo/2734-exact-author-match-excludes-partial` · **Base:** `origin/develop`

## Summary & Context

The posts feed ran the prefix (autocomplete) pass only when the whole-word pass found nothing, so a term that exactly matched one post hid every post whose title or author name merely started with it. On seed data, searching `jan` matched only "Boost.Charconv review runs **Jan** 15-25, 2024" and hid "Ruben's **January** update" - the loose fallback for the same feed. Both passes now feed one queryset: whole-word hits first in their relevance order, then the prefix hits that were not already listed. The prefix pass also starts at two letters instead of three, so `Ma` reaches both **Matt** Borland's and **Mark** Cooper's posts by author name.

- **Figma link**: n/a
- **Link to components/page:**
  - [http://localhost:8000/news/?q=jan](http://localhost:8000/news/?q=jan)
  - [http://localhost:8000/news/?q=ma](http://localhost:8000/news/?q=ma)

## Changes

- **`pages/models.py`** - `_results` no longer gates the prefix pass on `results.count()`; terms of 2+ characters always get both passes (`MIN_PREFIX_SEARCH_LENGTH` 3 to 2)
- **`pages/models.py`** - new `_with_prefix_matches` reads each pass's ranked queryset through `annotate_score().get_queryset()` and exposes the ranks as two correlated-subquery annotations, so ordering is whole-word score, then prefix score, then `-pk`
- **`pages/tests/test_posts_feed.py`** - regression test for the exact-hides-partial case from the ticket
- **`pages/tests/test_posts_feed.py`** - the old "prefers whole word over prefix" test asserted the bug; it is now an ordering test (Falco before Falconer)
- **`pages/tests/test_posts_feed.py`** - test that body-only hits (whole-word pass only) survive the merge, and that a two-letter author prefix lists more than one author

## ‼️ Risks & Considerations ‼️

- `get_queryset()` is a `PostgresSearchResults` method, not part of the modelsearch base API; the project already pins the Postgres backend (`core.search_backends`) for the unaccent configs, so this adds no new coupling
- The merged queryset runs two correlated tsvector subqueries per candidate post; the feed is a few hundred rows, and the query-count guard test still passes at its existing ceiling
- Any environment that ran with PR #2728 needs `manage.py wagtail_update_index` once: the author autocomplete field it added is only written when a post is reindexed, and `update_index` is django-haystack's command, which skips every Wagtail model

## Peer-review testing steps

1. The `v3` flag must be on (`waffle_flag v3 --everyone` or via admin), and the index must be current (`manage.py wagtail_update_index` after seeding).
2. Open [http://localhost:8000/news/?q=jan](http://localhost:8000/news/?q=jan) on seed data: both "Boost.Charconv review runs Jan 15-25, 2024" (whole-word, first) and "Ruben's January update: presenting Boost.MySQL's new pool!" (prefix) are listed. Before this fix, only the Jan post showed.
3. Search `january`: only Ruben's post is listed, confirming the whole-word pass still ranks an exact hit above a merely-related one.
4. Open [http://localhost:8000/news/?q=ma](http://localhost:8000/news/?q=ma): posts by Matt Borland and Mark Cooper are both listed by author-name prefix, alongside other `ma`-prefixed title matches.
5. Search `m` (one letter): only whole-word hits show (no prefix scan kicks in), confirming the two-letter floor still holds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved feed search to combine whole-word and prefix matches.
  * Search results now prioritize whole-word matches while retaining relevant prefix matches.
  * Two-letter searches now support prefix matching.

* **Bug Fixes**
  * Improved ranking for author and body matches.
  * Ensured exact author matches no longer exclude relevant prefix results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->