### PR TITLE
Issue #2776 :: GET or POST on version drop-down. Remove a cookie.

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -56,13 +56,14 @@ def selected_version(request):
 
     When the version comes from the URL, the dropdown renders anchor links that
     swap the version segment of the current path — shareable. Otherwise it
-    renders POST forms that write the cookie without navigating.
+    renders anchor links to the `set-version` GET endpoint, which writes the
+    cookie and redirects back without a visible navigation.
 
     Examples
     --------
     GET /releases/1.88.0/  (no cookie)
         selected_version               -> Version(slug="boost-1-88-0")
-        selected_version_is_url_driven -> True       (URL mode: render <a>s)
+        selected_version_is_url_driven -> True       (URL mode)
         selected_version_is_non_latest -> True       (button reads "1.88.0")
         selected_version_label         -> "1.88.0"
         version_dropdown_options[i]    -> Version with `.href` attached,
@@ -71,11 +72,12 @@ def selected_version(request):
 
     GET /  (cookie boost_version="boost-1-87-0")
         selected_version               -> Version(slug="boost-1-87-0")
-        selected_version_is_url_driven -> False      (cookie mode: render <form>s)
+        selected_version_is_url_driven -> False      (cookie mode)
         selected_version_is_non_latest -> True       (button reads "1.87.0")
         selected_version_label         -> "1.87.0"
-        version_dropdown_options[i]    -> Version (no `.href` needed)
-        latest_href                    -> ""
+        version_dropdown_options[i]    -> Version with `.href` attached,
+                                          e.g. "/set-version/?version=boost-1-87-0"
+        latest_href                    -> "/set-version/?version=latest"
 
     GET /  (no cookie)
         selected_version               -> Version.objects.most_recent()
@@ -123,6 +125,8 @@ def selected_version(request):
             url_kwargs=dict(resolver_match.kwargs),
             options=options,
         )
+    else:
+        latest_href = _annotate_set_version_hrefs(options)
 
     return {
         "selected_version": version,
@@ -171,6 +175,20 @@ def _annotate_option_hrefs(*, view_name, url_kwargs, options):
         )
     except NoReverseMatch:
         return ""
+
+
+def _annotate_set_version_hrefs(options):
+    """Attach `.href` to each option pointing at the cookie-setting GET
+    endpoint; return the latest option's href.
+
+    Used on pages that are not version-aware (i.e. everything except
+    `/releases/`, `/libraries/`, `/library/`) — picking a version here writes
+    the `boost_version` cookie and redirects back rather than navigating.
+    """
+    set_version_url = reverse("set-version")
+    for v in options:
+        v.href = f"{set_version_url}?version={v.slug}"
+    return f"{set_version_url}?version={LATEST_RELEASE_URL_PATH_STR}"
 
 
 class NavItem(StrEnum):

