### PR TITLE
Story 2766: add expandable library descriptions for long ones

### DIFF
--- a/libraries/constants.py
+++ b/libraries/constants.py
@@ -437,9 +437,3 @@ COMMIT_EMAIL_STALE_ACTION_ERROR = (
 # redirected GET to regenerate its error, so this covers the race where the
 # blocking condition cleared in between and validation now passes.
 COMMIT_EMAIL_ADD_FAILED_ERROR = "That email address could not be added."
-
-# Library descriptions come from the library's own metadata and are unbounded,
-# so a long one grows the detail-page hero until its actions row overlaps the
-# cards beneath it. Capped for layout until a real content solution lands.
-# See https://github.com/boostorg/website-v2/issues/2684.
-LIBRARY_DESCRIPTION_MAX_CHARS = 230

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -7,11 +7,7 @@ from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from model_bakery import baker
 
-from ..constants import (
-    LIBRARY_DESCRIPTION_MAX_CHARS,
-    README_MISSING,
-    SELECTED_LIBRARY_VIEW_COOKIE_NAME,
-)
+from ..constants import README_MISSING, SELECTED_LIBRARY_VIEW_COOKIE_NAME
 from ..models import Library
 from ..utils import benchmark_sets, designed_for_html
 from ..views import LibraryListBase, _build_quick_start_links, _is_boost_url
@@ -271,11 +267,11 @@ def test_library_detail(library_version, tp):
 
 
 @waffle.testutils.override_flag("v3", active=True)
-def test_library_detail_caps_a_long_description(library_version, tp):
-    """A long description is capped so the hero cannot grow into the cards below.
+def test_library_detail_passes_a_long_description_through_in_full(library_version, tp):
+    """A long description is no longer truncated (issue #2766).
 
-    The cap is on the rendered value rather than the model, so the full text is
-    still available to anything else that wants it.
+    The hero clamps it to three lines and reveals the rest behind a "See more"
+    toggle, so the full text has to reach the template.
     """
     library_version.description = "word " * 200
     library_version.save()
@@ -284,15 +280,13 @@ def test_library_detail_caps_a_long_description(library_version, tp):
     response = tp.get(url)
 
     tp.response_200(response)
-    rendered = response.context["hero_description"]
-    assert len(rendered) <= LIBRARY_DESCRIPTION_MAX_CHARS
-    assert rendered.endswith("\u2026")
-    assert len(library_version.description) > LIBRARY_DESCRIPTION_MAX_CHARS
+    assert response.context["hero_description"] == library_version.description
+    assert b"hero__description-toggle" in response.content
 
 
 @waffle.testutils.override_flag("v3", active=True)
 def test_library_detail_leaves_a_short_description_alone(library_version, tp):
-    """Anything already inside the cap passes through without an ellipsis."""
+    """A short description reaches the hero unchanged."""
     library_version.description = "Short and sweet."
     library_version.save()
     url = tp.reverse("library-detail", "latest", library_version.library.slug)

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -15,7 +15,6 @@ from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
-from django.utils.text import Truncator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import DetailView, ListView, FormView, TemplateView
@@ -69,7 +68,7 @@ from .utils import (
     designed_for_html,
     benchmark_sets,
 )
-from .constants import LATEST_RELEASE_URL_PATH_STR, LIBRARY_DESCRIPTION_MAX_CHARS
+from .constants import LATEST_RELEASE_URL_PATH_STR
 
 logger = structlog.get_logger()
 
@@ -656,15 +655,12 @@ class LibraryDetail(
         )
         context["slack_url"] = self.object.slack_url or SLACK_JOIN_URL
 
-        # Mirrors the template's old `library_version.description|default:...`,
-        # capped so the hero cannot grow into the cards below it.
-        description = (
-            getattr(library_version, "description", None) or self.object.description
-        )
+        # Passed through in full: the hero clamps a long description to three
+        # lines behind a "See more" toggle instead of truncating the text.
         context["hero_description"] = (
-            Truncator(description).chars(LIBRARY_DESCRIPTION_MAX_CHARS)
-            if description
-            else ""
+            getattr(library_version, "description", None)
+            or self.object.description
+            or ""
         )
 
         context["category_tags_v3"] = [

--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -773,12 +773,6 @@
   cursor: pointer;
 }
 
-/* The project defines no global [x-cloak] rule, so the toggle would flash before
-   Alpine measures the description and hides it again. */
-.hero__description-toggle[x-cloak] {
-  display: none;
-}
-
 .hero__description-input:focus-visible ~ .hero__description-toggle {
   outline: 2px solid var(--color-stroke-link-accent);
   outline-offset: 2px;

--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -709,6 +709,91 @@
   padding: 0;
 }
 
+/* Expandable description (expandable_description in _hero_library.html): library
+   descriptions are unbounded, so a long one is clamped to 3 lines and the rest is
+   reached through the "See more" toggle. */
+.hero__description-block {
+  position: relative;
+  align-self: stretch;
+  z-index: 1;
+}
+
+/* The block's fixed height would clip an expanded description, so it becomes a
+   floor instead. The illustration is absolutely positioned and bottom-anchored,
+   so it stays put as the block grows. .hero--no-image already sizes this way,
+   with its own smaller floor, and is left alone.
+   768 up only: below that the flagship hero stacks text over the figure and needs
+   a definite height for the figure to flex against (#2758), and this rule would
+   out-specify it. No library with hero art has a description long enough to clamp
+   yet, so nothing is cut off there today. */
+@media (min-width: 768px) {
+  .hero:not(.hero--no-image) .hero__block:has(.hero__description-block) {
+    height: auto;
+    min-height: var(--hero-block-height);
+  }
+}
+
+.hero__description--clamped {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  line-clamp: 3;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}
+
+.hero__description-input:checked ~ .hero__description--clamped,
+.hero__description--unclamped {
+  display: block;
+  overflow: visible;
+  line-clamp: none;
+  -webkit-line-clamp: none;
+}
+
+.hero__description-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.hero__description-toggle {
+  display: inline-block;
+  margin-top: var(--space-default);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-loose-alt);
+  letter-spacing: -0.01em;
+  font-weight: var(--font-weight-medium);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+/* The project defines no global [x-cloak] rule, so the toggle would flash before
+   Alpine measures the description and hides it again. */
+.hero__description-toggle[x-cloak] {
+  display: none;
+}
+
+.hero__description-input:focus-visible ~ .hero__description-toggle {
+  outline: 2px solid var(--color-stroke-link-accent);
+  outline-offset: 2px;
+  border-radius: var(--border-radius-xs);
+}
+
+.hero__description-toggle-less,
+.hero__description-input:checked ~ .hero__description-toggle .hero__description-toggle-more {
+  display: none;
+}
+
+.hero__description-input:checked ~ .hero__description-toggle .hero__description-toggle-less {
+  display: inline;
+}
+
 .hero__links {
   display: flex;
   flex-direction: row;
@@ -932,6 +1017,10 @@ html.dark .hero__links .btn-icon-library:hover {
    scrim dark, so raising the alpha below without reverting this will not help.
    `.hero--community` does the same. */
 .hero--library .hero__description {
+  color: #fff;
+}
+
+.hero--library.hero--with-background-image .hero__description-toggle {
   color: #fff;
 }
 

--- a/templates/v3/includes/_hero_library.html
+++ b/templates/v3/includes/_hero_library.html
@@ -85,7 +85,8 @@
             that already fits is a no-op, and a clamped one stays openable. {% endcomment %}
             <noscript>
               <style>
-                .hero__description-toggle[x-cloak] { display: inline-block; }
+                /* Beats the global `[x-cloak] { display: none !important }` in styles.css. */
+                .hero__description-toggle[x-cloak] { display: inline-block !important; }
               </style>
             </noscript>
             {% else %}

--- a/templates/v3/includes/_hero_library.html
+++ b/templates/v3/includes/_hero_library.html
@@ -6,6 +6,9 @@
   Variables:
     title              (optional) — Library name.
     description        (optional) — Short description.
+    expandable_description (optional) — Boolean. Clamps the description to 3 lines behind a
+                         "See more"/"See less" toggle, for pages whose description is unbounded
+                         (library subpages).
     category_tags      (optional) — List of dicts with "label" and "url". Omit to hide tag chips.
     version_tag        (optional) — e.g. "C++ 03". Omit to hide.
     first_boost_version (optional) — Version display name only, e.g. "1.66.0" (rendered as "Added in {version}"). Omit to hide.
@@ -60,7 +63,34 @@
           <h1 class="hero__title{% if is_flagship_lib %} hero__title--flagship{% endif %}" style="margin-bottom: 0;">{{ title }}</h1>
           {% endif %}
           {% if description %}
-          <p class="hero__description">{{ description }}</p>
+            {% if expandable_description %}
+            <div class="hero__description-block"
+                 x-data="{ overflowing: false, measure() { const d = this.$refs.description; if (this.$refs.expand.checked) return; const clamped = d.clientHeight; d.classList.add('hero__description--unclamped'); const full = d.clientHeight; d.classList.remove('hero__description--unclamped'); this.overflowing = full > clamped } }"
+                 x-init="$nextTick(() => measure()); document.fonts.ready.then(() => measure())"
+                 @resize.window.debounce="measure()">
+              <input type="checkbox"
+                     id="hero-description-expand"
+                     class="hero__description-input"
+                     x-ref="expand"
+                     aria-label="Show the full description">
+              <p class="hero__description hero__description--clamped" x-ref="description">{{ description }}</p>
+              <label class="hero__description-toggle" for="hero-description-expand" x-show="overflowing" x-cloak>
+                <span class="hero__description-toggle-more">See more</span>
+                <span class="hero__description-toggle-less">See less</span>
+              </label>
+            </div>
+            {% comment %} No-JS fallback: the toggle is hidden until Alpine measures the
+            description, so without JS nothing would ever reveal it and a clamped
+            description would be unreachable. Show it instead: expanding a description
+            that already fits is a no-op, and a clamped one stays openable. {% endcomment %}
+            <noscript>
+              <style>
+                .hero__description-toggle[x-cloak] { display: inline-block; }
+              </style>
+            </noscript>
+            {% else %}
+            <p class="hero__description">{{ description }}</p>
+            {% endif %}
           {% endif %}
         </div>
       </div>

--- a/templates/v3/libraries/library-subpage.html
+++ b/templates/v3/libraries/library-subpage.html
@@ -15,9 +15,9 @@
 {% else %}
   {% with cpp_ver=library_version.get_cpp_standard_minimum_display|default:"C++03" %}
       {% if is_flagship_lib %}
-        {% include "v3/includes/_hero_library.html" with title=object.display_name description=hero_description category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url is_flagship_lib=True hero_image_url_light=library_hero_image_url_light hero_image_url_dark=library_hero_image_url_dark hero_image_url_mobile=library_hero_image_url_mobile hero_background_image_url=library_hero_background_image_url extra_classes="hero--library" fullbleed_fg=True show_branch_buttons=True %}
+        {% include "v3/includes/_hero_library.html" with title=object.display_name description=hero_description expandable_description=True category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url is_flagship_lib=True hero_image_url_light=library_hero_image_url_light hero_image_url_dark=library_hero_image_url_dark hero_image_url_mobile=library_hero_image_url_mobile hero_background_image_url=library_hero_background_image_url extra_classes="hero--library" fullbleed_fg=True show_branch_buttons=True %}
       {% else %}
-        {% include "v3/includes/_hero_library.html" with title=object.display_name description=hero_description category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url show_branch_buttons=True %}
+        {% include "v3/includes/_hero_library.html" with title=object.display_name description=hero_description expandable_description=True category_tags=category_tags_v3 version_tag=cpp_ver first_boost_version=object.first_boost_version.display_name doc_url=documentation_url source_url=github_url slack_url=slack_url github_url=object.github_issues_url show_branch_buttons=True %}
       {% endif %}
   {% endwith %}
 


### PR DESCRIPTION
# Issue: #2766

## Summary & Context

Long library descriptions were cut off at 230 characters and the rest was thrown away. The full description is now shown: it is cut off after 3 lines with a **See more** control below it, and **See less** puts it back.

- **Figma link**: n/a 
- **Link to components/page:** [localhost:8000/library/latest/foreach/](http://localhost:8000/library/latest/foreach/) (longest description on the site), [/library/latest/math/](http://localhost:8000/library/latest/math/), [/library/latest/asio/](http://localhost:8000/library/latest/asio/) (short — no control)

## Changes

- **`libraries/views.py`:** the hero description is passed to the page in full. The 230-character cap it used to go through is gone.
- **`templates/v3/includes/_hero_library.html`:** the hero takes a new `expandable_description` option. When it is on, the description is wrapped with a hidden checkbox and a **See more** / **See less** label. When it is off, the hero renders the same plain paragraph it always did.
- **`templates/v3/libraries/library-subpage.html`:** turns that option on, for both the flagship and the non-flagship hero.
- **`static/css/v3/heros.css`:** cuts the description off after 3 lines, opens it back up when the checkbox is ticked, and styles the control. Also lets the hero grow taller instead of holding a fixed height, so an opened description pushes the cards below it down rather than sitting on top of them.

## ‼️ Risks & Considerations ‼️

- **Descriptions are no longer capped anywhere:** when closed, the hero is always 3 lines tall. When open, it is as tall as the description needs.
- **Which libraries get a control is decided in the browser, not in the code**, so it depends on the window width and the font. 
- **The hero can now grow past its fixed height.** That rule is written to leave every other hero alone, but the hero is shared with the community and release pages, so it is worth a look at those two to confirm nothing moved.
- The 3-line cut-off uses the standard CSS line clamp, which every browser we support handles.

## Screenshots
https://github.com/user-attachments/assets/ff251419-6086-41a3-bc29-b29bf2892b86

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Library hero descriptions now display in full, with expandable “See more” and “See less” controls when content exceeds three lines.
  - Expansion supports keyboard navigation, window resizing, font loading, and no-JavaScript fallback.
  - Expanded content adjusts the hero layout to prevent clipping.
  - Added tailored desktop and mobile hero artwork for the Beast library.

- **Bug Fixes**
  - Long library descriptions are no longer truncated or displayed with an ellipsis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->