### PR TITLE
Story 2767: hide dependencies card on library subpage when empty

### DIFF
--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -517,6 +517,27 @@ def test_library_detail_v3_about_card_falls_back_to_the_docs_link(
 
 
 @waffle.testutils.override_flag("v3", active=True)
+def test_library_detail_v3_bare_library_keeps_the_pinned_column_cards(
+    tp, library_version, wagtail_site
+):
+    """The masonry pins its columns on About, Quick Start and Contributors, so
+    those three render even when the library has no adoc content at all."""
+    library_version.website_adoc = {}
+    library_version.save()
+    library_version.dependencies.clear()
+
+    url = tp.reverse("library-detail", "latest", library_version.library.slug)
+    response = tp.get(url)
+    tp.response_200(response)
+
+    content = response.content.decode()
+    assert not tp.get_context("dependencies_list")
+    assert 'class="item-e"' not in content
+    for item in ('class="item-a"', 'class="item-b"', 'class="item-d"'):
+        assert item in content
+
+
+@waffle.testutils.override_flag("v3", active=True)
 def test_library_detail_v3_latest_posts_cta_points_at_the_news_index(
     tp, library_version, make_post_page, post_index_page, wagtail_site
 ):

--- a/static/css/v3/library-subpage.css
+++ b/static/css/v3/library-subpage.css
@@ -2,8 +2,9 @@
   Library Subpage layout.
 
   .card-masonry-top: CSS multi-column, so cards pack into as many columns as fit
-  (3 → 2 → 1 by width) with no strict breakpoints and no grid row-stretching
-  gaps. Reading order runs down each column, then across.
+  (3 → 2 → 1 by width) with no grid row-stretching gaps. Reading order runs down
+  each column, then across. At three columns the column starts are pinned, so
+  card placement does not depend on how many cards there are or how tall.
 
   .card-masonry-bottom: posts 2/3 + mailing list 1/3, stacking on mobile.
 */
@@ -49,6 +50,26 @@ body:has(.hero:not(.hero--no-image)) .library-subpage-container {
 .card-masonry-top > * {
   break-inside: avoid;
   margin-bottom: var(--space-card);
+}
+
+/* Pin the three columns at the widths where three actually fit. Balanced
+   multi-column places cards by height, so an absent optional card — or merely a
+   taller one — shifts every card after it into the wrong column. Quick Start and
+   Contributors always render, so forcing a break before each one fixes the
+   column starts regardless of which optional cards are present:
+     1 About, Benchmarks | 2 Quick Start, Dependencies, Designed for, Freeform,
+     Install | 3 Contributors
+   column-count pins it to 3 so the forced breaks can't spill into a 4th. */
+@media (min-width: 1120px) {
+  .card-masonry-top {
+    columns: 3;
+  }
+
+  .card-masonry-top .item-b,
+  .card-masonry-top .item-d {
+    -webkit-column-break-before: always;
+    break-before: column;
+  }
 }
 
 /* ── Bottom card row (desktop/tablet: posts 2/3, mailing 1/3) ────────────── */

--- a/templates/v3/libraries/library-subpage.html
+++ b/templates/v3/libraries/library-subpage.html
@@ -43,9 +43,11 @@
         {% include "v3/includes/_quick_start_card.html" with heading="Quick Start" links=quick_start_links %}
       </div>
 
+      {% if dependencies_list %}
       <div class="item-e">
         {% include "v3/includes/_dependencies_card.html" with dependencies=dependencies_list %}
       </div>
+      {% endif %}
 
       {% if website_adoc.designed_for %}
       <div class="item-f">


### PR DESCRIPTION
# Issue: #2767

## Summary & Context

The library sub page always showed a "Dependencies" card, even for libraries that have none — in that case it displayed a card with just the heading and the text "No dependencies". This hides the card entirely when the library has no dependencies.

- **Figma link**: N/A
- **Link to components/page:**
  - Card hidden (library with no dependencies): `http://localhost:8000/library/latest/config/`, `http://localhost:8000/library/latest/decimal/`
  - Card still shown (library with dependencies): `localhost:8000/library/boost-1-92-0/math/`

## Changes

- Wrapped the Dependencies card on the library sub page in a check for whether the library actually has dependencies, so nothing renders when the list is empty.
- The card's grid slot is removed along with it, so the surrounding cards close the gap instead of leaving a blank space in the layout.
- No changes to the Dependencies card itself, or to how the list of dependencies is built.

## ‼️ Risks & Considerations ‼️

- The Dependencies card is a shared component, and its "No dependencies" empty state is still used on the component examples page. It was intentionally left in place, so please don't expect it to disappear there.
- Worth a look at the card layout on a library with no dependencies: the cards below it shift up, so it's worth checking the arrangement still reads well on desktop and mobile.
- Many libraries in older releases have no dependency data imported, so this will hide the card more often on those versions than on the latest one. That's the intended behaviour, but it's a visible difference when switching versions.

## Screenshots

### Before Decimal Library
<img width="1347" height="759" alt="DecimalBefore" src="https://github.com/user-attachments/assets/1aa2e850-a96b-4b94-8feb-064357633670" />

### After Decimal Library
<img width="1342" height="750" alt="DecimalAfter" src="https://github.com/user-attachments/assets/e541615d-d368-4e73-b014-15ad4283c520" />


## Self-review Checklist
- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
- [x] Responsive / mobile verified
- [x] Accessibility checked (keyboard navigation, etc.)
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [x] Test without JavaScript (if applicable)
- [x] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Library detail pages no longer display an empty Dependencies card when no dependencies are available.
  - Pinned library information cards now remain in consistent column positions, even when optional cards are missing.
  - Improved large-screen card layout consistency for library pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->