### PR TITLE
Task 2746: Add Hero Illustration for Boost Beast

### DIFF
--- a/libraries/constants.py
+++ b/libraries/constants.py
@@ -395,6 +395,22 @@ LIBRARY_GITHUB_URL_OVERRIDES = {
     "outcome": "https://github.com/ned14/outcome/issues",
 }
 
+# Hero art for flagship library sub-pages. Paths are relative to the
+# static-content bucket (the art is too heavy to commit) and LibraryDetail
+# resolves them through large_static(). heros.css composites the two layers
+# rather than using one baked image, which only lines up while background and
+# illustration are exported at the same scale and height. No entry here means the
+# no-illustration hero from #2618, which is the intended fallback.
+# key: Library.slug
+LIBRARY_HERO_ART = {
+    "beast": {
+        "background": "img/v3/library-heros/beast-background.png",
+        "illustration": "img/v3/library-heros/beast.png",
+        # Narrower export of the same animal, swapped in below 768px.
+        "illustration_mobile": "img/v3/library-heros/beast-mobile.png",
+    },
+}
+
 DEFAULT_LIBRARIES_LANDING_VIEW = "list"
 SELECTED_BOOST_VERSION_COOKIE_NAME = "boost_version"
 SELECTED_LIBRARY_VIEW_COOKIE_NAME = "library_view"

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -29,11 +29,16 @@ from mailing_list.mixins import MailingListCardMixin
 from news.services import get_latest_post_cards
 from pages.routing import post_index_url
 from core.mock_data import SharedResources
+from core.templatetags.custom_static import large_static
 from users.models import User
 from versions.exceptions import BoostImportedDataException
 from versions.models import Version
 
-from .constants import COMMIT_EMAIL_STALE_ACTION_ERROR, README_MISSING
+from .constants import (
+    COMMIT_EMAIL_STALE_ACTION_ERROR,
+    LIBRARY_HERO_ART,
+    README_MISSING,
+)
 from .forms import CommitAuthorEmailForm, V3CommitAuthorEmailForm
 from .godbolt import build_compiler_explorer_url
 from .mixins import VersionAlertMixin, BoostVersionMixin, ContributorMixin
@@ -709,11 +714,41 @@ class LibraryDetail(
         )
 
         context["is_flagship_lib"] = self.object.tier == Tier.FLAGSHIP
-        context["library_hero_image_url_light"] = ""
-        context["library_hero_image_url_dark"] = ""
-        context["hero_image_url"] = ""
+        context.update(self.get_hero_art_context())
 
         return context