--- a/core/tests/test_context_processors.py
+++ b/core/tests/test_context_processors.py
@@ -114,16 +114,18 @@ def test_selected_version_url_driven_with_latest_slug(rf):
 
 def test_selected_version_cookie_driven(rf):
     """Cookie mode: no URL slug, cookie picks the version, dropdown renders
-    POST forms (no `latest_href`, no per-option `.href`)."""
+    GET links to `set-version` (no CSRF token needed)."""
     request = rf.get("/")
     request.COOKIES[SELECTED_BOOST_VERSION_COOKIE_NAME] = "boost-1-87-0"
-    _, older = _stub_header_data(request)
+    most_recent, older = _stub_header_data(request)
     ctx = selected_version(request)
     assert ctx["selected_version_is_url_driven"] is False
     assert ctx["selected_version_is_non_latest"] is True
     assert ctx["selected_version_label"] == "1.87.0"
     assert ctx["selected_version"] is older
-    assert ctx["latest_href"] == ""
+    assert ctx["latest_href"] == "/set-version/?version=latest"
+    assert most_recent.href == "/set-version/?version=boost-1-88-0"
+    assert older.href == "/set-version/?version=boost-1-87-0"
 
 
 def test_selected_version_ignores_foreign_route_with_same_kwarg(rf):

--- a/mailing_list/tests/test_views.py
+++ b/mailing_list/tests/test_views.py
@@ -1,5 +1,8 @@
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.core import signing
+from django.template.loader import render_to_string
+from django.test import Client
 from django.urls import reverse
 from model_bakery import baker
 from unittest.mock import patch
@@ -350,3 +353,89 @@ def test_no_js_quick_subscribe_strips_referer_host(client, user):
         )
     assert response.status_code == 302
     assert response["Location"] == "/community/?edit=true"
+
+
+# ---------------------------------------------------------------------------
+# CSRF: exempt for anonymous requests, still enforced once a session is involved
+# ---------------------------------------------------------------------------
+
+
+def _render_card(rf, user):
+    request = rf.get("/")
+    request.user = user
+    return render_to_string(
+        "v3/includes/_mailing_list_card.html",
+        {
+            "subscribe_url": reverse("mailing-list-quick-subscribe"),
+            "modal_subscribe_url": reverse("mailing-list-modal-subscribe"),
+            "mailing_lists": [
+                {"id": LIST_ID, "name": "Boost", "address": LIST_ID, "description": ""}
+            ],
+            "list_id": LIST_ID,
+        },
+        request=request,
+    )
+
+
+@pytest.mark.django_db
+def test_card_omits_csrf_token_for_anonymous(rf):
+    """Rendering the card for a logged-out visitor must not call {% csrf_token %},
+    or Django sets the csrftoken cookie on every response and the CDN can't
+    cache the page (community, learn, release detail, library pages)."""
+    html = _render_card(rf, AnonymousUser())
+    assert "csrfmiddlewaretoken" not in html
+
+
+@pytest.mark.django_db
+def test_card_includes_csrf_token_for_authenticated(rf, user):
+    """Authenticated rendering keeps the token: those pages aren't cached anyway,
+    and the forms mutate session-bound subscription state."""
+    html = _render_card(rf, user)
+    assert "csrfmiddlewaretoken" in html
+
+
+@pytest.mark.django_db
+def test_anon_quick_subscribe_succeeds_without_csrf_token():
+    """QuickSubscribeView is csrf_exempt: the anonymous flow is stateless (just
+    sends a confirmation email), so there's no session-bound action to forge."""
+    csrf_client = Client(enforce_csrf_checks=True)
+    url = reverse("mailing-list-quick-subscribe")
+    with patch("mailing_list.views._send_confirmation_email"), patch(
+        "mailing_list.views.MailmanClient"
+    ) as MockClient:
+        MockClient.return_value.is_confirmed.return_value = False
+        response = csrf_client.post(url, {"email": EMAIL, "list_id": LIST_ID})
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
+def test_auth_quick_subscribe_rejects_request_without_csrf_token(user):
+    """Authenticated requests write to the caller's own subscription state, so
+    the standard CSRF check still applies."""
+    csrf_client = Client(enforce_csrf_checks=True)
+    csrf_client.force_login(user)
+    url = reverse("mailing-list-quick-subscribe")
+    response = csrf_client.post(url, {"email": user.email, "list_id": LIST_ID})
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_anon_modal_subscribe_succeeds_without_csrf_token():
+    """ModalSubscribeView is csrf_exempt: the anonymous flow only sends a
+    confirmation email, no session-bound state is touched."""
+    csrf_client = Client(enforce_csrf_checks=True)
+    url = reverse("mailing-list-modal-subscribe")
+    with patch("mailing_list.views._send_confirmation_email"):
+        response = csrf_client.post(url, {"email": EMAIL, "list_id": [LIST_ID]})
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
+def test_auth_modal_subscribe_rejects_request_without_csrf_token(user):
+    """Authenticated requests can subscribe/unsubscribe the caller's own lists,
+    so the standard CSRF check still applies."""
+    csrf_client = Client(enforce_csrf_checks=True)
+    csrf_client.force_login(user)
+    url = reverse("mailing-list-modal-subscribe")
+    response = csrf_client.post(url, {"email": user.email, "list_id": [LIST_ID]})
+    assert response.status_code == 403

--- a/mailing_list/views.py
+++ b/mailing_list/views.py
@@ -9,13 +9,16 @@ from django.core import signing
 from django.core.cache import cache
 from django.core.mail import EmailMultiAlternatives
 from django.db import IntegrityError, transaction
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseForbidden, HttpResponseRedirect
+from django.middleware.csrf import CsrfViewMiddleware
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.decorators import method_decorator
 from django.utils.timesince import timesince
 from django.views import View
