### PR TITLE
fix: remove scroll cap on README and release notes cards

### DIFF
--- a/static/css/v3/library-subpage.css
+++ b/static/css/v3/library-subpage.css
@@ -97,10 +97,10 @@ body:has(.hero:not(.hero--no-image)) .library-subpage-container {
   max-height: none;
 }
 
-.library-subpage__documentation > .markdown-card {
-  max-height: 572px;
-  display: flex;
-  flex-direction: column;
+/* No scroll cap: the README should render at its full natural height. */
+.library-subpage__documentation > .markdown-card .markdown-card__body {
+  max-height: none;
+  overflow: visible;
 }
 
 /* ── Card body scroll caps ───────────────────────────────────────────────── */

--- a/static/css/v3/release-detail.css
+++ b/static/css/v3/release-detail.css
@@ -39,7 +39,12 @@
 /* ── Release Notes card ── */
 .release-detail .markdown-card {
   border-radius: var(--border-radius-l);
-  height: 572px;
+}
+
+/* No scroll cap: release notes should render at their full natural height. */
+.release-detail .markdown-card .markdown-card__body {
+  max-height: none;
+  overflow: visible;
 }
 
 .release-detail .markdown-content {


### PR DESCRIPTION
#2771  and #2775 

## Summary & Context

The library subpage's README ("Documentation" card) and the downloads page's release notes card were both capped to a 572px height with `overflow-y: auto`, forcing readers to scroll a nested region instead of the page. Both now render at their full natural height with no inner scrollbar.

- **Figma link**: n/a
- **Link to components/page:**
  - [http://localhost:8000/library/latest/math/](http://localhost:8000/library/latest/math/)
  - [http://localhost:8000/releases/](http://localhost:8000/releases/)

## Changes

- **`static/css/v3/library-subpage.css`** - replaced the `.library-subpage__documentation > .markdown-card` max-height/flex rule with a `.markdown-card__body { max-height: none; overflow: visible; }` override, scoped only to the documentation card.
- **`static/css/v3/release-detail.css`** - removed the fixed `height: 572px` on `.release-detail .markdown-card` and added the same body override for the release notes card.

## Risks & Considerations

- No fade-out mask, gradient, or "show more" JS toggle existed tied to this truncation, so nothing else needed removing.
- Sibling scroll caps on the same shared `.markdown-card` component ("Designed for" 245px, "Freeform" 143px on the library subpage) were left untouched since they're out of scope for this task.
- Very long READMEs/release notes will now make these cards (and the page) taller; no reflow issues observed in testing.

## Screenshots
<img width="1893" height="1284" alt="image" src="https://github.com/user-attachments/assets/4d9b26db-f3e3-4173-b393-40ccd123953e" />
<img width="1645" height="1279" alt="image" src="https://github.com/user-attachments/assets/37e5bed3-a762-4925-9133-83916591f927" />
<img width="1716" height="1195" alt="image" src="https://github.com/user-attachments/assets/33bf631c-ac92-4d3f-adfe-d0a52410a8ed" />


## Peer-review testing steps

1. Visit a library page with a long README, e.g. `/library/latest/math/`, and check the "Documentation" card.
2. Confirm the card has no max-height/inner scrollbar and the full README renders inline.
3. Visit `/releases/<a version with release notes>/` and confirm the release notes card also has no inner scrollbar.
4. Toggle dark mode on both pages and confirm text remains legible via existing semantic tokens.
5. Resize to mobile width and confirm both cards still read naturally, full width, no horizontal scroll.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Documentation and release notes cards now expand to display their full content.
  - Removed internal scrolling and fixed-height restrictions from these cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->