### PR TITLE
Issue #2739 :: Boostlook Theme Does Not Follow System Dark Mode on Initial Load

### DIFF
--- a/static/js/theme_handling.js
+++ b/static/js/theme_handling.js
@@ -99,8 +99,14 @@ function checkmedia() {
 checkmedia();
 
 document.addEventListener("alpine:init", function() {
+  // Match checkmedia()'s window.parent preference: inside the Boostlook docs
+  // srcdoc iframe, matchMedia on the iframe's own window unreliably reports
+  // "no preference" for prefers-color-scheme, which was making the gecko
+  // search widget's own React theme sync (mounted with that stale
+  // data-theme-mode) strip the "dark" class checkmedia() had just applied.
+  const relevantWindow = window.parent || window;
   document.getElementById("gecko-search-button").setAttribute(
     'data-theme-mode',
-    localStorage.getItem("colorMode") || getBrowserColorMode(window)
+    localStorage.getItem("colorMode") || getBrowserColorMode(relevantWindow)
   );
 });


### PR DESCRIPTION
# Issue: #2739

**Branch:** `teo/2739-boostlook-theme-system-dark-mode` · **Base:** `origin/develop`

## Summary & Context

Boostlook's docs iframe ignored the OS dark-mode preference on first load even though the rest of the site honored it correctly, only syncing after a manual toggle. Root cause: `prefers-color-scheme` matchMedia evaluated on the iframe's own `window` is unreliable inside the Boostlook `srcdoc` iframe, and a leftover `getBrowserColorMode(window)` call in the `alpine:init` handler used that unreliable self-check, which fed a stale value into the gecko search widget's React theme sync - that sync then stripped the "dark" class `checkmedia()` had just correctly applied moments earlier.

- **Figma link**: n/a (bug fix, no visual/design change)
- **Link to components/page:** [http://localhost:8000/doc/user-guide/getting-started.html](http://localhost:8000/doc/user-guide/getting-started.html)

## Changes

- **`static/js/theme_handling.js`** - `alpine:init` handler now derives the gecko-search-button's `data-theme-mode` from `window.parent || window`, matching the pattern already used by `checkmedia()`, instead of the iframe's own (unreliable) `window`.

## ‼️ Risks & Considerations ‼️

- Root cause was verified empirically via headless Chrome + CDP (matchMedia on the srcdoc iframe's own window returns false for `prefers-color-scheme: dark` even when the real OS is in dark mode, while `window.parent.matchMedia` correctly returns true) since no automated JS test harness exists in this repo for this file.
- No pytest coverage exists for this client-side theme logic; verification was manual/scripted only.

## Screenshots
Before
<img width="1728" height="964" alt="image" src="https://github.com/user-attachments/assets/88bd9850-21bb-4d9e-8f0e-eb0f144a8b3f" />


After
<img width="1728" height="965" alt="image" src="https://github.com/user-attachments/assets/227e9f13-d842-4eaa-8add-3013f10a2160" />


## Peer-review testing steps

1. Set the OS to dark mode, open a fresh/incognito browser session at `localhost:8000`.
2. From the homepage, click "I'm new to Boost" to load the user-guide docs page.
3. Observe the Boostlook iframe now loads dark immediately, matching the rest of the site, with no toggle needed.
4. Toggle the theme switcher to light, then back to dark, and confirm both the main site and the Boostlook iframe still switch correctly (manual toggle unaffected).
5. Repeat with OS set to light mode to confirm no regression there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved theme detection for embedded content so dark mode remains synchronized with the parent browser window.
  - Prevented embedded widgets from incorrectly switching out of dark mode when the iframe reports no color preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->