### PR TITLE
2670: Remove Admin Launch Panel

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -9,8 +9,6 @@ from django.db import transaction
 from django.db.models import BooleanField, Case, Value, When
 from django.utils import timezone
 
-from core.admin_buttons import TaskButtonAdminMixin
-
 from .constants import HOMEPAGE_POPULAR_TERMS_DISPLAY
 from .models import (
     PopularSearchTerm,
@@ -143,7 +141,7 @@ def _synchronize_commit_author_preview(_request, _value):
 
 
 @admin.register(SiteSettings)
-class SiteSettingsAdmin(TaskButtonAdminMixin, admin.ModelAdmin):
+class SiteSettingsAdmin(admin.ModelAdmin):
     list_display = ("id", "wordcloud_ignore", "rendered_content_replacement_start")
     readonly_fields = ("rendered_content_replacement_start",)
     filter_horizontal = ("pinned_community_libraries",)

--- a/core/admin.py
+++ b/core/admin.py
@@ -9,7 +9,7 @@ from django.db import transaction
 from django.db.models import BooleanField, Case, Value, When
 from django.utils import timezone
 
-from core.admin_buttons import TaskButtonAdminMixin, TaskButton
+from core.admin_buttons import TaskButtonAdminMixin
 
 from .constants import HOMEPAGE_POPULAR_TERMS_DISPLAY
 from .models import (
@@ -142,136 +142,8 @@ def _synchronize_commit_author_preview(_request, _value):
     }
 
 
-def get_buttons():
-    from dataclasses import replace
-
-    from badges.admin import BACKFILL_BUTTON
-
-    from pages.tasks import convert_news_entries_task, update_index_task
-
-    from libraries.tasks import synchronize_commit_author_user_data, update_commits
-
-    from users.tasks import recompute_displayed_profile_roles
-
-    from versions.admin import IMPORT_REVIEWS_BUTTON
-
-    CONVERT_NEW_ENTRIES_BUTTON = TaskButton(
-        name="convert_news_entries",
-        label="Convert News Entries",
-        task=convert_news_entries_task,
-        success_message="Entries are being converted in the background.",
-        busy_message="A conversion is already queued or running; not starting another one.",
-        argument="slug",
-        pass_actor=False,
-        description=("Converts legacy Entry models into Wagtail Post Pages."),
-    )
-
-    UPDATE_INDEX_BUTTON = TaskButton(
-        name="update_index",
-        label="Update Index",
-        task=update_index_task,
-        success_message="The index is being updated in the background.",
-        busy_message="An index update is already queued or running; not starting another one.",
-        pass_actor=False,
-        description=(
-            "Update the Index in order to allow for Wagtail searching. Should be run after "
-            "all pages are successfully converted."
-        ),
-    )
-
-    UPDATE_COMMITS_BUTTON = TaskButton(
-        name="update_commits",
-        label="Update Commits",
-        task=update_commits,
-        success_message="Commits are being updated in the background.",
-        busy_message="An update is already queued or running; not starting another one.",
-        pass_actor=False,
-        description=(
-            "Run first, before Synchronize Commit Authors. Imports any commits "
-            "the site is missing, which is what the commit and documentation "
-            "achievements are counted from. It only ever adds or refreshes "
-            "commits, so it is safe to run at any time; nothing is deleted."
-        ),
-    )
-
-    SYNCHRONIZE_COMMIT_AUTHOR_BUTTON = TaskButton(
-        name="synchronize_commit_author",
-        label="Synchronize Commit Authors",
-        task=synchronize_commit_author_user_data,
-        success_message="Authors are being synchronized in the background.",
-        busy_message="A synchronization is already queued or running; not starting another one.",
-        permission="libraries.delete_commitauthor",
-        pass_actor=False,
-        confirm=_synchronize_commit_author_preview,
-        description=(
-            "Run after Update Commits and before Backfill achievements. This is "
-            "what binds a commit author to the member who wrote the commits, by "
-            "matching their email addresses, and every commit and documentation "
-            "achievement is attributed through that link - skip it and the "
-            "backfill grants almost none of them. It also merges commit authors "
-            "sharing a GitHub profile, and fills in the GitHub username on the "
-            "members it matches."
-        ),
-    )
-
-    # Same button the versions changelist offers, including its confirmation
-    # screen and permission; only the wording is checklist-specific.
-    CHECKLIST_IMPORT_REVIEWS_BUTTON = replace(
-        IMPORT_REVIEWS_BUTTON,
-        description=(
-            "Run after Synchronize Commit Authors and before Backfill "
-            "achievements. Re-scrapes the formal-review results published on "
-            "boost.org, which are the only source of the Reviewer achievement. "
-            "It must follow the synchronize step: that step merges commit authors "
-            "sharing a GitHub profile, and a review naming a merged-away author as "
-            "its submitter loses that link. Nothing schedules this, so the "
-            "Reviewer achievement is only as current as the last time it was run."
-        ),
-    )
-
-    # Re-worded for the checklist, but the same button the badges changelist
-    # offers: one definition of the task, its sources and its permissions.
-    CHECKLIST_BACKFILL_BUTTON = replace(
-        BACKFILL_BUTTON,
-        description=(
-            "Run last. Grants the automatic achievements the sources support and "
-            "this site is missing, then awards any badge that reaches its "
-            "threshold. It only ever adds, so it is safe to run at any time and "
-            "safe to run again once the earlier steps have finished. Use "
-            "Reconcile instead if an achievement needs removing."
-        ),
-    )
-
-    UPDATE_DISPLAYED_ROLES_BUTTON = TaskButton(
-        name="update_roles",
-        label="Update Roles",
-        task=recompute_displayed_profile_roles,
-        success_message="Roles are being updated in the background.",
-        busy_message="A role update is already queued or running; not starting another one.",
-        pass_actor=False,
-        description=(
-            "Updates available user roles based on their contributions to boost."
-        ),
-    )
-
-    # Order is the checklist: commits are imported, their authors are bound to
-    # members, reviews are re-scraped against those authors, and only then does
-    # the backfill read all of it. The release synchronization is not part of that
-    # sequence - it is the repair for one release, run on its own.
-    return [
-        CONVERT_NEW_ENTRIES_BUTTON,
-        UPDATE_INDEX_BUTTON,
-        UPDATE_COMMITS_BUTTON,
-        SYNCHRONIZE_COMMIT_AUTHOR_BUTTON,
-        CHECKLIST_IMPORT_REVIEWS_BUTTON,
-        CHECKLIST_BACKFILL_BUTTON,
-        UPDATE_DISPLAYED_ROLES_BUTTON,
-    ]
-
-
 @admin.register(SiteSettings)
 class SiteSettingsAdmin(TaskButtonAdminMixin, admin.ModelAdmin):
-    task_buttons = get_buttons()
     list_display = ("id", "wordcloud_ignore", "rendered_content_replacement_start")
     readonly_fields = ("rendered_content_replacement_start",)
     filter_horizontal = ("pinned_community_libraries",)


### PR DESCRIPTION
# Issue: #2670 

## Summary & Context
<!-- *1-2 sentences describing what this PR does and why* -->
Removes Temporary Admin launch panel from SiteSettings Admin.

- **Link to components/page:** <!-- e.g. localhost:8000/news/add --> http://localhost:8000/admin/core/sitesettings/

## Changes

- Remove Admin Panel (all commands have been run in production)

## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*
N/A

## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [ ] Link this PR to the related GitHub Project ticket