+from django.views.decorators.csrf import csrf_exempt
 
 from mailing_list import constants
 from mailing_list.client import MailmanAPIError
@@ -77,6 +80,20 @@ def _get_client_ip(request) -> str:
 
 def _is_privileged(user) -> bool:
     return user.is_authenticated and (user.is_staff or user.is_superuser)
+
+
+def _reject_forged_authenticated_request(request) -> HttpResponseForbidden | None:
+    """Run the standard CSRF check, but only for authenticated requests.
+
+    Callers of this are csrf_exempt so the card can render on cached, logged-out
+    pages without Django setting the csrftoken cookie on every response. Once a
+    session is involved, a forged request can mutate that user's real
+    subscription state (e.g. unsubscribe them from active lists), so
+    authenticated requests still go through the normal check.
+    """
+    if not request.user.is_authenticated:
+        return None
+    return CsrfViewMiddleware(lambda r: None).process_view(request, None, (), {})
 
 
 def _rate_limit_key(request) -> str:
@@ -285,6 +302,7 @@ def _build_card_context(request) -> dict:
     return ctx
 
 
+@method_decorator(csrf_exempt, name="dispatch")
 class QuickSubscribeView(View):
     """Subscribe to a single list. Works for both authenticated and anonymous users.
 
@@ -300,6 +318,10 @@ class QuickSubscribeView(View):
         )
 
     def post(self, request):
+        rejected = _reject_forged_authenticated_request(request)
+        if rejected:
+            return rejected
+
         email = request.POST.get("email", "").strip()
         managed_lists = set(constants.MAILMAN_LISTS)
         list_id = request.POST.get("list_id", "").strip()
@@ -560,6 +582,7 @@ class ConfirmSubscriptionView(View):
         )
 
 
+@method_decorator(csrf_exempt, name="dispatch")
 class ModalSubscribeView(View):
     """Subscribe to one or more lists via the list-selection modal.
 
@@ -598,6 +621,10 @@ class ModalSubscribeView(View):
         )
 
     def post(self, request):
