### PR TITLE
Story 2405: serve downsized webp license and release process card images

### DIFF
--- a/templates/v3/homepage.html
+++ b/templates/v3/homepage.html
@@ -56,7 +56,7 @@
         {% include "v3/includes/_testimonial_card.html" with heading="What engineers are saying" testimonials=testimonial_cards %}
       </div>
       <div class="item-d license-card">
-        {% large_static 'img/v3/solo-images/capy-hot-tub.png' as license_card_image %}
+        {% large_static 'img/v3/solo-images/capy-hot-tub.webp' as license_card_image %}
         {% include "v3/includes/_horizontal_card.html" with title="Build anything with the Boost Software License" text="<p>A simple, one-paragraph license created specifically for C++. It gives permission to use, modify, and distribute for any purpose.</p><p>No license file is required in binaries, just attribution in the source code. And it's compatible with virtually all other licenses.</p><p>Companies like Microsoft, Adobe and Citigroup have used it for the past 20 years.</p>" image_url=license_card_image image_alt="" button_url=license_url button_label="See the license" %}
       </div>
     </div>

--- a/templates/v3/includes/_release_highlights_card.html
+++ b/templates/v3/includes/_release_highlights_card.html
@@ -50,7 +50,7 @@
   <p class="release-highlight__placeholder">The summary is being generated, please check back later.</p>
   <img
     class="release-highlight__illustration"
-    src="{% large_static 'img/v3/solo-images/capy-hot-tub.png' %}"
+    src="{% large_static 'img/v3/solo-images/capy-hot-tub.webp' %}"
     alt=""
     loading="lazy"
     decoding="async"

--- a/templates/v3/release_detail.html
+++ b/templates/v3/release_detail.html
@@ -45,7 +45,7 @@ and community/resource cards. Context is supplied by versions.views.VersionDetai
 
       {% include "v3/includes/_basic_card.html" with title="Want to fix bugs, review code, maintain libraries, and propose new features?" text="Read our contributors guide and join the Boost community." primary_button_url=contributors_guide_url primary_button_label="Start here" primary_button_style="green" theme="green" only %}
 
-      {% large_static 'img/v3/solo-images/gator-robot.png' as image_url %}
+      {% large_static 'img/v3/solo-images/gator-robot.webp' as image_url %}
       {% include "v3/includes/_media_text_card.html" with text="Boost is publicly released three times a year in April, August, and December. Each release has updates to existing libraries, and any new libraries that have passed the rigorous acceptance process." image_url=image_url button_url=release_process_url button_label="Read release process" %}
     </section>
 


### PR DESCRIPTION
# Issue: #2405

## Summary & Context

Replaces the two oversized illustrations on the Homepage and Downloads page with downsized WebP versions, cutting 6.7 MB of image weight down to 164 KB (a 97.6% reduction). The artwork is unchanged — only the file size and format.

- **Figma link**: N/A 
- **Link to components/page:**
  - `localhost:8000/` with license card at the bottom of the Homepage
  - `localhost:8000/releases/latest/` with read release process card at the bottom of Downloads page and release report card on the top.

## Changes

- Downsized both images with the existing `downsize_uploaded_image` utility in `news/utils.py`:
  - `capy-hot-tub`: 2048×1759 PNG, 3.45 MB → 838×720 WebP, **74 KB**
  - `gator-robot`: 1924×1739 PNG, 3.26 MB → 797×720 WebP, **90 KB**
- Updated the three template references from `.png` to `.webp`:
  - `templates/v3/homepage.html` for license card
  - `templates/v3/release_detail.html` for release process card
  - `templates/v3/includes/_release_highlights_card.html` for release highlights card
- Uploaded both WebP files to all three S3 buckets (prod, stage, cppal-dev) via `scripts/sync-large-static-images.sh`.

## ‼️ Risks & Considerations ‼️

- **The images are already on S3, uploaded before this merges.** That ordering is deliberate. There is no window where the cards 404. Both files confirmed serving `HTTP 200 image/webp` from the prod bucket.
- **Rollback is safe.** The original `.png` files were not deleted from S3, so reverting this PR restores working images immediately.
- **The issue named two images, but `capy-hot-tub` is used in three places.** The release highlights card (`_release_highlights_card.html`) also uses it and was not mentioned in the ticket. Missing it would have broken that card, so it is included here. Worth a second pair of eyes on that file.
- **Please review the release highlights card specifically.** It only appears when a release summary is still being generated, so it is easy to miss when testing.
- **Transparency was preserved** (both files are still RGBA), so the card background shows through in light and dark mode exactly as before.
- **:warning: Housekeeping, unrelated to this change ⚠️:** the S3 sync also re-uploaded 13 other files that were stale on my machine. All 13 are byte-identical across prod, stage, and local (verified by checksum), so no image content changed anywhere.

## Screenshots

*Both cards should look identical to before. Screenshots to confirm no visual regression:*

### Downsized Beaver
<img width="1050" height="698" alt="DownsizedBeaver" src="https://github.com/user-attachments/assets/276eb153-efe3-42ee-ae6c-514d06b3fa08" />

### Downsized Aligator
<img width="1065" height="767" alt="DownsizedAligator" src="https://github.com/user-attachments/assets/dc916d94-989a-468a-a386-946affa5ae1d" />


*Verified so far: both pages render the `.webp` paths, and both files return `HTTP 200 image/webp` locally and from the prod bucket. Images were visually inspected for compression artifacts, but none were found. 

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [x ] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design — N/A, no design change; same artwork
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.) — no change; `alt` attributes untouched
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values — N/A, no CSS changes
- [x] Test without JavaScript (if applicable) — N/A, plain `<img>` tags
- [x] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated homepage, release highlights, and release detail imagery to use WebP formats for more efficient image delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->