### PR TITLE
Task 2632: Update the Libraries Page Illustration

### DIFF
--- a/static/css/v3/library-page.css
+++ b/static/css/v3/library-page.css
@@ -24,17 +24,26 @@
 /* === Hero === */
 
 .library-page-hero {
-    margin-top: var(--space-xl);
-    margin-bottom: var(--space-xl);
+    /* The desktop rule cancels the top margin exactly; keep the two in step. */
+    --hero-outer-gap: var(--space-large);
+
+    margin-top: var(--hero-outer-gap);
+    margin-bottom: var(--hero-outer-gap);
     position: relative;
     display: grid;
     grid-template-columns: fit-content(574px) 1fr fit-content(40%);
-    gap: var(--space-xl);
+    column-gap: var(--space-xl);
+    row-gap: var(--space-large);
     align-items: center;
     grid-template-areas:
         "a . c"
         "b . c"
     ;
+    /* Rows pinned to content. Left auto, an illustration in column c taller than
+       the title and search stack spreads its surplus over both rows and forces
+       them apart. */
+    grid-template-rows: min-content min-content;
+    align-content: center;
 }
 
 .library-page-hero .hero-search-bar {
@@ -46,10 +55,33 @@
     grid-area: c;
 }
 
+/* The art runs on a diagonal rather than filling its frame, so it needs more height
+   than a centred mascot to read at the same size. 250 is the design minimum. */
 .library-page-hero .hero-image,
 .library-page-hero .hero-image img {
-    height: 160px;
+    height: 250px;
     width: auto;
+}
+
+/* Desktop: keep the band as tall as its text and let the art overhang instead.
+   `height: 0` takes the container out of row sizing, `align-self: start` sends the
+   overhang downward rather than up into the header, and the negative margin lifts
+   it flush under whatever precedes the hero. The container still occupies column c,
+   so it keeps its width and cannot ride over the title. */
+@media (min-width: 1280px) {
+    .library-page-hero .hero-image-container {
+        align-self: start;
+        height: 0;
+        margin-top: calc(var(--hero-outer-gap) * -1);
+        /* Holds the overhang clear of the Master/Develop buttons at the end of the
+           filter row, which it otherwise covers. Not cosmetic. */
+        margin-right: calc(var(--space-xxl) + var(--space-xl));
+    }
+
+    .library-page-hero .hero-image,
+    .library-page-hero .hero-image img {
+        height: 270px;
+    }
 }
 
 .library-page-hero .hero-image-dark {
@@ -202,14 +234,20 @@ html.dark .library-page-hero .hero-image-dark {
         width: 100%;
     }
 
+    /* No illustration on mobile: nothing for it to sit against, and stacked it
+       pushed the search field below the fold. Area "c" leaves the template as well
+       as the container being hidden, so the stack keeps no dead row. */
     .library-page-hero {
         grid-template-areas:
-            "c"
             "a"
             "b"
         ;
         grid-template-columns: 100%;
         justify-items: start;
+    }
+
+    .library-page-hero .hero-image-container {
+        display: none;
     }
 
     .library-page__container {

--- a/templates/v3/library_page.html
+++ b/templates/v3/library_page.html
@@ -17,10 +17,18 @@ Inputs:
   <script src="{% static 'js/v3/fuse.min.js' %}" defer></script>
   <noscript>
     <style>
-      .hero-search-bar,
       .library-filter__clear-all,
       .library-filter__field:not(:has(select[name="view"])) {
         display: none !important;
+      }
+      /* The search bar keeps its space rather than being removed. It is one of the
+         hero's two grid rows, and the desktop rule hangs the illustration off the
+         top of that band assuming both rows are there: collapse the row and the
+         overhang runs into the table below, shrink the art to suit and it drops
+         under the 250 minimum. Reserving the row leaves the hero identical to the
+         scripted layout, which is what the no-JS page should look like. */
+      .hero-search-bar {
+        visibility: hidden !important;
       }
       .library-item-list[x-cloak],
       .library-item-card-grid[x-cloak] {

--- a/templates/v3/library_page.html
+++ b/templates/v3/library_page.html
@@ -406,7 +406,7 @@ Inputs:
             {% include 'v3/includes/_field_text.html' with label='Search' name='q' value=library_search_query placeholder='Keyword, name, etc.' icon_left='search' submit_icon='arrow-right' submit_label='Search' dispatch_field_change=True %}
           </div>
           <div class="hero-image-container">
-            <img alt="Excited Cartoon Mascot" class="hero-image" src="{% large_static 'img/v3/solo-images/cow-solo.png' %}" loading="lazy" decoding="async" />
+            <img alt="" class="hero-image" src="{% large_static 'img/v3/solo-images/beaver-computer-blow-up.png' %}" loading="lazy" decoding="async" />
           </div>
       </section>
     <form action="" method="get">


### PR DESCRIPTION
# Issue: #2632

## Summary & Context

The libraries page hero now carries the new beaver illustration in place of `cow-solo.png`, at 250px tall and 270px from 1280px up.

Most of the diff is layout rather than the swap. This illustration runs along a diagonal rather than filling its frame, so the previous 160px box read much smaller than the cow did at the same height. Getting it larger without the hero band stretching to match took three changes: the grid rows are pinned to `min-content` so a tall illustration no longer drives the title and the search bar apart, on desktop the art comes out of row sizing altogether and overhangs instead of setting the band's height, and it sits 92px in from the right edge so the Master/Develop buttons at the end of the filter row stay clear.

The asset was trimmed flush to its ink before resizing, having arrived with 182x179 of transparent margin. It is now 676x800 and 126KB, against 3114KB as supplied and the 500KB the ticket asks for.

- **Figma link**: n/a (art supplied directly)
- **Link to components/page:** [http://localhost:8000/libraries/latest/list/](http://localhost:8000/libraries/latest/list/)

## Changes

- **`templates/v3/library_page.html`** - hero image source swapped; `alt` emptied, since the illustration is decorative and the old "Excited Cartoon Mascot" no longer described it
- **`static/css/v3/library-page.css`** - rows pinned to `min-content`; new `--hero-outer-gap` driving the band's margins; row gap reduced while the column gutter stays at `--space-xl`; base height 250, desktop 270 lifted out of row sizing; hidden below 768px
- **`static/static-large/img/v3/solo-images/beaver-computer-blow-up.png`** - new asset, gitignored so it is not in this diff

## ‼️ Risks & Considerations ‼️

- **The PNG needs a manual upload to the buckets.** It lives under `static/static-large/`, so the hero will be empty on stage and prod until the file is synced by hand.
- **The tightest constraint is ~12px.** With the band tightened the filter row rises by 48px, and the art clears the Master/Develop buttons by about 12px. The 92px right offset exists for exactly this reason and is not cosmetic. All pixel figures were measured at a 1348px viewport.
- `cow-solo.png` is now unreferenced, and the `hero-image-light` / `hero-image-dark` rules further down the file were already dead. Both left alone to keep this diff to #2632.

## Peer-review testing steps

1. Open [http://localhost:8000/libraries/latest/list/](http://localhost:8000/libraries/latest/list/) at desktop width.
2. Confirm the illustration sits top right at ~270px, and that the title and search field keep their spacing rather than being pushed apart.
3. Check the art overhangs below the band without touching the Master/Develop buttons or the top edge of the library table.
4. Between 768px and 1279px it drops to 250px and returns to normal flow, so the band grows to suit.
5. Below 768px it is gone entirely; the stack is title then search.
6. Toggle dark mode at each width.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Refined the library page hero layout with improved spacing and alignment between the title, search area, and illustration.
  - Increased the hero illustration size and adjusted its desktop positioning for a more prominent presentation.
  - Removed the hero illustration from mobile layouts to provide a cleaner, more compact view.
  - Improved the no-JavaScript layout so the search area retains its space while remaining hidden.

- **Visual Updates**
  - Replaced the library page mascot illustration with the beaver computer image.
  - Updated the illustration’s alternative text treatment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->