### PR TITLE
Story 2668: Add update and remove buttons for Image Post Editing

### DIFF
--- a/news/tests/test_v3_post_image_removal.py
+++ b/news/tests/test_v3_post_image_removal.py
@@ -142,3 +142,17 @@ class TestRemoveImage:
         assert 'name="remove_image"' in content
         # The preview hands its click target to the Replace control.
         assert 'aria-label="Change file"' not in content
+
+    def test_the_controls_open_confirmation_popovers(self, tp, post, user):
+        with tp.login(user):
+            response = tp.get("v3-news-edit", slug=post.slug)
+
+        content = response.content.decode()
+        assert 'id="field-image-replace-menu"' in content
+        assert 'id="field-image-remove-menu"' in content
+        assert "Are you sure you want to remove the image?" in content
+        assert ">Cancel</button>" in content
+        assert ">Remove</button>" in content
+        # Each trigger is wired to the popover it controls.
+        assert 'aria-controls="field-image-replace-menu"' in content
+        assert 'aria-controls="field-image-remove-menu"' in content

--- a/news/tests/test_v3_post_image_removal.py
+++ b/news/tests/test_v3_post_image_removal.py
@@ -86,6 +86,12 @@ def submit(tp, page, **overrides):
     return tp.post("v3-news-edit", slug=page.slug, data=data)
 
 
+def replace_menu(content):
+    """The markup of the Replace popover alone."""
+    start = content.index('id="field-image-replace-menu"')
+    return content[start : content.index("</div>", start)]
+
+
 def latest_image(page):
     # `latest_revision` is an FK cached on the instance, so the revision the
     # POST just created is only visible after a refetch.
@@ -156,3 +162,34 @@ class TestRemoveImage:
         # Each trigger is wired to the popover it controls.
         assert 'aria-controls="field-image-replace-menu"' in content
         assert 'aria-controls="field-image-remove-menu"' in content
+
+    def test_the_replace_popover_always_prompts_for_a_file(self, tp, post, user):
+        """It must not echo the current file name back — it asks for a new one."""
+        with tp.login(user):
+            response = tp.get("v3-news-edit", slug=post.slug)
+
+        menu = replace_menu(response.content.decode())
+        assert "Choose File" in menu
+        assert "fileName" not in menu
+
+
+class TestCreatePage:
+    """The create page shares this field, and shows the popovers once a file is
+    picked client-side — which is where the prompt regressed."""
+
+    def test_the_field_carries_the_controls_before_any_image(self, tp, user):
+        with tp.login(user):
+            response = tp.get("v3-news-create")
+
+        content = response.content.decode()
+        assert 'aria-label="Replace image"' in content
+        assert 'aria-label="Remove image"' in content
+        assert 'name="remove_image"' in content
+
+    def test_the_replace_popover_always_prompts_for_a_file(self, tp, user):
+        with tp.login(user):
+            response = tp.get("v3-news-create")
+
+        menu = replace_menu(response.content.decode())
+        assert "Choose File" in menu
+        assert "fileName" not in menu