+        rejected = _reject_forged_authenticated_request(request)
+        if rejected:
+            return rejected
+
         email = request.POST.get("email", "").strip()
         managed_lists = set(constants.MAILMAN_LISTS)
         list_ids = [

--- a/static/js/install-card-version-sync.js
+++ b/static/js/install-card-version-sync.js
@@ -5,8 +5,8 @@
  * version-dropdown JS (see _header_v3.html) and swaps the install card between
  * its "latest" and "older" variants without a page reload.
  *
- * Progressive enhancement: with JS disabled, the dropdown's form submits
- * normally and the server's POST + 302 + GET roundtrip swaps the card.
+ * Progressive enhancement: with JS disabled, the dropdown link navigates
+ * normally and the server's GET + redirect + GET roundtrip swaps the card.
  *
  * Requires:
  *   - Wrapper element [data-install-card-wrapper][data-active-variant]

--- a/templates/v3/includes/_header_v3.html
+++ b/templates/v3/includes/_header_v3.html
@@ -84,112 +84,105 @@
  *   - Dismiss open menus on outside click or focus.
  *   - Toggle menus on Enter (checkboxes only respond to Space natively).
  */
-(function () {
-  'use strict';
+  (function () {
+    'use strict';
 
-  var TOGGLE_SELECTOR = '.header__user-toggle, .header__menu-toggle, .header__version-toggle';
+    var TOGGLE_SELECTOR = '.header__user-toggle, .header__menu-toggle, .header__version-toggle';
 
-  function dismissOpenMenus(target) {
-    var openUserToggles = document.querySelectorAll('.header__user-toggle:checked');
-    openUserToggles.forEach(function (toggle) {
-      var menu = toggle.closest('.header__user-menu');
-      if (menu && !menu.contains(target)) {
-        toggle.checked = false;
-      }
-    });
-
-    var openVersionToggles = document.querySelectorAll('.header__version-toggle:checked');
-    openVersionToggles.forEach(function (toggle) {
-      var menu = toggle.closest('.header__version-menu');
-      if (menu && !menu.contains(target)) {
-        toggle.checked = false;
-      }
-    });
-
-    var drawerToggle = document.querySelector('.header__menu-toggle:checked');
-    if (drawerToggle) {
-      var mobileActions = drawerToggle.closest('.header__mobile-actions');
-      if (mobileActions && !mobileActions.contains(target)) {
-        drawerToggle.checked = false;
-      }
-    }
-  }
-
-  document.addEventListener('click', function (e) {
-    dismissOpenMenus(e.target);
-  });
-
-  document.addEventListener('focusin', function (e) {
-    dismissOpenMenus(e.target);
-  });
-
-  document.addEventListener('keydown', function (e) {
-    if (e.key !== 'Enter') return;
-    var toggle = e.target;
-    if (toggle.matches && toggle.matches(TOGGLE_SELECTOR)) {
-      e.preventDefault();
-      toggle.checked = !toggle.checked;
-    }
-  });
-
-  /**
-   * Progressive enhancement for the cookie-mode version dropdown: send the
-   * POST via fetch and update the UI in place, avoiding a full page reload.
-   * Falls back to a normal form submit on any error.
-   *
-   * After a successful fetch, dispatch a `boost:version-changed` CustomEvent
-   * on document so other components (e.g. the install card) can react without
-   * a page reload. Detail: { slug, label, isLatest, docUrl }.
-   */
-  document.addEventListener('submit', function (e) {
-    var form = e.target;
-    if (!form.matches || !form.matches('.header__version-form')) return;
-
-    // The clicked option button carries name="version" value="<slug>".
-    // FormData(form) doesn't include the submitter's name/value, so append it.
-    var submitter = e.submitter;
-    if (!submitter || submitter.name !== 'version') return;
-    e.preventDefault();
-
-    var selectedValue = submitter.value;
-    var newLabel = submitter.textContent.trim();
-    var isLatest = submitter.dataset.isLatest === 'true';
-    var docUrl = submitter.dataset.docUrl || '';
-    var formData = new FormData(form);
-    formData.set('version', selectedValue);
-
-    fetch(form.action, {
-      method: 'POST',
-      body: formData,
-      credentials: 'same-origin',
-      redirect: 'manual'
-    }).then(function (response) {
-      if (!(response.type === 'opaqueredirect' || response.ok)) {
-        form.submit();
-        return;
-      }
-      document.querySelectorAll('.header__version-menu').forEach(function (menu) {
-        var label = menu.querySelector('.header__version-label');
-        if (label) label.textContent = newLabel;
-
-        menu.querySelectorAll('.header__version-option').forEach(function (opt) {
-          if (opt.value === selectedValue) {
-            opt.setAttribute('aria-current', 'true');
-          } else {
-            opt.removeAttribute('aria-current');
-          }
-        });
-
-        var toggle = menu.querySelector('.header__version-toggle');
-        if (toggle) toggle.checked = false;
+    function dismissOpenMenus(target) {
+      var openUserToggles = document.querySelectorAll('.header__user-toggle:checked');
+      openUserToggles.forEach(function (toggle) {
+        var menu = toggle.closest('.header__user-menu');
+        if (menu && !menu.contains(target)) {
+          toggle.checked = false;
+        }
       });
 
-      document.dispatchEvent(new CustomEvent('boost:version-changed', {
-        detail: { slug: selectedValue, label: newLabel, isLatest: isLatest, docUrl: docUrl }
-      }));
-    }).catch(function () {
-      form.submit();
+      var openVersionToggles = document.querySelectorAll('.header__version-toggle:checked');
+      openVersionToggles.forEach(function (toggle) {
+        var menu = toggle.closest('.header__version-menu');
+        if (menu && !menu.contains(target)) {
+          toggle.checked = false;
+        }
+      });
+
+      var drawerToggle = document.querySelector('.header__menu-toggle:checked');
+      if (drawerToggle) {
+        var mobileActions = drawerToggle.closest('.header__mobile-actions');
+        if (mobileActions && !mobileActions.contains(target)) {
+          drawerToggle.checked = false;
+        }
+      }
+    }
+
+    document.addEventListener('click', function (e) {
+      dismissOpenMenus(e.target);
     });
-  });
-})();
+
+    document.addEventListener('focusin', function (e) {
+      dismissOpenMenus(e.target);
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key !== 'Enter') return;
+      var toggle = e.target;
+      if (toggle.matches && toggle.matches(TOGGLE_SELECTOR)) {
+        e.preventDefault();
+        toggle.checked = !toggle.checked;
+      }
+    });
+
+    /**
+     * Progressive enhancement for the cookie-mode version dropdown: send the
+     * `set-version` GET via fetch and update the UI in place, avoiding a full
+     * page reload. Falls back to a normal navigation on any error.
+     *
+     * After a successful fetch, dispatch a `boost:version-changed` CustomEvent
+     * on document so other components (e.g. the install card) can react without
+     * a page reload. Detail: { slug, label, isLatest, docUrl }.
+     */
+    document.addEventListener('click', function (e) {
+      var link = e.target.closest('a.header__version-option[data-set-version]');
+      if (!link) return;
+      e.preventDefault();
+
+      var selectedValue = new URL(link.href, window.location.href).searchParams.get('version');
+      var newLabel = link.textContent.trim();
+      var isLatest = link.dataset.isLatest === 'true';
+      var docUrl = link.dataset.docUrl || '';
+
+      fetch(link.href, {
+        method: 'GET',
+        credentials: 'same-origin',
+        redirect: 'manual'
+      }).then(function (response) {
+        if (!(response.type === 'opaqueredirect' || response.ok)) {
+          window.location.href = link.href;
+          return;
+        }
+        document.querySelectorAll('.header__version-menu').forEach(function (menu) {
+          var label = menu.querySelector('.header__version-label');
+          if (label) label.textContent = newLabel;
+
+          menu.querySelectorAll('a.header__version-option[data-set-version]').forEach(function (opt) {
+            var optValue = new URL(opt.href, window.location.href).searchParams.get('version');
+            if (optValue === selectedValue) {
+              opt.setAttribute('aria-current', 'true');
+            } else {
+              opt.removeAttribute('aria-current');
+            }
+          });
+
+          var toggle = menu.querySelector('.header__version-toggle');
+          if (toggle) toggle.checked = false;
+        });
+
+        document.dispatchEvent(new CustomEvent('boost:version-changed', {
+          detail: { slug: selectedValue, label: newLabel, isLatest: isLatest, docUrl: docUrl }
+        }));
+      }).catch(function () {
+        window.location.href = link.href;
+      });
+    });
+  })();
 </script>

--- a/templates/v3/includes/_mailing_list_card.html
+++ b/templates/v3/includes/_mailing_list_card.html
@@ -15,6 +15,14 @@ Variables:
   subscribed_ids       - (optional) set of list IDs the user is currently subscribed to; controls checkbox state
   error_message        - error text shown when state="error"
 
+Both forms omit {% csrf_token %} for anonymous requests, on purpose: this card
+renders on cached, logged-out pages, and calling the tag unconditionally makes
+Django set the csrftoken cookie on every response, which defeats CDN caching.
+The anonymous POST handlers (QuickSubscribeView, ModalSubscribeView) are
+csrf_exempt to match, since anonymous submissions here don't touch any
+session-bound state. Authenticated requests still get the token and are still
+checked.
+
 Modal open/close: CSS-only via :target (id="mailing-list-modal"), matching the _dialog.html pattern.
 The "Manage your lists" trigger and the modal form work without JS (the form posts
 natively via method/action; the view redirects (PRG) for non-HTMX requests).
@@ -76,7 +84,7 @@ and HTMX swaps [data-ml-block] in place; x-init then clears the URL hash so the 
         class="mailing-list-card__form"
         @submit.prevent="mlEmail = $event.target.elements.email.value.trim(); if (mlEmail && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(mlEmail)) window.location.hash = 'mailing-list-modal'"
       >
-        {% csrf_token %}
+        {% if request.user.is_authenticated %}{% csrf_token %}{% endif %}
         <input type="hidden" name="list_id" value="{{ list_id|default:'boost.lists.boost.org' }}">
         <div class="card__column px-large">
           <span>Get the latest on releases, features, security patches, fixes and all major announcements.</span>
@@ -138,7 +146,7 @@ and HTMX swaps [data-ml-block] in place; x-init then clears the URL hash so the 
               hx-post="{{ modal_subscribe_url }}"
               hx-target="closest [data-ml-block]"
               hx-swap="outerHTML">
-          {% csrf_token %}
+          {% if request.user.is_authenticated %}{% csrf_token %}{% endif %}
           <input type="hidden" name="email" value="{{ user_email|default:'' }}" :value="mlEmail">
           <div class="mailing-list-modal__list-card">
             <ul class="mailing-list-modal__list" role="list" x-ref="checkboxContainer">

--- a/templates/v3/includes/header/_header_version_dropdown.html
+++ b/templates/v3/includes/header/_header_version_dropdown.html
@@ -4,8 +4,9 @@
   On version-aware pages (/releases/, /libraries/, /library/), the options are
   <a> links that swap the version segment of the current URL and trigger navigation.
 
-  Elsewhere, the options are POST forms that write the cookie via
-  `set-version` and redirect back — no visible navigation.
+  Elsewhere, the options are <a> links to the `set-version` GET endpoint,
+  which writes the cookie and redirects back — no visible navigation, and no
+  CSRF token needed since it is a plain GET.
 
   The dropdown is a CSS-only toggle via hidden checkbox; works with JS disabled.
 
@@ -17,8 +18,8 @@
     selected_version_is_url_driven   (bool)     — true on version-aware pages (/releases/, /libraries/, /library/)
     selected_version_is_non_latest   (bool)     — drives whether the button label shows a version number or "Latest"
     selected_version_label           (str)      — pre-resolved button label
-    version_dropdown_options         (list[Version]) — each has `.href` when URL-driven
-    latest_href                      (str)      — URL for the "Latest" option when URL-driven
+    version_dropdown_options         (list[Version]) — each has `.href` pre-built
+    latest_href                      (str)      — URL for the "Latest" option
 {% endcomment %}
 <div class="header__version-menu">
   <input type="checkbox"
@@ -38,52 +39,27 @@
        role="group"
        class="header__version-dropdown">
     <div class="header__version-dropdown-scroll">
-      {% if selected_version_is_url_driven %}
-        {% if latest_href %}
-          <a href="{{ latest_href }}"
+      {% if latest_href %}
+        <a href="{{ latest_href }}"
+           class="header__version-option"
+           data-version-option
+           data-is-latest="true"
+           {% if not selected_version_is_url_driven %}data-set-version{% endif %}
+           {% if not selected_version_is_non_latest %}aria-current="true"{% endif %}>Latest</a>
+      {% endif %}
+      {% for v in version_dropdown_options %}
+        {% if v.href %}
+          <a href="{{ v.href }}"
              class="header__version-option"
              data-version-option
-             data-is-latest="true"
-             {% if not selected_version_is_non_latest %}aria-current="true"{% endif %}>Latest</a>
+             data-is-latest="false"
+             data-doc-url="{{ v.documentation_url }}"
+             {% if not selected_version_is_url_driven %}data-set-version{% endif %}
+             {% if selected_version_is_non_latest and selected_version and v.slug == selected_version.slug %}aria-current="true"{% endif %}>
+            {{ v.display_name }}
+          </a>
         {% endif %}
-        {% for v in version_dropdown_options %}
-          {% if v.href %}
-            <a href="{{ v.href }}"
-               class="header__version-option"
-               data-version-option
-               data-is-latest="false"
-               data-doc-url="{{ v.documentation_url }}"
-               {% if selected_version_is_non_latest and selected_version and v.slug == selected_version.slug %}aria-current="true"{% endif %}>
-              {{ v.display_name }}
-            </a>
-          {% endif %}
-        {% endfor %}
-      {% else %}
-        <form method="post"
-              action="{% url 'set-version' %}"
-              class="header__version-form">
-          {% csrf_token %}
-          <button type="submit"
-                  name="version"
-                  value="latest"
-                  class="header__version-option"
-                  data-version-option
-                  data-is-latest="true"
-                  {% if not selected_version_is_non_latest %}aria-current="true"{% endif %}>Latest</button>
-          {% for v in version_dropdown_options %}
-            <button type="submit"
-                    name="version"
-                    value="{{ v.slug }}"
-                    class="header__version-option"
-                    data-version-option
-                    data-is-latest="false"
-                    data-doc-url="{{ v.documentation_url }}"
-                    {% if selected_version_is_non_latest and selected_version and v.slug == selected_version.slug %}aria-current="true"{% endif %}>
-              {{ v.display_name }}
-            </button>
-          {% endfor %}
-        </form>
-      {% endif %}
+      {% endfor %}
     </div>
   </div>
 </div>

--- a/versions/views.py
+++ b/versions/views.py
@@ -8,7 +8,7 @@ from operator import attrgetter
 from django.db.models import Q, Count
 from django.http import HttpResponse, HttpResponseRedirect
 from django.views import View
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_GET
 from django.views.generic import DetailView, TemplateView, ListView
 from django.shortcuts import redirect, get_object_or_404
 from django.urls import reverse
@@ -42,15 +42,16 @@ from versions.models import Review, Version
 logger = structlog.get_logger()
 
 
-@require_POST
+@require_GET
 def set_version(request):
     """Writes the selected version cookie, then redirects back to the referring page.
 
     Used by the navbar version dropdown on pages that are not version-aware
-    (i.e. everything except `/releases/`, `/libraries/`, `/library/`). Validation
-    and cookie semantics are delegated to `set_selected_boost_version`.
+    (i.e. everything except `/releases/`, `/libraries/`, `/library/`). A plain
+    GET link, so no CSRF token is required in the header on every page.
+    Validation and cookie semantics are delegated to `set_selected_boost_version`.
     """
-    version_slug = request.POST.get("version", "")
+    version_slug = request.GET.get("version", "")
     referer = request.headers.get("referer", "")
     if referer and url_has_allowed_host_and_scheme(
         url=referer,
@@ -60,7 +61,7 @@ def set_version(request):
         next_url = referer
     else:
         next_url = "/"
-    response = HttpResponseRedirect(next_url, status=303)
+    response = HttpResponseRedirect(next_url)
     set_selected_boost_version(version_slug, response)
     return response
 


### PR DESCRIPTION
# Issue: #2776

**Branch:** `teo/2776-get-post-version-dropdown-cookie` · **Base:** `origin/develop`

## Summary & Context

The header version dropdown's cookie-mode options (everything except `/releases/`, `/libraries/`, `/library/`) POSTed to `set-version` with `{% csrf_token %}`, which forces Django to set a CSRF cookie on every page site-wide since the header renders on every page - this is what was breaking CDN cacheability. The fix switches those options to plain GET links, matching how the pre-v3 dropdown worked and how the URL-driven branch already works; the `boost_version` cookie itself is unchanged and pre-dates v3, so it is out of scope here.

- **Figma link**: n/a
- **Link to components/page:** [http://localhost:8000/](http://localhost:8000/)

## Changes

- **`versions/views.py`** - `set_version` now requires GET (`require_GET`) instead of POST, reads `request.GET`, drops the POST-specific 303 status
- **`core/context_processors.py`** - `selected_version` now pre-builds `.href`/`latest_href` for cookie-mode options too (pointing at `set-version?version=<slug>`), same pattern already used for URL-driven pages
- **`templates/v3/includes/header/_header_version_dropdown.html`** - cookie-mode options render as `<a href>` links instead of a `<form method="post">` with buttons; both branches now share one loop
- **`templates/v3/includes/_header_v3.html`** - the no-full-reload JS enhancement now intercepts clicks on the GET links via `fetch(..., {method:'GET'})` instead of listening for the removed form's `submit` event
- **`static/js/install-card-version-sync.js`** - doc comment updated to describe the GET-based no-JS fallback path

## ‼️ Risks & Considerations ‼️

- The install-card in-place swap (via `boost:version-changed`) now depends on a `data-set-version` attribute distinguishing cookie-mode links from URL-driven ones; verified in the running app but worth a second look
- No dedicated test existed for `set_version` before this change; only `core/tests/test_context_processors.py::test_selected_version_cookie_driven` was updated to match the new hrefs

## Peer-review testing steps

1. Stack is already up. Visit any non-version-aware page (home, news, community) and confirm `curl -sI` shows no `Set-Cookie` header at all
2. Open the version dropdown on the homepage, pick an older version - confirm the label updates in place (no full reload) and the install card swaps if present
3. With JS disabled, repeat step 2 - confirm the link navigates, the `boost_version` cookie is set, and the page reflects the new version
4. Visit `/releases/` and confirm its dropdown still swaps the URL directly (unaffected, still `<a href="/releases/<version>/">`)
5. Pick "Latest" from the cookie-mode dropdown and confirm the `boost_version` cookie is deleted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version selection now uses navigable links and GET requests, including improved no-JavaScript support.
  * Version dropdowns provide direct links for the latest and available versions.
  * Version changes continue updating the page and dropdown state without a full manual refresh.

* **Bug Fixes**
  * Anonymous mailing-list subscriptions no longer set CSRF cookies on cached pages.
  * Authenticated subscription requests remain protected against forged requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->