### PR TITLE
Story 2777: remove empty space on Library Subpage on Safari

### DIFF
--- a/static/css/v3/library-subpage.css
+++ b/static/css/v3/library-subpage.css
@@ -44,11 +44,15 @@ body:has(.hero:not(.hero--no-image)) .library-subpage-container {
   --subpage-col-min: 22rem;
   columns: var(--subpage-col-min);
   column-gap: var(--space-card);
+  /* Cancels the trailing row gap the last card in each column carries. */
+  margin-bottom: calc(-1 * var(--space-card));
 }
 
+/* Row gap as padding, not margin: Safari adds a card's bottom margin to the
+   balanced column height, which leaves a tall empty band under the masonry. */
 .card-masonry-top > * {
   break-inside: avoid;
-  margin-bottom: var(--space-card);
+  padding-bottom: var(--space-card);
 }
 
 /* ── Bottom card row (desktop/tablet: posts 2/3, mailing 1/3) ────────────── */


### PR DESCRIPTION
# Issue: #2777

## Summary & Context

Safari renders a large empty band between the top card block and the Documentation card on library subpages. The cards are laid out with CSS multi-column and each card carries a 16px `margin-bottom`; Safari includes that trailing margin when it calculates the column height, so the block is drawn taller than the cards inside it. This swaps the spacing from margin to padding, which Safari measures correctly.

- **Figma link**: <!-- Add link to relevant Figma design here -->
- **Link to components/page:** localhost:8000/library/latest/decimal/

## Changes

- `static/css/v3/library-subpage.css`: the 16px gap between cards in `.card-masonry-top` is now `padding-bottom` on each card wrapper instead of `margin-bottom`. Padding belongs to the card's own box, so Safari can't add it on top of the column height.
- `static/css/v3/library-subpage.css`: `.card-masonry-top` gets `margin-bottom: calc(-1 * var(--space-card))` to absorb the padding under the last card in the tallest column, so the gap before the Documentation card stays at 16px exactly as before.

## Measurements

Taken on the live Boost.Decimal page at 1440px, before the fix:

| | Card block height | Height of the cards inside it | Empty space before Documentation |
|---|---|---|---|
| Safari | 509px | 379px | 146px |
| Chrome | 379px | 379px | 16px |

Other pages hit the same bug by different amounts: `/library/latest/json/` 122px, `/library/latest/math/` 11px.

After the fix, the space before the Documentation card is 16px in both browsers at 390 / 768 / 1024 / 1440px, and the card block height matches the cards inside it.

## ‼️ Risks & Considerations ‼️

- **The negative margin is tied to the padding.** They are the same token (`--space-card`) and must stay in sync. If someone changes one, the gap before the Documentation card shifts.
- **The negative margin assumes `.card-masonry-top` has no bottom padding or border of its own.** Adding either would change where the block ends.
- **Every direct child of `.card-masonry-top` now gets 16px of bottom padding**, including the `.library-subpage__freeform` wrapper. These wrappers are transparent today, so the padding is invisible. If a wrapper ever gets a background or border, that 16px would become visible inside it — the spacing would need to move to the card element instead.
- **Same rules drive the mobile layout.** Under 768px `.card-masonry-top` switches to flex column; padding spaces the cards there the same way margin did, and `--space-card` drops to 12px on mobile as before.
- Worth a look on a library page with more cards than Boost.Decimal (one with Benchmarks, Install and a freeform section) to confirm the packing is unchanged.

## Screenshots

### Before 
<img width="1438" height="951" alt="SafariBefore" src="https://github.com/user-attachments/assets/a8e36676-5d4a-465a-b2f8-a85554de792e" />

### After
<img width="1431" height="825" alt="SafariAfter" src="https://github.com/user-attachments/assets/9abed2aa-8b8d-4b0b-845a-569a9beb977b" />


<!-- Desktop Light Mode | Desktop Dark Mode | Mobile
-- | -- | -- -->

## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode — layout measured in dark mode; the change is spacing only and is not theme-dependent
- [x] Responsive / mobile verified — measured at 390 / 768 / 1024 / 1440px in Safari and Chrome
- [x] Accessibility checked (keyboard navigation, etc.) — no markup or focus order changes
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values — uses `var(--space-card)` on both sides
- [x] Test without JavaScript (if applicable) — CSS only, no JS involved
- [x] No console errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved card masonry layout spacing in Safari.
  * Prevented extra gaps from appearing between masonry rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->