### PR TITLE
Story 2790: gate flagship hero white description on the presence of hero art to enable visibility

### DIFF
--- a/static/css/v3/heros.css
+++ b/static/css/v3/heros.css
@@ -916,8 +916,11 @@ html.dark .hero__links .btn-icon-library:hover {
    under it, putting the description tail on the animal's trousers. Same cap and
    same value the community hero uses for this collision a few rules down; worst
    case is a 3-line description at 286px in the 400px block, so nothing spills. */
+/* `:not(.hero--no-image)` because the cap exists to clear the figure, and an
+   art-less flagship has none — there it would only halve the column against the
+   base 662px. Same reason the mobile block rule below is gated. */
 @media (min-width: 768px) and (max-width: 1279px) {
-  .hero--library .hero__content {
+  .hero--library:not(.hero--no-image) .hero__content {
     max-width: min(615px, 50vw);
   }
 }
@@ -930,8 +933,11 @@ html.dark .hero__links .btn-icon-library:hover {
    description at every width in that range. */
 /* White rather than the grey-400 the shared rule sets. Grey is what forced the
    scrim dark, so raising the alpha below without reverting this will not help.
-   `.hero--community` does the same. */
-.hero--library .hero__description {
+   `.hero--community` does the same.
+   Gated on the scrim, not on `.hero--library`: the flagship branch adds that class
+   whether or not LIBRARY_HERO_ART has an entry, so ungated this turned every
+   art-less flagship description white on the light surface (#2790). */
+.hero--library.hero--with-background-image .hero__description {
   color: #fff;
 }
 


### PR DESCRIPTION
# Issue: #2790

## Summary & Context

Flagship library descriptions were rendering in white on the light page background, making them invisible on 21 of the 22 flagship libraries. Two style rules added for the Beast hero in #2758 were written to match every flagship library instead of only the ones that have background artwork behind the text, so libraries with no artwork got white text with nothing dark behind it.

- **Figma link**: n/a 
restores the description to the color it had before #2758
- **Link to components/page:** [http://localhost:8000/library/latest/decimal/](http://localhost:8000/library/latest/decimal/) (broken case) and [http://localhost:8000/library/latest/beast/](http://localhost:8000/library/latest/beast/) (must stay unchanged).

## Changes

Both changes are in `static/css/v3/heros.css`. No template or Python changes were needed — the page already outputs the classes required to tell the two cases apart.

- **Description color is now limited to heroes that actually have a background image.** `.hero--library .hero__description` became `.hero--library.hero--with-background-image .hero__description`. The `hero--library` class is added to *every* flagship library by `templates/v3/libraries/library-subpage.html:18`, but `LIBRARY_HERO_ART` in `libraries/constants.py` only has an entry for `beast`. So the white applied to all 22 flagship libraries while only Beast had the dark artwork that made white readable. Libraries without artwork now fall back to the standard `--color-text-secondary` token: `#585a64` in light mode, `#cacbce` in dark.

- **The tablet width cap is now limited to heroes that have a foreground illustration.** `.hero--library .hero__content` became `.hero--library:not(.hero--no-image) .hero__content` in the 768–1279px range. This rule narrows the text column to `min(615px, 50vw)` so the text does not run underneath the animal illustration. With no illustration present there is nothing to avoid, so it was only cutting the text column roughly in half against the normal 662px and forcing early line wraps. This is a second symptom of the same mistake, three lines away in the same file, which is why it is fixed here rather than separately.

- **Added comments on both rules** explaining why each one is scoped the way it is, so the next person adding hero artwork does not reintroduce this.

## ‼️ Risks & Considerations ‼️

- **Beast must not change, and it does not.** Beast's hero carries `hero--with-background-image`, so it keeps the white description over its dark gradient. The new selector is more specific than the shared `.hero--with-bg-and-image .hero__description` grey rule that would otherwise take over, so the cascade still resolves to white. Verified in the browser at desktop, tablet and mobile widths — please confirm Beast still looks correct as part of review.

- **The two rules are scoped on different conditions on purpose.** The color is scoped to "has a background image" because the dark gradient is what makes white readable. The width cap is scoped to "has a foreground image" because the illustration is what the text needs to avoid. Today both conditions are always true or false together, because `libraries/views.py` returns the background and the illustration as an all-or-nothing pair. They are written separately so they stay correct if that ever stops being true.

- **This fix is per-library, not global.** Any flagship library that gets artwork added to `LIBRARY_HERO_ART` in future will correctly pick up the white description and the width cap, with no further CSS changes.

## Screenshots
https://github.com/user-attachments/assets/e6985108-9a05-46d3-9d5a-d66e26e77f01



## Self-review Checklist

- [ ] Tag at least one team member from each team to review this PR
- [x] Link this PR to the related GitHub Project ticket

### Frontend
- [x] UI implementation matches Figma design — no Figma for this; it restores the description to the color used before #2758 and on every non-flagship library page
- [x] Tested in light and dark mode — Decimal and Beast checked in both
- [x] Responsive / mobile verified — checked at 1440px, 1200px (the tablet range where the width cap applies) and 390px
- [x] Accessibility checked (keyboard navigation, etc.) — no interactive elements changed. The relevant check here is contrast: the description went from 1.07:1 (invisible) to 6.44:1 in light mode, and is 11.36:1 in dark mode. Both pass AA for body text.
- [x] Ensure design tokens are used for colors, spacing, typography, etc. – No hardcoded values — this change removes a hardcoded `#fff` from the libraries that should not have had it and returns them to the `--color-text-secondary` token. The remaining `#fff` on Beast is pre-existing and deliberate, because the token it would otherwise use is black in light mode and would be unreadable over the artwork.
- [x] Test without JavaScript (if applicable) — CSS-only change. Light mode is the no-JavaScript default, which is the case this fixes.
- [x] No console errors or warnings — no JavaScript touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved flagship library hero layouts on tablet-sized screens when no illustration is present.
  - Corrected description text color for flagship library heroes without background artwork, preserving the standard secondary text styling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->