--- a/news/tests/test_v3_post_image_removal.py
+++ b/news/tests/test_v3_post_image_removal.py
@@ -1,0 +1,144 @@
+"""Removing — not just replacing — the image on a v3 post (issue #2668).
+
+`set_page_attrs` only ever assigned `page.image` when a file was uploaded, so
+there was no submission that could clear it. The create/edit template now posts
+`remove_image=1` from the "Remove Image" button beside the preview.
+"""
+
+from io import BytesIO
+
+import pytest
+import waffle.testutils
+from django.contrib.auth.models import Group
+from django.core.files.images import ImageFile
+from django.utils.timezone import now
+from PIL import Image as PILImage
+from wagtail.images.models import Image
+from wagtail.models import GroupApprovalTask, Workflow, WorkflowPage, WorkflowTask
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def v3_flag():
+    with waffle.testutils.override_flag("v3", active=True):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def site(wagtail_site):
+    """The view redirects to the index page's URL, which is None without a site."""
+
+
+@pytest.fixture(autouse=True)
+def post_workflow(post_index_page):
+    """The moderation workflow that submitting an edit starts.
+
+    Wagtail ships its default workflow as migration data, which --no-migrations
+    skips, and the view calls `get_workflow().start()` unconditionally.
+    """
+    workflow = Workflow.objects.create(name="Moderators approval")
+    task = GroupApprovalTask.objects.create(name="Moderators approval")
+    task.groups.set([Group.objects.create(name="Moderators")])
+    WorkflowTask.objects.create(workflow=workflow, task=task, sort_order=0)
+    WorkflowPage.objects.create(workflow=workflow, page=post_index_page)
+    return workflow
+
+
+def png_file(name):
+    """A real PNG, so Wagtail can generate a rendition for the preview."""
+    buffer = BytesIO()
+    PILImage.new("RGB", (100, 100), color=(155, 0, 0)).save(buffer, "png")
+    buffer.seek(0)
+    buffer.name = name
+    return buffer
+
+
+@pytest.fixture
+def wagtail_image():
+    file = png_file("original.png")
+    return Image.objects.create(
+        title="original.png",
+        file=ImageFile(file, name=file.name),
+        width=100,
+        height=100,
+    )
+
+
+@pytest.fixture
+def post(make_post_page, user, wagtail_image):
+    """A post owned by `user`, with an image and an open edit window."""
+    page = make_post_page(owner=user, image=wagtail_image)
+    page.save_revision()
+    return page
+
+
+def submit(tp, page, **overrides):
+    """POST the edit form for `page`, echoing back its current values."""
+    data = {
+        "post_type": page.post_content_type.lower(),
+        "title": page.title,
+        "content": page.content[0].value,
+        "description": page.summary,
+        "publish_at": now().strftime("%Y-%m-%dT%H:%M"),
+    }
+    data.update(overrides)
+    return tp.post("v3-news-edit", slug=page.slug, data=data)
+
+
+def latest_image(page):
+    # `latest_revision` is an FK cached on the instance, so the revision the
+    # POST just created is only visible after a refetch.
+    page.refresh_from_db()
+    return page.get_latest_revision_as_object().image
+
+
+class TestRemoveImage:
+    def test_the_flag_clears_the_image(self, tp, post, user):
+        with tp.login(user):
+            submit(tp, post, remove_image="1")
+
+        assert latest_image(post) is None
+
+    def test_without_the_flag_the_image_is_kept(self, tp, post, user, wagtail_image):
+        """The original behaviour: an edit that touches nothing else keeps it."""
+        with tp.login(user):
+            submit(tp, post)
+
+        assert latest_image(post) == wagtail_image
+
+    def test_an_empty_flag_is_not_a_removal(self, tp, post, user, wagtail_image):
+        """What the hidden input posts while the button has not been pressed."""
+        with tp.login(user):
+            submit(tp, post, remove_image="")
+
+        assert latest_image(post) == wagtail_image
+
+    def test_a_new_upload_wins_over_the_flag(self, tp, post, user, wagtail_image):
+        """A stale flag must not discard the file the author just chose."""
+        with tp.login(user):
+            submit(tp, post, remove_image="1", image=png_file("replacement.png"))
+
+        replacement = latest_image(post)
+        assert replacement is not None
+        assert replacement != wagtail_image
+
+    def test_the_flag_is_harmless_with_no_image(self, tp, make_post_page, user):
+        page = make_post_page(owner=user)
+        page.save_revision()
+
+        with tp.login(user):
+            submit(tp, page, remove_image="1")
+
+        assert latest_image(page) is None
+
+    def test_the_edit_page_offers_the_controls(self, tp, post, user):
+        with tp.login(user):
+            response = tp.get("v3-news-edit", slug=post.slug)
+
+        content = response.content.decode()
+        assert 'aria-label="Replace image"' in content
+        assert 'aria-label="Remove image"' in content
+        assert 'name="remove_image"' in content
+        # The preview hands its click target to the Replace control.
+        assert 'aria-label="Change file"' not in content

--- a/news/views.py
+++ b/news/views.py
@@ -587,6 +587,7 @@ class V3AllTypesCreateView(V3Mixin, AllTypesCreateView):
         related_libraries: list,
         block_name: str,
         post_type: str,
+        remove_image: bool = False,
     ):
         cleaned_data = form.cleaned_data
         page.title = cleaned_data.get("title")
