### PR TITLE
Fix slow query, get_commit_data_by_release

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -724,6 +724,11 @@ POSTS_RANKING_GRAVITY = env.float("POSTS_RANKING_GRAVITY", default=2.0)
 EVENTS_CACHE_KEY = "homepage_events"
 EVENTS_CACHE_TIMEOUT = 300  # 5 min
 
+# Homepage "Boost in numbers" commit chart. The underlying data only changes
+# when a new release's commits are imported, so a day-long TTL is safe.
+COMMIT_DATA_CACHE_KEY = "homepage_commit_data_by_release"
+COMMIT_DATA_CACHE_TIMEOUT = 60 * 60 * 24  # 1 day
+
 # OAuth settings
 OAUTH_APP_NAME = (
     "Boost OAuth Concept"  # Stored in the admin; replicated for convenience

--- a/libraries/utils.py
+++ b/libraries/utils.py
@@ -15,6 +15,7 @@ from dateutil.relativedelta import relativedelta
 
 from dateutil.parser import ParserError, parse
 from django.conf import settings
+from django.core.cache import cache
 from django.db.models import Count, F, QuerySet, prefetch_related_objects
 from django.db.models.functions import Lower
 from django.urls import reverse
@@ -48,8 +49,15 @@ def get_commit_data_by_release_for_library(library, limit=20):
     """Return list of { release, commit_count } for a library, ordered by release (oldest first).
 
     Used by the library detail page and by the V3 examples “commits per release” lookup.
+    Cached for a day (same reasoning as `get_commit_data_by_release`: counts only
+    change when a release's commits are imported).
     """
     from .models import LibraryVersion
+
+    cache_key = f"{settings.COMMIT_DATA_CACHE_KEY}:library:{library.id}:{limit}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
 
     qs = (
         LibraryVersion.objects.filter(
@@ -59,27 +67,56 @@ def get_commit_data_by_release_for_library(library, limit=20):
         .annotate(count=Count("commit"), version_name=F("version__name"))
         .order_by("-version__name")
     )[:limit]
-    return [
+    result = [
         {"release": x.version_name.removeprefix("boost-"), "commit_count": x.count}
         for x in reversed(list(qs))
     ]
+    cache.set(cache_key, result, settings.COMMIT_DATA_CACHE_TIMEOUT)
+    return result
 
 
 def get_commit_data_by_release(limit=10):
     """Return list of { release, commit_count } across all Boost libraries per
     minor release, ordered by release (oldest first).
 
-    Used by the homepage "Boost in numbers" chart.
+    Used by the homepage "Boost in numbers" chart. Cached for a day: the counts
+    only change when a release's commits are imported, and computing them joins
+    the full commit history, which is far too expensive to run per pageview.
+
+    The versions are selected first (a cheap, join-free query) and commits are
+    counted only for those, rather than aggregating commit counts for every
+    release and then discarding all but `limit` of them.
     """
-    qs = (
+    from .models import Commit
+
+    cache_key = f"{settings.COMMIT_DATA_CACHE_KEY}:{limit}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    # Newest `limit` minor releases. Ordered by the numeric version parts, not
+    # by name: name ordering is lexicographic ("boost-1.9.0" > "boost-1.85.0").
+    versions = list(
         Version.objects.minor_versions()
-        .annotate(count=Count("library_version__commit"))
-        .order_by("-name")
-    )[:limit]
-    return [
-        {"release": v.name.removeprefix("boost-"), "commit_count": v.count}
-        for v in reversed(list(qs))
+        .order_by("-version_array")
+        .values_list("id", "name")[:limit]
+    )
+    version_ids = [version_id for version_id, _ in versions]
+    counts = dict(
+        Commit.objects.filter(library_version__version_id__in=version_ids)
+        .values("library_version__version_id")
+        .annotate(count=Count("id"))
+        .values_list("library_version__version_id", "count")
+    )
+    result = [
+        {
+            "release": name.removeprefix("boost-"),
+            "commit_count": counts.get(version_id, 0),
+        }
+        for version_id, name in reversed(versions)
     ]
+    cache.set(cache_key, result, settings.COMMIT_DATA_CACHE_TIMEOUT)
+    return result
 
 
 def commit_data_to_stats_bars(commit_data):


### PR DESCRIPTION
The boost.org database server seems to intermittently become extremely busy, CPU spikes to 100%, even for extended periods of time.

slow query log:  

`
2026-09-12 13:01:58.157 UTC [868363] boost_production@boost_production LOG:  duration: 8836.575 ms  statement: SELECT "versions_version"."id", "versions_version"."name", "versions_version"."slug", "versions_version"."release_date", "versions_version"."description", "versions_version"."active", "versions_version"."github_url", "versions_version"."beta", "versions_version"."full_release", "versions_version"."data", "versions_version"."fully_imported", "versions_version"."whats_new", "versions_version"."whats_new_approved", "versions_version"."whats_new_generated_at", REPLACE("versions_version"."name", 'boost-', '') AS "simple_version", (regexp_split_to_array(REPLACE("versions_version"."name", 'boost-', ''), '\.')::int[]) AS "version_array", ((regexp_split_to_array(REPLACE("versions_version"."name", 'boost-', ''), '\.')::int[]))[1] AS "major", ((regexp_split_to_array(REPLACE("versions_version"."name", 'boost-', ''), '\.')::int[]))[2] AS "minor", ((regexp_split_to_array(REPLACE("versions_version"."name", 'boost-', ''), '\.')::int[]))[3] AS "patch", COUNT("libraries_commit"."id") AS "count" FROM "versions_version" LEFT OUTER JOIN "libraries_libraryversion" ON ("versions_version"."id" = "libraries_libraryversion"."version_id") LEFT OUTER JOIN "libraries_commit" ON ("libraries_libraryversion"."id" = "libraries_commit"."library_version_id") WHERE ("versions_version"."fully_imported" AND "versions_version"."name"::text ~ '^(boost-)?\d+\.\d+\.\d+$' AND ((regexp_split_to_array(REPLACE("versions_version"."name", 'boost-', ''), '\.')::int[]))[3] = 0) GROUP BY "versions_version"."id", 15, 16, 17, 18, 19 ORDER BY "versions_version"."name" DESC LIMIT 10
`

6-8 seconds on every visit to the homepage.  !!!

When encountering such situations, there are many possible solutions, adding new indexes, or adjusting the content of the query, perhaps simplifying it, etc.   Whatever is done here, it doesn't mean it's the same for the next slow query. Every optimization strategy is different.  

Consulting with Claude it recommends to cache the result in redis.   

In general, keep in mind the redis cache is small and a more costly service than a DB, don't cache docs or release notes into redis, but in this case it's probably a very good solution.  

More info below:  

---

"""

I've traced the slowest query end to end. Here's the full picture.

What the slowest query is

Everything in the log except one hyperkitty entry is a single repeated query: 3–11 seconds per execution, firing many times per minute from boost_production. It's the homepage "Boost in numbers" commit chart. The chain is:

HomepageView.get_v3_context_data() in ak/views.py calls get_commit_data_by_release(limit=10) on every homepage request, with no caching.

```
utils.py
Lines 74-78
qs = (
    Version.objects.minor_versions()
    .annotate(count=Count("library_version__commit"))
    .order_by("-name")
)[:limit]
```
minor_versions() comes from versions/managers.py — it filters version names with a regex and splits them into [major, minor, patch] arrays via regexp_split_to_array, which is where all the regex noise in the logged SQL comes from.

Why it's slow

The LIMIT 10 is deceptive. Because the COUNT aggregation happens before the limit, Postgres has to join every minor release to every row in libraries_commit (the entire commit history of every Boost library, likely millions of rows), count them all, and only then throw away everything but the top 10 versions. Indexing won't rescue this: library_version_id already has Django's automatic FK index, and the regex/array expressions in the WHERE clause aren't sensibly indexable anyway. The real cost is the full-table aggregation, repeated for every visitor landing on the front page. Concurrent homepage hits stack these 5-second scans on top of each other, which is exactly your intermittent "hammered" pattern — it tracks homepage traffic bursts.

Is it new or old?

New, effectively. The git history says:

get_commit_data_by_release() was written on March 3, 2026 (commit ec05f9d3, commit-stats feature for library detail/examples pages).
It was wired into the homepage on July 8, 2026 (commit c5ea2084, "Story 2366: Homepage Integration") — but behind the v3 waffle flag.
So it produced essentially zero production load until the v3 launch a couple of days ago flipped that flag for real traffic. The site from 6 months ago never ran this query on the homepage. This is a genuine v3 regression, and it matches your timeline exactly.

Recommended fix

This is a caching problem, not an indexing problem. The chart shows commit counts per Boost release — data that changes only when a new release is imported, i.e. a few times a year. Recomputing it per pageview is pure waste.

Immediate, tiny, safe: cache the result of get_commit_data_by_release() in Redis. The infrastructure is already there — the same view already caches calendar events this way (cache.get/cache.set with EVENTS_CACHE_KEY, in ak/views.py). A TTL of even one hour reduces this query from thousands of executions per day to ~24. A day-long TTL would be equally correct. No new table needed — Redis already plays that "cache interim results" role.

Optional second step: restructure the query to pick the 10 newest minor versions first (cheap, ~10 rows), then count commits only for those 10, instead of aggregating over all ~100+ releases. That would take the cold-cache cost from seconds to tens of milliseconds. Worth doing, but with caching in place it's no longer urgent.

One latent bug worth noting while you're in there: .order_by("-name") sorts lexicographically, so a hypothetical boost-1.9.0 would sort above boost-1.85.0. The queryset already computes version_array; ordering by -version_array would be both correct and consistent with the filtering.

I'd also flag that the sibling function get_commit_data_by_release_for_library() (library detail pages) has the same shape and will show up next in your slow log once you fix this one — the same cache treatment applies, keyed per library.

If you want, I can implement the cache wrapper (and optionally the query restructure) now — it's about a 10-line change in libraries/utils.py plus a settings constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved loading speed for the homepage “Boost in numbers” commit chart through data caching.
  * Cached commit data remains available for up to one day and refreshes when release data changes.

* **Bug Fixes**
  * Commit totals now reflect the newest minor versions within the selected limit, rather than aggregating older versions before applying the limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->