### PR TITLE
Story 2781: Add docs header to library list page

### DIFF
--- a/templates/v3/library_page.html
+++ b/templates/v3/library_page.html
@@ -431,7 +431,7 @@ Inputs:
           <div class="library-page__list-header-flex"><span class="library-page__list-header-text">Category</span>{% include "includes/icon.html" with icon_name="chevron-down" icon_size=16 %}</div>
           <div class="library-page__list-header-flex"><span class="library-page__list-header-text">Author</span>{% include "includes/icon.html" with icon_name="chevron-down" icon_size=16 %}</div>
           <div class="library-page__list-header-flex library-page__list-header-justify"><span class="library-page__list-header-text">Version</span>{% include "includes/icon.html" with icon_name="chevron-down" icon_size=16 %}</div>
-          <div></div>
+          <div class="library-page__list-header-flex library-page__list-header-justify"><span class="library-page__list-header-text">Docs</span></div>
         </li>
         {% for item in object_list %}
           {% include 'v3/includes/_library_item.html' with variant=library_view_str library_name=item.library.name library_slug=item.library.slug library_url=item.library_detail_url description=item.description categories=item.library.category_tags cpp_version=item.cpp_standard_minimum author=item.author_details doc_url=item.documentation_url version_str=version_str only %}


### PR DESCRIPTION
# Issue: #2781 

## Summary & Context
<!-- *1-2 sentences describing what this PR does and why* -->
Adds a header to the documentation column on the library list page to better clarify how to reach the documents.

- **Figma link**: <!-- Add link to relevant Figma design here --> https://www.figma.com/design/5j0fQssrV9ipoU16P7hfKy/Website-Deliverables?node-id=12519-67283&m=dev
- **Link to components/page:** <!-- e.g. localhost:8000/news/add --> http://localhost:8000/libraries/1.92.0/list/


## ‼️ Risks & Considerations ‼️
*Please list any potential risks or areas that need extra attention during review/testing*
None

## Screenshots

<!-- Before | After
-- | -- -->

Before:
<img width="1920" height="13639" alt="image" src="https://github.com/user-attachments/assets/3848aee1-2642-4dc3-93f4-cdd970e4b278" />

After:
<img width="1920" height="13644" alt="image" src="https://github.com/user-attachments/assets/be1778cd-a999-40ee-adc8-c2b17fc4a255" />


## Self-review Checklist
<!-- Delete the section that doesn't apply -->
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design
- [x] Tested in light and dark mode
