### PR TITLE
[fix] Conan command requires mandatory parameters

### DIFF
--- a/core/install_commands.py
+++ b/core/install_commands.py
@@ -5,7 +5,7 @@ the radio/CSS state key, `command` is the shell command shown to the user.
 """
 
 INSTALL_PKG_MANAGERS = [
-    {"label": "Conan", "value": "conan", "command": "conan install boost"},
+    {"label": "Conan", "value": "conan", "command": "conan install --requires='boost/[*]'"},
     {"label": "Vcpkg", "value": "vcpkg", "command": "vcpkg install boost"},
 ]
 


### PR DESCRIPTION
## Summary & Context

Hello! 

First, congratulations on your new website! I'll miss the red button, but this is an incredible new view :clap: 

The main page shows a few commands to install Boost, including with Conan. The provided command is `conan install boost`, but this is Conan 1.x (EOL) design, for Conan 2.x (current version), users need to pass `--require=` parameter to be explicit about what they want: 

https://docs.conan.io/2/reference/commands/install.html#conanfile-path-or-requires

Short history: Conan 2.x became more explicit to avoid common errors, like `conan install boost`, is boost a folder or a package?

Also, the version is a mandatory part of the package reference. The pattern `[*]` means: Get the most recent version available. 

By default, Conan will pick from Conan Center: https://conan.io/center/recipes/boost?version=1.91.0

When running that command on Linux, you will have:

```
$ conan install --requires='boost/[*]'

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux
[conf]
tools.build:verbosity=verbose
tools.cmake.cmaketoolchain:generator=Ninja
tools.compilation:verbosity=verbose

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux
[conf]
tools.build:verbosity=verbose
tools.cmake.cmaketoolchain:generator=Ninja
tools.compilation:verbosity=verbose


======== Computing dependency graph ========
Connecting to remote 'conancenter' anonymously
boost/1.91.0: Not found in local cache, looking in remotes...
boost/1.91.0: Checking remote: conancenter
boost/1.91.0: Downloaded recipe revision 9b41246fdc6288d648e8ad5b1649fbaf
zlib/1.3.2: Not found in local cache, looking in remotes...
zlib/1.3.2: Checking remote: conancenter
zlib/1.3.2: Downloaded recipe revision 1cb806da49011867778ffb6ac7190fcb
bzip2/1.0.8: Not found in local cache, looking in remotes...
bzip2/1.0.8: Checking remote: conancenter
bzip2/1.0.8: Downloaded recipe revision c470882369c2d95c5c77e970c0c7e321
libbacktrace/cci.20210118: Not found in local cache, looking in remotes...
libbacktrace/cci.20210118: Checking remote: conancenter
libbacktrace/cci.20210118: Downloaded recipe revision a7691bfccd8caaf66309df196790a5a1
b2/5.5.3: Not found in local cache, looking in remotes...
b2/5.5.3: Checking remote: conancenter
b2/5.5.3: Downloaded recipe revision 043a75bcbb090e3f81f7ac849850d0ca
Graph root
    cli
Requirements
    boost/1.91.0#9b41246fdc6288d648e8ad5b1649fbaf - Downloaded (conancenter)
    bzip2/1.0.8#c470882369c2d95c5c77e970c0c7e321 - Downloaded (conancenter)
    libbacktrace/cci.20210118#a7691bfccd8caaf66309df196790a5a1 - Downloaded (conancenter)
    zlib/1.3.2#1cb806da49011867778ffb6ac7190fcb - Downloaded (conancenter)
Build requirements
    b2/5.5.3#043a75bcbb090e3f81f7ac849850d0ca - Downloaded (conancenter)
Resolved version ranges
    b2/[>=5.2 <6]: b2/5.5.3
    boost/[*]: boost/1.91.0
    zlib/[>=1.2.11 <2]: zlib/1.3.2

======== Computing necessary packages ========
Requirements
    boost/1.91.0#9b41246fdc6288d648e8ad5b1649fbaf:67d064756c5cd8ddb96f75c0339fe34766849071#cebaa2567f056ab0a0a0d4e11740bbda - Download (conancenter)
    bzip2/1.0.8#c470882369c2d95c5c77e970c0c7e321:432d7695adc526147073285e155d2ca0340bc76d#133f71a59b79de7c74a2c3af9cb9bc7b - Download (conancenter)
    libbacktrace/cci.20210118#a7691bfccd8caaf66309df196790a5a1:c81087b06d1a5beef0ad711fc32d45f7a425a8f3#3bb49ca4eb3a1ffca9b5c9509c79d237 - Download (conancenter)
    zlib/1.3.2#1cb806da49011867778ffb6ac7190fcb:c81087b06d1a5beef0ad711fc32d45f7a425a8f3#424b3705b50fb9c7a13cf3d299743946 - Download (conancenter)
Build requirements
Skipped binaries
    b2/5.5.3
```

## Changes

* Replace `conan install boost` command with its correct form based on Conan 2.x

### Frontend
- [ ] UI implementation matches Figma design
- [ ] Tested in light and dark mode
- [ ] Responsive / mobile verified
- [ ] Accessibility checked (keyboard navigation, etc.)
- [ ] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values
- [ ] Test without JavaScript (if applicable)
- [ ] No console errors or warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Conan installation command to use the supported version-pattern syntax for Boost dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->