### PR TITLE
Fix 2727: add Hide mailing list activity filed to admin

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -94,6 +94,10 @@ class EmailUserAdmin(UserAdmin):
                 )
             },
         ),
+        (
+            _("Privacy"),
+            {"fields": ("hide_mailing_list_activity",)},
+        ),
         (_("Badges"), {"fields": ("badge_summary",)}),
         (
             _("Permissions"),

--- a/users/tests/test_admin.py
+++ b/users/tests/test_admin.py
@@ -187,3 +187,14 @@ def test_admin_save_mints_for_a_user_with_no_key():
     save_in_admin(user)
 
     assert user.profile_routing_keys.get().routing_key.startswith("jane-doe-")
+
+
+def test_change_form_exposes_hide_mailing_list_activity(client, super_user, user):
+    """Staff need to read back the member's own mailing list opt-out here."""
+    client.force_login(super_user)
+
+    html = client.get(
+        reverse("admin:users_user_change", args=[user.pk])
+    ).content.decode()
+
+    assert 'name="hide_mailing_list_activity"' in html


### PR DESCRIPTION
# Issue: #2727

## Summary & Context

Simple fix added to #2727 addressing Cristian's comments regarding the lack of **_Hide mailing list activity_** field in admin.

## Screenshots
### Hide Activity
https://github.com/user-attachments/assets/956a7668-0417-4695-953d-f6c003f0febb

### Unhide Activity
https://github.com/user-attachments/assets/f064f2fd-652e-4e1d-9398-1761be94a2b7

### Peer Testing (as defined originally in #2727)
The card does not render, so the visible half of this feature cannot be observed yet. What can be verified:

1. **The checkbox persists.**
   - Go to `/users/me/?edit=true`.
   - In the visibility section, tick **"Hide your mailing list activity from your profile"** and click **Save changes**.
   - Reload the page. The box is still ticked.
   - Untick it, save, reload. It stays unticked.

2. **The value reaches the database.**
   - In `/admin/`, open the same user under **Users**.
   - `hide_mailing_list_activity` matches the checkbox state from step 1.

3. **The other two toggles are unaffected.**
   - The same section holds "Hide your GitHub activity" and "Hide badges and achievements". Toggle each one on its own, save, reload and you'll notice each persists independently, and toggling the mailing list box does not disturb them.
   - With a GitHub account linked and synced activity, ticking "Hide your GitHub activity" still removes the GitHub card from another user's view of your profile. This confirms the shared save handler wasn't broken.

## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Privacy section to the user administration form, allowing administrators to manage mailing list activity visibility.

* **Tests**
  * Added coverage confirming the privacy setting appears on the user change page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->