@@ -607,6 +608,8 @@ class V3AllTypesCreateView(V3Mixin, AllTypesCreateView):
                 file=image,
             )
             page.image = wagtail_image
+        elif remove_image:
+            page.image = None
         tags = []
         if related_libraries:
             for library in related_libraries:
@@ -671,6 +674,7 @@ class V3AllTypesCreateView(V3Mixin, AllTypesCreateView):
                         block_name=block_name,
                         post_type=post_type,
                         related_libraries=post_data.getlist("related_libraries"),
+                        remove_image=bool(post_data.get("remove_image")),
                     )
                 except Library.DoesNotExist:
                     return self.error_message_and_render(
@@ -861,6 +865,7 @@ class V3AllTypesEditView(V3AllTypesCreateView):
                     block_name=block_name,
                     post_type=post_type,
                     related_libraries=post_data.getlist("related_libraries"),
+                    remove_image=bool(post_data.get("remove_image")),
                 )
                 page.save_revision(user=request.user)
                 if not page.workflow_in_progress:

--- a/static/css/v3/forms.css
+++ b/static/css/v3/forms.css
@@ -759,6 +759,56 @@
   object-fit: cover;
 }
 
+/* Overlaid Replace/Remove controls, which take the preview's own click target */
+.field__image-preview-wrapper--actions {
+  position: relative;
+  cursor: default;
+}
+
+.field__image-actions {
+  position: absolute;
+  top: var(--space-medium, 12px);
+  right: var(--space-medium, 12px);
+  display: flex;
+  gap: var(--space-default, 8px);
+}
+
+.field__image-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 48px;
+  padding: 0 var(--space-large, 16px);
+  background-color: var(--color-surface-weak, #fff);
+  border: 1px solid var(--color-stroke-weak, #0508161a);
+  border-radius: var(--border-radius-xl, 12px);
+  color: var(--color-text-primary, #050816);
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.field__image-action:hover {
+  border-color: var(--color-stroke-link-accent);
+  color: var(--color-text-link-accent);
+}
+
+.field__image-action:focus-visible {
+  outline: 2px solid var(--color-stroke-link-accent, #1f3044);
+  outline-offset: 2px;
+}
+
+.field__image-action--remove,
+.field__image-action--remove:hover {
+  background-color: var(--color-surface-error-weak, #fdf2f2);
+  color: var(--color-text-error, #d32f2f);
+}
+
+.field__image-action--remove:hover {
+  border-color: var(--color-error-strong);
+}
+
 .field__input--file {
   position: absolute;
   inset: 0;

--- a/static/css/v3/forms.css
+++ b/static/css/v3/forms.css
@@ -765,10 +765,13 @@
   cursor: default;
 }
 
-.field__image-actions {
+.field__image-overlay {
   position: absolute;
   top: var(--space-medium, 12px);
   right: var(--space-medium, 12px);
+}
+
+.field__image-actions {
   display: flex;
   gap: var(--space-default, 8px);
 }
@@ -785,6 +788,7 @@
   color: var(--color-text-primary, #050816);
   cursor: pointer;
   transition:
+    background-color 0.15s ease,
     border-color 0.15s ease,
     color 0.15s ease;
 }
@@ -794,19 +798,63 @@
   color: var(--color-text-link-accent);
 }
 
+.field__image-action[aria-expanded="true"] {
+  background-color: var(--color-surface-strong, #efeff1);
+}
+
 .field__image-action:focus-visible {
   outline: 2px solid var(--color-stroke-link-accent, #1f3044);
   outline-offset: 2px;
 }
 
-.field__image-action--remove,
-.field__image-action--remove:hover {
+.field__image-action--remove:hover,
+.field__image-action--remove[aria-expanded="true"] {
   background-color: var(--color-surface-error-weak, #fdf2f2);
   color: var(--color-text-error, #d32f2f);
 }
 
 .field__image-action--remove:hover {
   border-color: var(--color-error-strong);
+}
+
+.field__image-menu {
+  position: absolute;
+  top: calc(100% + var(--space-large, 16px));
+  right: 0;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-default, 8px);
+  width: 209px;
+  padding: var(--space-large, 16px);
+  background-color: var(--color-surface-weak, #fff);
+  border: 1px solid var(--color-stroke-weak, #0508161a);
+  border-radius: var(--border-radius-xl, 12px);
+  text-align: left;
+  cursor: default;
+}
+
+.field__image-menu .btn {
+  width: 100%;
+}
+
+.field__image-menu-text {
+  display: flex;
+  align-items: center;
+  min-height: 32px;
+  margin: 0;
+  padding: 0 var(--space-large, 16px);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-small, 14px);
+  font-weight: var(--font-weight-regular, 400);
+  line-height: var(--line-height-relaxed, 1.24);
+  color: var(--color-text-primary, #050816);
+}
+
+.field__image-menu-file {
+  width: 100%;
+  font: inherit;
+  color: inherit;
 }
 
 .field__input--file {

--- a/static/css/v3/forms.css
+++ b/static/css/v3/forms.css
@@ -857,6 +857,11 @@
   color: inherit;
 }
 
+/* `.field__file-display` centres its text for the inline control */
+.field__file-display--start {
+  text-align: left;
+}
+
 .field__input--file {
   position: absolute;
   inset: 0;

--- a/templates/news/v3/create.html
+++ b/templates/news/v3/create.html
@@ -182,7 +182,7 @@
             <p class="field__error" id="field-link-description-error" role="alert" x-show="isLink && linkError" x-text="linkError" x-cloak aria-live="polite"></p>
           </div>
 
-          {% include "v3/includes/_field_file.html" with name="image" label="Image" accept="image/png,image/jpeg" preview=True alpine_error="errors.image" error=form.errors.image.0 help_text="This should be a PNG or JPEG format and no larger than 5MB" extra_class="field--file-narrow create-post-page__field-image" preview_url=current_image %}
+          {% include "v3/includes/_field_file.html" with name="image" label="Image" accept="image/png,image/jpeg" preview=True alpine_error="errors.image" error=form.errors.image.0 help_text="This should be a PNG or JPEG format and no larger than 5MB" extra_class="field--file-narrow create-post-page__field-image" preview_url=current_image allow_remove=True %}
 
           {% include "v3/includes/_field_multiselect.html" with name="related_libraries" label="Related Libraries" options=related_libraries_options placeholder="Select" selected_values=related_libraries %}
 

--- a/templates/v3/includes/_field_file.html
+++ b/templates/v3/includes/_field_file.html
@@ -84,9 +84,8 @@
         <span class="field__label">{{ edit_label|default:"Replace image" }}</span>
         <button type="button" class="field__control field__control--file field__image-menu-file" x-ref="chooseFile"
           x-on:click="$refs.fileInput.click()">
-          <span class="field__file-display">
-            <span x-show="!fileName" class="field__file-placeholder">Choose File</span>
-            <span x-show="fileName" x-cloak class="field__file-name" x-text="fileName"></span>
+          <span class="field__file-display field__file-display--start">
+            <span class="field__file-placeholder">Choose File</span>
           </span>
         </button>
         {% if help_text %}<p class="field__help">{{ help_text }}</p>{% endif %}

--- a/templates/v3/includes/_field_file.html
+++ b/templates/v3/includes/_field_file.html
@@ -11,6 +11,12 @@
     extra_class   (optional) — additional classes on the wrapper
     preview       (optional) — if truthy, enables clickable image preview after file selection
     preview_url   (optional) — if preview is truthy, this value will be preloaded into the image field if set
+    allow_remove  (optional) — if truthy, overlays Replace and Remove controls on the preview. Remove clears
+                               it and posts `remove_<name>=1` so the view can drop the stored file. With these
+                               controls the preview itself is no longer a click-to-replace target.
+                               Requires `preview`.
+    edit_label    (optional) — accessible name for the Replace control (default "Replace image")
+    remove_label  (optional) — accessible name for the Remove control (default "Remove image")
     alpine_error  (optional) — Alpine expression for dynamic error binding (e.g. "errors.image")
   Usage:
     {% include "v3/includes/_field_file.html" with name="image" label="Image" accept="image/png,image/jpeg" help_text="PNG or JPEG, max 1MB" %}
@@ -21,8 +27,8 @@
 {% with field_id=id|default:default_id %}
 <div class="field field--file{% if error %} field--error{% endif %}{% if extra_class %} {{ extra_class }}{% endif %}"
      {% if alpine_error %}:class="{ 'field--error': {{ alpine_error }} }"{% endif %}
-     x-data="{ jsReady: false, fileName: ''{% if preview %}, previewUrl: '{{preview_url|escapejs}}'{% endif %} }"
-     x-init="jsReady = true; const form = $el.closest('form'); if (form) form.addEventListener('reset', () => { fileName = '';{% if preview %} if (previewUrl) { URL.revokeObjectURL(previewUrl); previewUrl = '{{preview_url|escapejs}}'; }{% endif %} })">
+     x-data="{ jsReady: false, fileName: ''{% if preview %}, previewUrl: '{{preview_url|escapejs}}'{% endif %}{% if allow_remove %}, cleared: false{% endif %} }"
+     x-init="jsReady = true; const form = $el.closest('form'); if (form) form.addEventListener('reset', () => { fileName = '';{% if preview %} if (previewUrl) { URL.revokeObjectURL(previewUrl); previewUrl = '{{preview_url|escapejs}}'; }{% endif %}{% if allow_remove %} cleared = false;{% endif %} })">
   {% if label %}
   <label class="field__label" for="{{ field_id }}">{{ label }}</label>
   {% endif %}
@@ -43,16 +49,36 @@
       {% if preview %}x-on:change="
         const file = $event.target.files && $event.target.files[0];
         if (previewUrl) { URL.revokeObjectURL(previewUrl); previewUrl = ''; }
-        if (file) { fileName = file.name; previewUrl = URL.createObjectURL(file); } else { fileName = ''; }
+        if (file) { fileName = file.name; previewUrl = URL.createObjectURL(file); } else { fileName = ''; }{% if allow_remove %}
+        cleared = !file;{% endif %}
       "{% else %}x-on:change="fileName = $event.target.files.length ? $event.target.files[0].name : ''"{% endif %}
       {% if alpine_error %}:aria-invalid="!!{{ alpine_error }}" :aria-describedby="{{ alpine_error }} ? 'field-{{ name }}-error' : {% if help_text %}'field-{{ name }}-help'{% else %}null{% endif %}"
       {% elif error %}aria-invalid="true" aria-describedby="field-{{ name }}-error"{% elif help_text %}aria-describedby="field-{{ name }}-help"{% endif %}
     >
   </div>
   {% if preview %}
-  <div class="field__image-preview-wrapper" x-show="previewUrl" x-cloak tabindex="0" role="button" aria-label="Change file" @click="previewUrl && $refs.fileInput.click()" @keydown.enter.prevent="previewUrl && $refs.fileInput.click()" @keydown.space.prevent="previewUrl && $refs.fileInput.click()">
+  <div class="field__image-preview-wrapper{% if allow_remove %} field__image-preview-wrapper--actions{% endif %}" x-show="previewUrl" x-cloak{% if not allow_remove %} tabindex="0" role="button" aria-label="Change file" @click="previewUrl && $refs.fileInput.click()" @keydown.enter.prevent="previewUrl && $refs.fileInput.click()" @keydown.space.prevent="previewUrl && $refs.fileInput.click()"{% endif %}>
     <img :src="previewUrl" alt="" class="field__image-preview">
+    {% if allow_remove %}
+    <div class="field__image-actions">
+      <button type="button" class="field__image-action" aria-label="{{ edit_label|default:'Replace image' }}" x-on:click="$refs.fileInput.click()">
+        {% include "includes/icon.html" with icon_name="pixel-pencil" icon_size=16 icon_viewbox="0 0 16 16" only %}
+      </button>
+      <button type="button" class="field__image-action field__image-action--remove" aria-label="{{ remove_label|default:'Remove image' }}"
+        x-on:click="
+          if (previewUrl) { URL.revokeObjectURL(previewUrl); previewUrl = ''; }
+          fileName = '';
+          if ($refs.fileInput) { $refs.fileInput.value = ''; }
+          cleared = true;
+        ">
+        {% include "includes/icon.html" with icon_name="pixel-trash" icon_size=16 icon_viewbox="0 0 16 16" only %}
+      </button>
+    </div>
+    {% endif %}
   </div>
+  {% if allow_remove %}
+  <input type="hidden" name="remove_{{ name }}" :value="cleared ? '1' : ''">
+  {% endif %}
   {% endif %}
   {% if alpine_error %}
   <p class="field__error" id="field-{{ name }}-error" role="alert" x-show="{{ alpine_error }}" x-text="{{ alpine_error }}" x-cloak aria-live="polite"></p>

--- a/templates/v3/includes/_field_file.html
+++ b/templates/v3/includes/_field_file.html
@@ -11,12 +11,13 @@
     extra_class   (optional) — additional classes on the wrapper
     preview       (optional) — if truthy, enables clickable image preview after file selection
     preview_url   (optional) — if preview is truthy, this value will be preloaded into the image field if set
-    allow_remove  (optional) — if truthy, overlays Replace and Remove controls on the preview. Remove clears
-                               it and posts `remove_<name>=1` so the view can drop the stored file. With these
-                               controls the preview itself is no longer a click-to-replace target.
-                               Requires `preview`.
+    allow_remove  (optional) — if truthy, overlays Replace and Remove controls on the preview. Each opens a
+                               popover: Replace offers the file picker, Remove asks for confirmation and then
+                               clears the preview and posts `remove_<name>=1` so the view can drop the stored
+                               file.
     edit_label    (optional) — accessible name for the Replace control (default "Replace image")
     remove_label  (optional) — accessible name for the Remove control (default "Remove image")
+    remove_prompt (optional) — confirmation question (default "Are you sure you want to remove the image?")
     alpine_error  (optional) — Alpine expression for dynamic error binding (e.g. "errors.image")
   Usage:
     {% include "v3/includes/_field_file.html" with name="image" label="Image" accept="image/png,image/jpeg" help_text="PNG or JPEG, max 1MB" %}
@@ -27,8 +28,8 @@
 {% with field_id=id|default:default_id %}
 <div class="field field--file{% if error %} field--error{% endif %}{% if extra_class %} {{ extra_class }}{% endif %}"
      {% if alpine_error %}:class="{ 'field--error': {{ alpine_error }} }"{% endif %}
-     x-data="{ jsReady: false, fileName: ''{% if preview %}, previewUrl: '{{preview_url|escapejs}}'{% endif %}{% if allow_remove %}, cleared: false{% endif %} }"
-     x-init="jsReady = true; const form = $el.closest('form'); if (form) form.addEventListener('reset', () => { fileName = '';{% if preview %} if (previewUrl) { URL.revokeObjectURL(previewUrl); previewUrl = '{{preview_url|escapejs}}'; }{% endif %}{% if allow_remove %} cleared = false;{% endif %} })">
+     x-data="{ jsReady: false, fileName: ''{% if preview %}, previewUrl: '{{preview_url|escapejs}}'{% endif %}{% if allow_remove %}, cleared: false, menu: ''{% endif %} }"
+     x-init="jsReady = true; const form = $el.closest('form'); if (form) form.addEventListener('reset', () => { fileName = '';{% if preview %} if (previewUrl) { URL.revokeObjectURL(previewUrl); previewUrl = '{{preview_url|escapejs}}'; }{% endif %}{% if allow_remove %} cleared = false; menu = '';{% endif %} })">
   {% if label %}
   <label class="field__label" for="{{ field_id }}">{{ label }}</label>
   {% endif %}
@@ -50,7 +51,8 @@
         const file = $event.target.files && $event.target.files[0];
         if (previewUrl) { URL.revokeObjectURL(previewUrl); previewUrl = ''; }
         if (file) { fileName = file.name; previewUrl = URL.createObjectURL(file); } else { fileName = ''; }{% if allow_remove %}
-        cleared = !file;{% endif %}
+        cleared = !file;
+        menu = '';{% endif %}
       "{% else %}x-on:change="fileName = $event.target.files.length ? $event.target.files[0].name : ''"{% endif %}
       {% if alpine_error %}:aria-invalid="!!{{ alpine_error }}" :aria-describedby="{{ alpine_error }} ? 'field-{{ name }}-error' : {% if help_text %}'field-{{ name }}-help'{% else %}null{% endif %}"
       {% elif error %}aria-invalid="true" aria-describedby="field-{{ name }}-error"{% elif help_text %}aria-describedby="field-{{ name }}-help"{% endif %}
@@ -60,19 +62,50 @@
   <div class="field__image-preview-wrapper{% if allow_remove %} field__image-preview-wrapper--actions{% endif %}" x-show="previewUrl" x-cloak{% if not allow_remove %} tabindex="0" role="button" aria-label="Change file" @click="previewUrl && $refs.fileInput.click()" @keydown.enter.prevent="previewUrl && $refs.fileInput.click()" @keydown.space.prevent="previewUrl && $refs.fileInput.click()"{% endif %}>
     <img :src="previewUrl" alt="" class="field__image-preview">
     {% if allow_remove %}
-    <div class="field__image-actions">
-      <button type="button" class="field__image-action" aria-label="{{ edit_label|default:'Replace image' }}" x-on:click="$refs.fileInput.click()">
-        {% include "includes/icon.html" with icon_name="pixel-pencil" icon_size=16 icon_viewbox="0 0 16 16" only %}
-      </button>
-      <button type="button" class="field__image-action field__image-action--remove" aria-label="{{ remove_label|default:'Remove image' }}"
-        x-on:click="
-          if (previewUrl) { URL.revokeObjectURL(previewUrl); previewUrl = ''; }
-          fileName = '';
-          if ($refs.fileInput) { $refs.fileInput.value = ''; }
-          cleared = true;
-        ">
-        {% include "includes/icon.html" with icon_name="pixel-trash" icon_size=16 icon_viewbox="0 0 16 16" only %}
-      </button>
+    <div class="field__image-overlay" x-on:click.outside="menu = ''" x-on:keydown.escape.window="if (menu) { const t = menu; menu = ''; $refs[t === 'edit' ? 'editTrigger' : 'removeTrigger'].focus(); }">
+      <div class="field__image-actions">
+        <button type="button" class="field__image-action" x-ref="editTrigger"
+          aria-label="{{ edit_label|default:'Replace image' }}" aria-haspopup="true"
+          aria-controls="{{ field_id }}-replace-menu" :aria-expanded="menu === 'edit'"
+          x-on:click="menu = menu === 'edit' ? '' : 'edit'; if (menu) $nextTick(() => $refs.chooseFile.focus())">
+          {% include "includes/icon.html" with icon_name="pixel-pencil" icon_size=16 icon_viewbox="0 0 16 16" only %}
+        </button>
+        <button type="button" class="field__image-action field__image-action--remove" x-ref="removeTrigger"
+          aria-label="{{ remove_label|default:'Remove image' }}" aria-haspopup="true"
+          aria-controls="{{ field_id }}-remove-menu" :aria-expanded="menu === 'remove'"
+          x-on:click="menu = menu === 'remove' ? '' : 'remove'; if (menu) $nextTick(() => $refs.removeCancel.focus())">
+          {% include "includes/icon.html" with icon_name="pixel-trash" icon_size=16 icon_viewbox="0 0 16 16" only %}
+        </button>
+      </div>
+
+      {% comment %} The real file input stays in the field's own control. This row proxies to it. {% endcomment %}
+      <div class="field__image-menu" id="{{ field_id }}-replace-menu" role="dialog"
+           aria-label="{{ edit_label|default:'Replace image' }}" x-show="menu === 'edit'" x-cloak>
+        <span class="field__label">{{ edit_label|default:"Replace image" }}</span>
+        <button type="button" class="field__control field__control--file field__image-menu-file" x-ref="chooseFile"
+          x-on:click="$refs.fileInput.click()">
+          <span class="field__file-display">
+            <span x-show="!fileName" class="field__file-placeholder">Choose File</span>
+            <span x-show="fileName" x-cloak class="field__file-name" x-text="fileName"></span>
+          </span>
+        </button>
+        {% if help_text %}<p class="field__help">{{ help_text }}</p>{% endif %}
+      </div>
+
+      <div class="field__image-menu" id="{{ field_id }}-remove-menu" role="dialog"
+           aria-label="{{ remove_label|default:'Remove image' }}" x-show="menu === 'remove'" x-cloak>
+        <p class="field__image-menu-text">{{ remove_prompt|default:"Are you sure you want to remove the image?" }}</p>
+        <button type="button" class="btn btn-secondary" x-ref="removeCancel"
+          x-on:click="menu = ''; $refs.removeTrigger.focus()">Cancel</button>
+        <button type="button" class="btn btn-error"
+          x-on:click="
+            if (previewUrl) { URL.revokeObjectURL(previewUrl); previewUrl = ''; }
+            fileName = '';
+            if ($refs.fileInput) { $refs.fileInput.value = ''; }
+            cleared = true;
+            menu = '';
+          ">Remove</button>
+      </div>
     </div>
     {% endif %}
   </div>


### PR DESCRIPTION
# Issue: #2668

## Summary & Context

Authors could only swap a post's image, never take it off. This adds a remove option, and puts both actions on the image itself as two buttons with a short confirmation step.

- **Figma link**: [Buttons on the image](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=4822-29472) · [Remove dialog](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=4748-7199) · [Replace dialog](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=4750-48794) · [Remove button, resting state](https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=4822-29549)
- **Link to components/page:** `localhost:8000/v3/news/add/ and localhost:8000/v3/news/edit/&lt;post-slug&gt;/`

## Changes

1. Two buttons now sit on top of the image in the post form: a pencil to replace it and a bin to remove it. They only appear once there is an image to act on.
2. The pencil opens a small panel with the file picker, so replacing an image works the same way as adding one.
3. The bin opens a small panel asking "Are you sure you want to remove the image?" with **Cancel** and **Remove**. Picking Remove clears the image from the form.
4. Removing now actually saves. Before this, the form had no way to tell the server "there should be no image here", so a cleared image was silently kept. Submitting after Remove drops the image from the post.
5. The image is no longer clickable as a whole. It used to open the file picker wherever you clicked it; the pencil does that now, which also avoids a button sitting inside another clickable area.

## ‼️ Risks & Considerations ‼️

1. **The image field is shared:** the same field is used by the feedback page, the feedback widget, the profile avatar and the examples page. The new buttons are switched on only for the post form, so those four should look and behave exactly as before.
2. **:warning: Nothing is deleted from the server :warning::** `Remove` only unlinks the image from the post, but the file stays in the media library and its URL keeps working, so "removed" does not mean "unreachable". Anyone who needs an image actually gone should ask a moderator to delete it in the CMS. The reason it can't happen here is that `Post` edits go through moderation, and the live post keeps pointing at the old image until approval. Deleting at submit time would set that pointer to null on the live page straight away, thus vanishing the image from the public site before anyone approved it, and if the moderator then rejected the change the file would already be unrecoverable. 
3. **With JavaScript off, images can't be removed.** 
4. **To reproduce on the edit page**, note that a post is only editable by its author for 6 hours after it's first submitted. Easier to test on the create page, where no setup is needed.

**Two small gaps against the frames, left alone on purpose**: 
- The image's corner rounding is 2px in the code, 4px in the design.
- The design crops the preview to a fixed 3:2 shape; the code shows it at its natural height.

## Screenshots

### Create Post
https://github.com/user-attachments/assets/8d993c75-7dc9-47c3-9871-f3e8754dd771

### Edit Post
https://github.com/user-attachments/assets/6e5261ab-b61c-4055-93c1-fec8f66d3335

### Remove Image
https://github.com/user-attachments/assets/c2b564a3-5c14-41f0-9df2-ff6ec5fabf37


## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [ ] Link this PR to the related GitHub Project ticket

### Frontend
- [ ] UI implementation matches Figma design
- [ ] Tested in light and dark mode
- [ ] Responsive / mobile verified
- [ ] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [ ] Test without JavaScript (if applicable) — see note above: the buttons need JavaScript
- [x] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added image management controls to v3 post forms, including Replace and Remove actions.
  - Added confirmation prompts when removing an image.
  - Added support for removing existing images from posts without uploading a replacement.
  - New image uploads take precedence over removal requests.

- **Bug Fixes**
  - Prevented image removal requests from affecting posts without an existing image.
  - Preserved existing images when no removal action is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->