+
+    def get_hero_art_context(self):
+        """Resolve this library's hero illustration, if one has been drawn for it.
+
+        Keys are prefixed `library_hero_` rather than matching the include's own
+        `hero_image_url_*` names because `{% include %}` hands the parent context to
+        both the flagship and non-flagship hero; a bare name would light up the
+        branch meant to stay plain. The sub-page maps them on the flagship branch.
+
+        One export serves both themes, so the dark slot stays empty: supplying a
+        dark URL is what puts `.hero-fg` in theme-aware mode, which hides the light
+        image under `html.dark` and would blank the hero.
+        """
+        art = LIBRARY_HERO_ART.get(self.object.slug or "", {})
+        # All or nothing: a background with no illustration would still add
+        # `hero--with-bg-and-image` and leave nothing to composite over it.
+        if not art.get("illustration"):
+            art = {}
+
+        def url(key):
+            path = art.get(key)
+            return large_static(path) if path else ""
+
+        return {
+            "library_hero_image_url_light": url("illustration"),
+            "library_hero_image_url_dark": "",
+            "library_hero_image_url_mobile": url("illustration_mobile"),
+            "library_hero_background_image_url": url("background"),
+            # Empty so the include's small-box `.hero__image` stays unused; the
+            # flagship hero paints through the full-bleed `.hero-fg`.
+            "hero_image_url": "",
+        }
 
     def get_missing_version_context(self, context):
         """Add the copy and CTA for the "no records for this version" empty state.

--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -922,35 +922,52 @@ html.dark .hero__links .btn-icon-library:hover {
   }
 }
 
-/* Flagship library, 768px up: the shared scrim's stops are percentages of the
-   viewport, but the text column is a fixed 662px, so how much of it gets covered
-   moves with the window — the description tail measured 1.09:1 at 1024 and 1.63:1
-   against the 3.0:1 its 24px type needs. Anchor the stops to the block instead;
-   `--o` is the block's left edge once the 1440 cap starts centring it.
-   Ends at 800 so the wash stays off the illustration, which starts at 881 at 1440
-   and 825 at 1279 (measured as the leftmost painted pixel, not the frame edge).
-   The taper is steep rather than long for the same reason: the description runs to
-   648, so the alpha has to hold that far and then clear the art within 150px.
-   Holds 3.2:1 or better on the description everywhere from 1279 up. */
-@media (min-width: 768px) {
+/* Flagship library, desktop. The shared scrim's stops are viewport percentages,
+   but the text column is a fixed 662px, so coverage moved with the window and the
+   description tail measured as low as 1.09:1 against the 3.0:1 its 24px type needs.
+   These stops are anchored to the block instead; `--o` is the block's left edge
+   once the 1440 cap starts centring it.
+   Alpha rises slightly left to right on purpose. The savanna brightens towards the
+   horizon, so a flat wash reads heavy over the dark scrub and weak under the text.
+   0.36-0.40 works only because the description is white here rather than the
+   grey-400 the shared rule gives it: 3.42:1 on the description and 3.56:1 on the
+   title, both measured in their own bands. With grey-400 it needs 0.52-0.56.
+   Ends at 900, past the art's leading edge (881 at 1440, 825 at 1280). The art
+   paints above this layer, so the overlap is hidden where the animal is opaque and
+   continuous in the gaps around it; alpha there is 0.17 at 1280, the widest case.
+   1280 rather than 768 because the tablet block below replaces the background for
+   the rest of the range. */
+/* White rather than the grey-400 the shared `.hero--with-bg-and-image` rule sets.
+   Grey on the wash is what forced the scrim dark: at grey-400 the description needs
+   alpha 0.52 to clear 3.0:1, at white it clears it at 0.36, so this one line buys a
+   third off the wash. `.hero--community` already does the same thing below. */
+.hero--library .hero__description {
+  color: #fff;
+}
+
+@media (min-width: 1280px) {
   .hero--library.hero--with-background-image::before {
     --o: max(0px, (100% - 1440px) / 2);
 
     background: linear-gradient(
       90deg,
-      rgba(0, 0, 0, 0.72) 0%,
-      rgba(0, 0, 0, 0.72) var(--o),
-      rgba(0, 0, 0, 0.62) calc(var(--o) + 420px),
-      rgba(0, 0, 0, 0.50) calc(var(--o) + 680px),
-      /* Eased rather than linear to the end. A straight ramp ends in a slope
-         discontinuity, which the eye reads as a vertical seam (Mach band); these
-         stops approach zero asymptotically so the tail disappears instead. Same
-         endpoint and same alpha at the text, so contrast is unchanged. */
-      rgba(0, 0, 0, 0.30) calc(var(--o) + 716px),
-      rgba(0, 0, 0, 0.16) calc(var(--o) + 746px),
-      rgba(0, 0, 0, 0.07) calc(var(--o) + 770px),
-      rgba(0, 0, 0, 0.02) calc(var(--o) + 787px),
-      rgba(0, 0, 0, 0) calc(var(--o) + 800px)
+      rgba(0, 0, 0, 0.36) 0%,
+      rgba(0, 0, 0, 0.36) var(--o),
+      rgba(0, 0, 0, 0.38) calc(var(--o) + 320px),
+      rgba(0, 0, 0, 0.40) calc(var(--o) + 600px),
+      /* Smootherstep (6t^5 - 15t^4 + 10t^3) over a 300px zone. A seam is a slope
+         discontinuity, so the curve is picked for zero slope at both ends, and the
+         width holds the peak to 0.0024 alpha/px. Narrower zones showed a visible
+         line at 0.034, 0.012 and 0.0067. Judge changes by peak slope, not stops. */
+      rgba(0, 0, 0, 0.40) calc(var(--o) + 633px),
+      rgba(0, 0, 0, 0.37) calc(var(--o) + 667px),
+      rgba(0, 0, 0, 0.32) calc(var(--o) + 700px),
+      rgba(0, 0, 0, 0.24) calc(var(--o) + 733px),
+      rgba(0, 0, 0, 0.16) calc(var(--o) + 767px),
+      rgba(0, 0, 0, 0.08) calc(var(--o) + 800px),
+      rgba(0, 0, 0, 0.03) calc(var(--o) + 833px),
+      rgba(0, 0, 0, 0.01) calc(var(--o) + 867px),
+      rgba(0, 0, 0, 0) calc(var(--o) + 900px)
     );
   }
 }

--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -882,13 +882,158 @@ html.dark .hero__links .btn-icon-library:hover {
    ═══════════════════════════════════════════════════════════════════════════ */
 
 /* Flagship library: Figma draws the illustration as a 1440x480 layer filling the
-   hero, animals right-anchored (x=321), with the text laid over it. The shipped
-   art is a 488x416 crop of just the animals, so `contain` scales it to the block's
-   full height and `right bottom` pins it to the corner the design anchors it to.
-   Height now comes from the block, so the art can no longer overhang the hero
-   background the way the old fixed 488x416 box did in the tablet band. */
+   hero, animals right-anchored (x=321), with the text laid over it. It ships as
+   two layers rather than one baked image — a background filling the block and an
+   animal on top — so `contain` scales the animal to the block's full height and
+   `right bottom` pins it where the design anchors it. Height comes from the block,
+   so the art can no longer overhang the background the way the old fixed 488x416
+   placeholder did in the tablet band. See LIBRARY_HERO_ART in
+   libraries/constants.py for why the layers line up. */
 .hero--library .hero-fg__img {
   object-position: right bottom;
+}
+
+/* Flagship library, 768px up: hold the figure clear of the header. `.hero__block`
+   reserves room for the absolutely-positioned header with `padding-top`, which is
+   why the text clears it, but `.hero-fg` is positioned against the block's padding
+   box and so spans the full height and slides underneath. Short bottom-weighted
+   art never noticed; this animal fills the frame top to bottom (Figma draws it 483
+   tall in a 480 hero), so its raised paw and mane sat behind the opaque nav pills —
+   10% of the art at desktop, 13% at tablet, where the header stays 64 while the
+   block drops to 400. Inset the top by the header's own footprint and let
+   `inset-block-end: 0` size it, so `contain` fits the animal into the visible band.
+   Costs ~13% of its size; art with headroom baked in could drop this. */
+@media (min-width: 768px) {
+  .hero--library .hero-fg {
+    top: var(--v3-header-footprint);
+    height: auto;
+  }
+}
+
+/* Flagship library, tablet: `contain` fits the animal to the block's height, and
+   the tablet block is short (400) for its width, so the animal claims ~71% of a
+   768px viewport where the design gives it 46%. The 662px text column then runs
+   under it, putting the description tail on the animal's trousers. Same cap and
+   same value the community hero uses for this collision a few rules down; worst
+   case is a 3-line description at 286px in the 400px block, so nothing spills. */
+@media (min-width: 768px) and (max-width: 1279px) {
+  .hero--library .hero__content {
+    max-width: min(615px, 50vw);
+  }
+}
+
+/* Flagship library, 768px up: the shared scrim's stops are percentages of the
+   viewport, but the text column is a fixed 662px, so how much of it gets covered
+   moves with the window — the description tail measured 1.09:1 at 1024 and 1.63:1
+   against the 3.0:1 its 24px type needs. Anchor the stops to the block instead;
+   `--o` is the block's left edge once the 1440 cap starts centring it.
+   Ends at 800 so the wash stays off the illustration, which starts at 881 at 1440
+   and 825 at 1279 (measured as the leftmost painted pixel, not the frame edge).
+   The taper is steep rather than long for the same reason: the description runs to
+   648, so the alpha has to hold that far and then clear the art within 150px.
+   Holds 3.2:1 or better on the description everywhere from 1279 up. */
+@media (min-width: 768px) {
+  .hero--library.hero--with-background-image::before {
+    --o: max(0px, (100% - 1440px) / 2);
+
+    background: linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.72) 0%,
+      rgba(0, 0, 0, 0.72) var(--o),
+      rgba(0, 0, 0, 0.62) calc(var(--o) + 420px),
+      rgba(0, 0, 0, 0.50) calc(var(--o) + 680px),
+      /* Eased rather than linear to the end. A straight ramp ends in a slope
+         discontinuity, which the eye reads as a vertical seam (Mach band); these
+         stops approach zero asymptotically so the tail disappears instead. Same
+         endpoint and same alpha at the text, so contrast is unchanged. */
+      rgba(0, 0, 0, 0.30) calc(var(--o) + 716px),
+      rgba(0, 0, 0, 0.16) calc(var(--o) + 746px),
+      rgba(0, 0, 0, 0.07) calc(var(--o) + 770px),
+      rgba(0, 0, 0, 0.02) calc(var(--o) + 787px),
+      rgba(0, 0, 0, 0) calc(var(--o) + 800px)
+    );
+  }
+}
+
+/* Flagship library, tablet: same shape, pulled in again. `contain` fits the
+   animal to the short 400px block, so it starts much further left here than on
+   desktop — 570 at 1024 against 881 at 1440 — and the desktop ramp would run
+   under it. Ends at 560 to stay off the art at 1024 while still covering the
+   capped text column, which ends at 456.
+   Below about 900 the two constraints cross: the description ends at 456 and the
+   art starts at 456, so no ramp both covers the text and clears the animal. This
+   keeps the text legible and lets the tail of the wash reach the art rather than
+   the reverse; closing that needs a narrower text column, which is a design call. */
+@media (min-width: 768px) and (max-width: 1279px) {
+  .hero--library.hero--with-background-image::before {
+    /* The animal is ~456 wide across this whole band (the block stays 400 tall),
+       so it starts at about `100% - 470`. Fade out there — but never tighter than
+       560, which is what the widest capped text column in the band needs. The
+       `max()` is which constraint wins: art clearance from 1024 up, text coverage
+       below it, where the two cross. */
+    --end: max(560px, calc(100% - 470px));
+
+    background: linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.72) 0%,
+      rgba(0, 0, 0, 0.62) calc(var(--end) - 260px),
+      rgba(0, 0, 0, 0.50) calc(var(--end) - 90px),
+      rgba(0, 0, 0, 0) var(--end)
+    );
+  }
+}
+
+/* Flagship library, mobile: `--hero-fg-aspect` (768/672) is tuned to home's and
+   community's art, and it makes the figure declare its own height. This hero's
+   text column is taller than theirs — three description lines and four link
+   buttons over two rows — so content plus figure cleared the shared 600px floor
+   and the block grew to 710, 110px past every other hero. Let the figure take
+   whatever the text leaves instead of asking for a fixed ratio, which holds the
+   block on the floor; `contain` then scales the animal to fit. `margin-top` back
+   to 0 because `flex: 1` absorbs the slack that `auto` was there to absorb. */
+@media (max-width: 767px) {
+  /* `height` as well as the inherited `min-height` floor, so the block is a
+     definite size that flex can divide. Left at auto there is nothing for
+     `flex: 1` to grow into, and the figure falls back to sizing itself from the
+     image's own ratio (289px at 378 wide), which is what put the block at 668.
+     Content is `flex: 0 0 auto` and keeps its full height; only the figure
+     flexes. Beast's text uses 251 of the 472 available, so there is room for a
+     longer description before this needs revisiting.
+     `:not(.hero--no-image)` because the flagship branch adds `hero--library`
+     whether or not art exists, and this rule would otherwise out-order
+     `.hero--no-image .hero__block`'s `height: auto` at equal specificity and hold
+     an illustration-less flagship open at the full 600 — the gap #2618 closed. */
+  .hero--library:not(.hero--no-image) .hero__block {
+    height: var(--hero-block-height);
+    /* The shared mobile padding leaves 32px under the figure, which reads as a
+       gap below the animal's rock. Community zeroes it for the same reason. */
+    padding-bottom: 0;
+  }
+
+  .hero--library .hero-fg {
+    flex: 1;
+    min-height: 0;
+    aspect-ratio: auto;
+    margin-top: 0;
+  }
+}
+
+/* Flagship library, mobile: below 768px the block turns into a column — text on
+   top, animal stacked under — so every line runs the full width and falls past the
+   end of the left-to-right scrim, taking the description to ~1.4:1 over open sky.
+   Same answer as `.hero--home` above: darken the top edge instead of the left.
+   Stronger than home's 0.5 because this text sits lower, where home's gradient has
+   decayed to ~0.3. Out by 60% so the ground still reads as painted; the animal
+   paints above this layer either way. */
+@media (max-width: 767px) {
+  .hero--library.hero--with-background-image::before {
+    background: linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.68) 0%,
+      rgba(0, 0, 0, 0.61) 44%,
+      rgba(0, 0, 0, 0) 60%
+    );
+  }
 }
 
 /* Community: background focal point + tuned per-breakpoint sizing (independent of

--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -922,30 +922,20 @@ html.dark .hero__links .btn-icon-library:hover {
   }
 }
 
-/* Flagship library, desktop. The shared scrim's stops are viewport percentages,
-   but the text column is a fixed 662px, so coverage moved with the window and the
-   description tail measured as low as 1.09:1 against the 3.0:1 its 24px type needs.
-   These stops are anchored to the block instead; `--o` is the block's left edge
-   once the 1440 cap starts centring it.
-   Alpha rises slightly left to right on purpose. The savanna brightens towards the
-   horizon, so a flat wash reads heavy over the dark scrub and weak under the text.
-   0.36-0.40 works only because the description is white here rather than the
-   grey-400 the shared rule gives it: 3.42:1 on the description and 3.56:1 on the
-   title, both measured in their own bands. With grey-400 it needs 0.52-0.56.
-   Ends at 900, past the art's leading edge (881 at 1440, 825 at 1280). The art
-   paints above this layer, so the overlap is hidden where the animal is opaque and
-   continuous in the gaps around it; alpha there is 0.17 at 1280, the widest case.
-   1280 rather than 768 because the tablet block below replaces the background for
-   the rest of the range. */
-/* White rather than the grey-400 the shared `.hero--with-bg-and-image` rule sets.
-   Grey on the wash is what forced the scrim dark: at grey-400 the description needs
-   alpha 0.52 to clear 3.0:1, at white it clears it at 0.36, so this one line buys a
-   third off the wash. `.hero--community` already does the same thing below. */
+/* Stops are anchored to the block, not the viewport: the text column is a fixed
+   662px, so percentage stops moved coverage with the window. `--o` is the block's
+   left edge once the 1440 cap starts centring it.
+   Alpha rises left to right on purpose, because the savanna brightens towards the
+   horizon. One gradient serves 768 up; the plateau reaches 550, past the end of the
+   description at every width in that range. */
+/* White rather than the grey-400 the shared rule sets. Grey is what forced the
+   scrim dark, so raising the alpha below without reverting this will not help.
+   `.hero--community` does the same. */
 .hero--library .hero__description {
   color: #fff;
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 768px) {
   .hero--library.hero--with-background-image::before {
     --o: max(0px, (100% - 1440px) / 2);
 
@@ -954,48 +944,20 @@ html.dark .hero__links .btn-icon-library:hover {
       rgba(0, 0, 0, 0.36) 0%,
       rgba(0, 0, 0, 0.36) var(--o),
       rgba(0, 0, 0, 0.38) calc(var(--o) + 320px),
-      rgba(0, 0, 0, 0.40) calc(var(--o) + 600px),
-      /* Smootherstep (6t^5 - 15t^4 + 10t^3) over a 300px zone. A seam is a slope
-         discontinuity, so the curve is picked for zero slope at both ends, and the
-         width holds the peak to 0.0024 alpha/px. Narrower zones showed a visible
-         line at 0.034, 0.012 and 0.0067. Judge changes by peak slope, not stops. */
-      rgba(0, 0, 0, 0.40) calc(var(--o) + 633px),
-      rgba(0, 0, 0, 0.37) calc(var(--o) + 667px),
-      rgba(0, 0, 0, 0.32) calc(var(--o) + 700px),
-      rgba(0, 0, 0, 0.24) calc(var(--o) + 733px),
-      rgba(0, 0, 0, 0.16) calc(var(--o) + 767px),
-      rgba(0, 0, 0, 0.08) calc(var(--o) + 800px),
-      rgba(0, 0, 0, 0.03) calc(var(--o) + 833px),
-      rgba(0, 0, 0, 0.01) calc(var(--o) + 867px),
-      rgba(0, 0, 0, 0) calc(var(--o) + 900px)
-    );
-  }
-}
-
-/* Flagship library, tablet: same shape, pulled in again. `contain` fits the
-   animal to the short 400px block, so it starts much further left here than on
-   desktop — 570 at 1024 against 881 at 1440 — and the desktop ramp would run
-   under it. Ends at 560 to stay off the art at 1024 while still covering the
-   capped text column, which ends at 456.
-   Below about 900 the two constraints cross: the description ends at 456 and the
-   art starts at 456, so no ramp both covers the text and clears the animal. This
-   keeps the text legible and lets the tail of the wash reach the art rather than
-   the reverse; closing that needs a narrower text column, which is a design call. */
-@media (min-width: 768px) and (max-width: 1279px) {
-  .hero--library.hero--with-background-image::before {
-    /* The animal is ~456 wide across this whole band (the block stays 400 tall),
-       so it starts at about `100% - 470`. Fade out there — but never tighter than
-       560, which is what the widest capped text column in the band needs. The
-       `max()` is which constraint wins: art clearance from 1024 up, text coverage
-       below it, where the two cross. */
-    --end: max(560px, calc(100% - 470px));
-
-    background: linear-gradient(
-      90deg,
-      rgba(0, 0, 0, 0.72) 0%,
-      rgba(0, 0, 0, 0.62) calc(var(--end) - 260px),
-      rgba(0, 0, 0, 0.50) calc(var(--end) - 90px),
-      rgba(0, 0, 0, 0) var(--end)
+      rgba(0, 0, 0, 0.40) calc(var(--o) + 550px),
+      /* Smootherstep over 450px. A seam is a slope discontinuity, so the curve is
+         picked for zero slope at both ends. Judge changes by peak slope, not by
+         stop count; anything above ~0.003 alpha/px reads as a line. */
+      rgba(0, 0, 0, 0.40) calc(var(--o) + 591px),
+      rgba(0, 0, 0, 0.38) calc(var(--o) + 632px),
+      rgba(0, 0, 0, 0.35) calc(var(--o) + 673px),
+      rgba(0, 0, 0, 0.30) calc(var(--o) + 714px),
+      rgba(0, 0, 0, 0.23) calc(var(--o) + 755px),
+      rgba(0, 0, 0, 0.17) calc(var(--o) + 795px),
+      rgba(0, 0, 0, 0.10) calc(var(--o) + 836px),
+      rgba(0, 0, 0, 0.05) calc(var(--o) + 877px),
+      rgba(0, 0, 0, 0.02) calc(var(--o) + 918px),
+      rgba(0, 0, 0, 0) calc(var(--o) + 959px)
     );
   }
 }
@@ -1038,16 +1000,14 @@ html.dark .hero__links .btn-icon-library:hover {
 /* Flagship library, mobile: below 768px the block turns into a column — text on
    top, animal stacked under — so every line runs the full width and falls past the
    end of the left-to-right scrim, taking the description to ~1.4:1 over open sky.
-   Same answer as `.hero--home` above: darken the top edge instead of the left.
-   Stronger than home's 0.5 because this text sits lower, where home's gradient has
-   decayed to ~0.3. Out by 60% so the ground still reads as painted; the animal
-   paints above this layer either way. */
+   Same answer as `.hero--home` above, at the same 0.5: darken the top edge rather
+   than the left. Out by 60% so the ground still reads as painted. */
 @media (max-width: 767px) {
   .hero--library.hero--with-background-image::before {
     background: linear-gradient(
       180deg,
-      rgba(0, 0, 0, 0.68) 0%,
-      rgba(0, 0, 0, 0.61) 44%,
+      rgba(0, 0, 0, 0.50) 0%,
+      rgba(0, 0, 0, 0.45) 44%,
       rgba(0, 0, 0, 0) 60%
     );
   }

--- a/templates/v3/libraries/library-subpage.html
+++ b/templates/v3/libraries/library-subpage.html
@@ -15,7 +15,7 @@
 {% else %}
   {% with cpp_ver=library_version.get_cpp_standard_minimum_display|default:"C++03" %}
       {% if is_flagship_lib %}
-        {% include "v3/includes/_hero_library.html" with title=object.display_name description=hero_description category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url is_flagship_lib=True hero_image_url_light=library_hero_image_url_light hero_image_url_dark=library_hero_image_url_dark extra_classes="hero--library" fullbleed_fg=True show_branch_buttons=True %}
+        {% include "v3/includes/_hero_library.html" with title=object.display_name description=hero_description category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url is_flagship_lib=True hero_image_url_light=library_hero_image_url_light hero_image_url_dark=library_hero_image_url_dark hero_image_url_mobile=library_hero_image_url_mobile hero_background_image_url=library_hero_background_image_url extra_classes="hero--library" fullbleed_fg=True show_branch_buttons=True %}
       {% else %}
         {% include "v3/includes/_hero_library.html" with title=object.display_name description=hero_description category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url show_branch_buttons=True %}
       {% endif %}


### PR DESCRIPTION
# Issue: #2746

## Summary & Context

The Beast sub-page hero now carries the illustration attached to the ticket, and the scrim behind it has been reworked so the text stays legible without the artwork disappearing under a black slab.

The art ships as two layers rather than one baked image, a background filling the hero block and the animal composited on top. They only line up while both are exported at the same scale and height, which is the thing to watch if the art is ever redrawn. Paths live in a `LIBRARY_HERO_ART` map keyed by library slug, resolved through `large_static()`; any library without an entry keeps the plain no-illustration hero from #2618.

Most of the diff is the scrim. Three changes, in the order they mattered.

**The description is white here now**, rather than the grey-400 the shared `.hero--with-bg-and-image` rule gives it. That is the change everything else depends on: over this artwork grey needs alpha 0.52 to clear 3.0:1, white clears it at 0.36, so the wash could drop by a third. `.hero--community` already does the same thing.

**The wash is 0.36-0.40 instead of 0.72**, anchored to the block rather than the viewport. The shared scrim uses percentage stops, but this text column is a fixed 662px, so coverage moved with the window and the description tail measured as low as 1.09:1 at some widths. Alpha rises slightly left to right on purpose, because the savanna brightens towards the horizon and a flat wash reads heavy over the dark scrub and weak under the text.

**The falloff is a smootherstep over 450px.** What the eye reads as a seam is a slope discontinuity, not steepness, so the curve is chosen for having zero slope at both ends. Width took several passes to get right: at 23px the falloff peaked at 0.034 alpha/px and was a hard line, at 90px it peaked at 0.012 and was still visible, at 170px at 0.0067 it was still called out. At 450px it peaks at 0.0017.

Finally, the per-breakpoint variants are gone. The base scrim and `.hero--home` each use a single horizontal wash plus a separate vertical one for mobile; this hero had grown a third, for tablet, and that is what made it step visibly at 1280. One gradient now covers 768 up.

- **Figma link**: n/a (art attached to the ticket)
- **Link to components/page:** [http://localhost:8000/library/1.90.0/beast/](http://localhost:8000/library/1.90.0/beast/)

## Changes

- **`libraries/constants.py`** - new `LIBRARY_HERO_ART` map with Beast's background, illustration and mobile crop
- **`libraries/views.py`** - `LibraryDetail.get_hero_art_context()` resolves the map through `large_static()`
- **`templates/v3/libraries/library-subpage.html`** - pass the mobile and background URLs on the flagship branch
- **`static/css/v3/heros.css`** - white description text; header clearance, tablet text cap and mobile block sizing for `.hero--library`; one horizontal scrim from 768 up plus the mobile vertical

## Measured contrast

Sampled by recovering the artwork behind the text and re-compositing against each candidate wash, so the figures are for the artwork actually there rather than a flat colour. Title and description are measured in their own vertical bands, since the sky behind the title and the scrub behind the description differ.

| width | description | title |
|---|---|---|
| 1440 | 3.42:1 | 3.56:1 |
| 1024 | 3.93:1 | — |
| 768 | 3.46:1 | — |
| mobile | 3.54:1 | — |

All above the 3.0:1 their sizes require. The binding point is the description's **left** edge, not its tail: the artwork there is mid-tone scrub, which is the worst case for light text.

## ‼️ Risks & Considerations ‼️

- **The three PNGs are not in this diff.** They live under `static/static-large/`, which is gitignored. They are uploaded to stage and prod and return 200, so the hero has its art wherever this lands.
- **The wash now ends past the illustration's leading edge** (881 at 1440, 825 at 1280), reaching zero at 959. That is deliberate: the art paints above this layer, so the overlap is hidden where the animal is opaque and reads as one continuous falloff in the gaps around it. Alpha there is 0.17 at 1280, the widest case.
- **Title contrast fell from 5.77:1 to 3.56:1** as a consequence of lightening the wash. Still clear of the 3.0:1 its size needs, but with much less headroom than before, so it is worth being deliberate about rather than assuming lighter is free.
- The desktop rule takes the illustration out of row sizing (`height: 0` plus `align-self: start`) so the hero band stays as tall as its text and the art overhangs. Removing either declaration collapses that.

## Screenshots

Captured at 2x against the branch, light theme unless noted. The thing to look for is the right-hand edge of the wash, and that 1280 and 1024 do not step between two treatments.

**1440, desktop**
<img width="2880" height="1120" alt="Beast hero at 1440" src="https://github.com/user-attachments/assets/72a76d6a-cdb7-4c63-9b5b-717f85ef1a6d" />

**1280, narrowest width the desktop layout hits, where `--o` is 0**
<img width="2560" height="1120" alt="Beast hero at 1280" src="https://github.com/user-attachments/assets/b2b8af5a-7fc2-407f-9ed0-8e8001e27151" />

**1024, tablet**
<img width="2048" height="1040" alt="Beast hero at 1024" src="https://github.com/user-attachments/assets/3b5adfd5-cabf-46fe-b36d-68ebe25b77f7" />

**768, narrowest tablet**
<img width="1536" height="1040" alt="Beast hero at 768" src="https://github.com/user-attachments/assets/3e18ae88-ca99-4ac7-bcb5-6f4cc19987e0" />

**414, mobile. Vertical wash, art stacked below the text**
<img width="828" height="1560" alt="Beast hero at 414" src="https://github.com/user-attachments/assets/655525ba-1c1a-4a00-809b-d152d3173781" />

**1440, dark mode**
<img width="2880" height="1120" alt="Beast hero at 1440 in dark mode" src="https://github.com/user-attachments/assets/e1521e5e-3a53-4a37-94e0-6333e40a4813" />

## Peer-review testing steps

1. Open [http://localhost:8000/library/1.90.0/beast/](http://localhost:8000/library/1.90.0/beast/) at desktop width.
2. Confirm the title and description are legible and the artwork still reads through the wash rather than sitting behind a slab.
3. Look along the right edge of the wash for a visible vertical line. There should not be one.
4. Drag the window across 1280. The hero should not step between two different treatments.
5. Check 1024 and 768: same wash, description still legible.
6. Below 767px the wash becomes vertical, darkening the top edge, and the art stacks below the text.
7. Toggle dark mode at each width.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added layered hero artwork for the Beast library, including desktop and mobile illustrations.
  - Library hero sections now display responsive background and foreground artwork across screen sizes.
  - About cards now remain visible with library information, documentation links, or fallback messaging.

- **Improvements**
  - Refined hero layouts, overlays, spacing, and text contrast for improved readability.
  - Improved mobile hero sizing and desktop artwork positioning.
  - Hero descriptions now display consistently across flagship and other library pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->